### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ docker exec -it vpp agentctl -h
 3. Check the configuration (using agentctl or directly using VPP console):
 ```
 docker exec -it vpp agentctl show
-docker exec -it vpp vppctl
+docker exec -it vpp vppctl -s localhost:5002
 ```
 
 ## Documentation


### PR DESCRIPTION
vppctl used to be a python script that would read the VPP startup config to learn the socket address where to connect to (token "cli-listen"). Recently it has been re-written to C and became a bit stupider. Now it assumes the default address, which is a unix local socket with path /run/vpp/cli.sock, unless it is told differently using an argument "-s <addr>".
We use TCP/IP socket listening on all IP addresses and TCP port 5002 rather than the unix local socket so that we can attach to VPP remotely. Hence we need to use the argument "-s" to tell vppctl not to connect to the default address.