### PR TITLE
Modify vEth config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 - [LinuxPlugin](plugins/linuxplugin)
    - Configuration of vEth interfaces modified. Veth configuration defines
-   two names: symbolic used internally and the one used in host OS. Added
-   `HostIfName` field has to be filled in vEth config.
+   two names: symbolic used internally and the one used in host OS.
+   `HostIfName` field is optional. If it is not defined, the name in the host OS
+   will be the same as the symbolic one - defined by `Name` field.
 
 # Release v1.0.5 (2017-9-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Release v1.0.6 (not released yet)
+
+## Major Themes
+
+- [LinuxPlugin](plugins/linuxplugin)
+   - Configuration of vEth interfaces modified. Veth configuration defines
+   two names: symbolic used internally and the one used in host OS. Added
+   `HostIfName` field has to be filled in vEth config.
+
 # Release v1.0.5 (2017-9-26)
 
 ## Compatibility
@@ -12,9 +21,9 @@ VPP version v17.10-rc0~334-gce41a5c
     - Changes in offset handling, only automatically partitioned messages (hash, random)
       have their offset marked. Manually partitioned messages are not marked.
     - Implemented post-init consumer (for manual partitioner only) which allows to start
-      consuming after kafka-plugin Init()   
+      consuming after kafka-plugin Init()
     - Minimalistic examples & documentation for Kafka API will be improved in a later release.
-    
+
 # Release v1.0.4 (2017-09-08)
 
 ## Major Themes

--- a/cmd/vpp-agent-ctl/json/veth1.json
+++ b/cmd/vpp-agent-ctl/json/veth1.json
@@ -10,6 +10,7 @@
         "type": 2
     },
     "name": "veth1",
+    "host_if_name": "veth1Name",
     "phys_address": "d2:74:8c:12:67:d2",
     "type": 0,
     "veth": {

--- a/cmd/vpp-agent-ctl/json/veth2.json
+++ b/cmd/vpp-agent-ctl/json/veth2.json
@@ -10,6 +10,7 @@
         "type": 2
     },
     "name": "veth2",
+    "host_if_name": "veth2Name",
     "phys_address": "92:c7:42:67:ab:cd",
     "type": 0,
     "veth": {

--- a/examples/localclient_linux/main.go
+++ b/examples/localclient_linux/main.go
@@ -127,12 +127,12 @@ func (plugin *ExamplePlugin) reconfigureLinuxAndVPP(ctx context.Context) {
 		// simulate configuration change exactly 20seconds after resync
 		err := localclient.DataChangeRequest(PluginID).
 			Put().
-			LinuxInterface(&veth11Ns1). /* move veth11 into the namespace "ns1" */
+			LinuxInterface(&veth11Ns1).     /* move veth11 into the namespace "ns1" */
 			LinuxInterface(&veth12WithMtu). /* reconfigure veth12 -- explicitly set Mtu to 1000 */
-			LinuxInterface(&veth21Ns2). /* create veth21-veth22 pair, put veth21 into the namespace "ns2" */
-			LinuxInterface(&veth22). /* enable veth22, keep default configuration */
-			VppInterface(&afpacket2). /* create afpacket2 interface and attach it to veth2 */
-			BD(&BDAfpackets). /* put afpacket1 and afpacket2 into the same bridge domain */
+			LinuxInterface(&veth21Ns2).     /* create veth21-veth22 pair, put veth21 into the namespace "ns2" */
+			LinuxInterface(&veth22).        /* enable veth22, keep default configuration */
+			VppInterface(&afpacket2).       /* create afpacket2 interface and attach it to veth2 */
+			BD(&BDAfpackets).               /* put afpacket1 and afpacket2 into the same bridge domain */
 			Delete().
 			VppInterface(tap1.Name). /* remove the tap interface */
 			Send().ReceiveReply()
@@ -215,9 +215,10 @@ var (
 
 	// veth11DefaultNs is one end of the veth11-veth12 VETH pair, put into the default namespace and NOT attached to VPP
 	veth11DefaultNs = linux_intf.LinuxInterfaces_Interface{
-		Name:    "veth11",
-		Type:    linux_intf.LinuxInterfaces_VETH,
-		Enabled: true,
+		Name:       "veth11",
+		HostIfName: "veth11",
+		Type:       linux_intf.LinuxInterfaces_VETH,
+		Enabled:    true,
 		Veth: &linux_intf.LinuxInterfaces_Interface_Veth{
 			PeerIfName: "veth12",
 		},
@@ -226,9 +227,10 @@ var (
 
 	// veth11Ns1 is veth11DefaultNs moved to the namespace "ns1"
 	veth11Ns1 = linux_intf.LinuxInterfaces_Interface{
-		Name:    "veth11",
-		Type:    linux_intf.LinuxInterfaces_VETH,
-		Enabled: true,
+		Name:       "veth11",
+		HostIfName: "veth11",
+		Type:       linux_intf.LinuxInterfaces_VETH,
+		Enabled:    true,
 		Veth: &linux_intf.LinuxInterfaces_Interface_Veth{
 			PeerIfName: "veth12",
 		},
@@ -241,9 +243,10 @@ var (
 
 	// veth12 is one end of the veth11-veth12 VETH pair, put into the default namespace and attached to VPP
 	veth12 = linux_intf.LinuxInterfaces_Interface{
-		Name:    "veth12",
-		Type:    linux_intf.LinuxInterfaces_VETH,
-		Enabled: true,
+		Name:       "veth12",
+		HostIfName: "veth12",
+		Type:       linux_intf.LinuxInterfaces_VETH,
+		Enabled:    true,
 		Veth: &linux_intf.LinuxInterfaces_Interface_Veth{
 			PeerIfName: "veth11",
 		},
@@ -251,9 +254,10 @@ var (
 
 	// veth12WithMtu is like veth12, but MTU is reconfigured
 	veth12WithMtu = linux_intf.LinuxInterfaces_Interface{
-		Name:    "veth12",
-		Type:    linux_intf.LinuxInterfaces_VETH,
-		Enabled: true,
+		Name:       "veth12",
+		HostIfName: "veth12",
+		Type:       linux_intf.LinuxInterfaces_VETH,
+		Enabled:    true,
 		Veth: &linux_intf.LinuxInterfaces_Interface_Veth{
 			PeerIfName: "veth11",
 		},
@@ -262,9 +266,10 @@ var (
 
 	// veth21Ns2 is one end of the veth21-veth22 VETH pair, put into the namespace "ns2" and NOT attached to VPP
 	veth21Ns2 = linux_intf.LinuxInterfaces_Interface{
-		Name:    "veth21",
-		Type:    linux_intf.LinuxInterfaces_VETH,
-		Enabled: true,
+		Name:       "veth21",
+		HostIfName: "veth21",
+		Type:       linux_intf.LinuxInterfaces_VETH,
+		Enabled:    true,
 		Veth: &linux_intf.LinuxInterfaces_Interface_Veth{
 			PeerIfName: "veth22",
 		},
@@ -277,11 +282,12 @@ var (
 
 	// veth22 is one end of the veth21-veth22 VETH pair, put into the default namespace and attached to VPP
 	veth22 = linux_intf.LinuxInterfaces_Interface{
-		Name:    "veth22",
-		Type:    linux_intf.LinuxInterfaces_VETH,
-		Enabled: true,
+		Name:       "veth22",
+		HostIfName: "veth22",
+		Type:       linux_intf.LinuxInterfaces_VETH,
+		Enabled:    true,
 		Veth: &linux_intf.LinuxInterfaces_Interface_Veth{
-			PeerIfName: "veth2",
+			PeerIfName: "veth21",
 		},
 	}
 
@@ -316,10 +322,10 @@ var (
 		MacAge:              0, /* means disable aging */
 		Interfaces: []*vpp_l2.BridgeDomains_BridgeDomain_Interfaces{
 			{
-				Name:                    "afpacket1",
+				Name: "afpacket1",
 				BridgedVirtualInterface: false,
 			}, {
-				Name:                    "afpacket2",
+				Name: "afpacket2",
 				BridgedVirtualInterface: false,
 			},
 		},

--- a/plugins/defaultplugins/watch_events.go
+++ b/plugins/defaultplugins/watch_events.go
@@ -108,11 +108,17 @@ func (plugin *Plugin) watchEvents(ctx context.Context) {
 			ifIdxEv.Done()
 
 		case linuxIfIdxEv := <-plugin.linuxIfIdxWatchCh:
+			var name string
+			if linuxIfIdxEv.Metadata != nil && linuxIfIdxEv.Metadata.HostIfName != "" {
+				name = linuxIfIdxEv.Metadata.HostIfName
+			} else {
+				name = linuxIfIdxEv.Name
+			}
 			if !linuxIfIdxEv.IsDelete() {
-				plugin.ifConfigurator.ResolveCreatedLinuxInterface(linuxIfIdxEv.Name, linuxIfIdxEv.Idx)
+				plugin.ifConfigurator.ResolveCreatedLinuxInterface(name, linuxIfIdxEv.Idx)
 				// TODO propagate error
 			} else {
-				plugin.ifConfigurator.ResolveDeletedLinuxInterface(linuxIfIdxEv.Name)
+				plugin.ifConfigurator.ResolveDeletedLinuxInterface(name)
 				// TODO propagate error
 			}
 			linuxIfIdxEv.Done()

--- a/plugins/linuxplugin/data_resync.go
+++ b/plugins/linuxplugin/data_resync.go
@@ -103,7 +103,8 @@ func (plugin *Plugin) changePropagateRequest(dataChng datasync.ChangeEvent) erro
 		if err != nil {
 			return err
 		}
-		diff, err := dataChng.GetPrevValue(&prevValue)
+		var diff bool
+		diff, err = dataChng.GetPrevValue(&prevValue)
 		if err == nil {
 			err = plugin.dataChangeIface(diff, &value, &prevValue, dataChng.GetChangeType())
 		}

--- a/plugins/linuxplugin/model/interfaces/interfaces.pb.go
+++ b/plugins/linuxplugin/model/interfaces/interfaces.pb.go
@@ -83,6 +83,7 @@ type LinuxInterfaces_Interface struct {
 	Enabled     bool                          `protobuf:"varint,4,opt,name=enabled,proto3" json:"enabled,omitempty"`
 	PhysAddress string                        `protobuf:"bytes,5,opt,name=phys_address,proto3" json:"phys_address,omitempty"`
 	Mtu         uint32                        `protobuf:"varint,6,opt,name=mtu,proto3" json:"mtu,omitempty"`
+	HostIfName  string                        `protobuf:"bytes,7,opt,name=host_if_name,proto3" json:"host_if_name,omitempty"`
 	// Required format is "ipAddress/ipPrefix"
 	IpAddresses []string                             `protobuf:"bytes,10,rep,name=ip_addresses" json:"ip_addresses,omitempty"`
 	Namespace   *LinuxInterfaces_Interface_Namespace `protobuf:"bytes,50,opt,name=namespace" json:"namespace,omitempty"`

--- a/plugins/linuxplugin/model/interfaces/interfaces.proto
+++ b/plugins/linuxplugin/model/interfaces/interfaces.proto
@@ -14,6 +14,7 @@ message LinuxInterfaces {
         bool enabled = 4;
         string phys_address = 5;
         uint32 mtu = 6;
+        string host_if_name = 7; /* name of the interface in the host OS */
 
         // Required format is "ipAddress/ipPrefix"
         repeated string ip_addresses = 10;


### PR DESCRIPTION
vEth config allows to define the name of the interface in the host OS different from the one used internally by th agent