### PR TITLE
Update build-vpp.sh script for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: required
 language: go
 
 go_import_path: github.com/ligato/vpp-agent
+git:
+    depth: 5
 
 go:
   - 1.9.x

--- a/scripts/build-vpp.sh
+++ b/scripts/build-vpp.sh
@@ -2,19 +2,20 @@
 set -e
 
 VPP_CACHE_DIR=$HOME/build-cache/vpp
+
 VPP_COMMIT=`git submodule status vpp | awk '{print $1}'`
 VPP_IMG_TAG=`echo ${VPP_COMMIT} | cut -c1-7`
 
+# check if cache folder contains same version
 if [ -d "$VPP_CACHE_DIR" ] && [ ! -f ${VPP_CACHE_DIR}/vpp_*${VPP_IMG_TAG}*.deb ]; then
-    echo "Found different VPP version in cache, removing folderr"
+    echo "Removing cached VPP folder with different version"
     rm -rf "$VPP_CACHE_DIR"
 fi
 
-
 if [ ! -d "$VPP_CACHE_DIR" ]; then
-    IMG_NAME=ligato/vppdeb:${VPP_IMG_TAG}
     echo "Pulling VPP binaries (commit ${VPP_IMG_TAG})"
 
+    IMG_NAME=ligato/vppdeb:${VPP_IMG_TAG}
     docker pull ${IMG_NAME}
     id=$(docker create ${IMG_NAME})
     docker cp $id:/vpp-deb/vpp.tar .
@@ -49,7 +50,7 @@ if [ ! -d "$VPP_CACHE_DIR" ]; then
 #    mkdir $VPP_CACHE_DIR
 #    cp /tmp/vpp/build-root/*.deb $VPP_CACHE_DIR
 else
-    echo "Using cached VPP binaries from $VPP_CACHE_DIR (commit ${VPP_IMG_TAG})"
+    echo "Using cached VPP binaries (commit ${VPP_IMG_TAG})"
 fi
 
 # install VPP

--- a/scripts/build-vpp.sh
+++ b/scripts/build-vpp.sh
@@ -3,7 +3,7 @@ set -e
 
 VPP_CACHE_DIR=$HOME/build-cache/vpp
 
-VPP_COMMIT=`git submodule status vpp | awk '{print $1}'`
+VPP_COMMIT="92b0275a364022af6ab828dfac83e38c0117cfe6"
 VPP_IMG_TAG=`echo ${VPP_COMMIT} | cut -c1-7`
 
 # check if cache folder contains same version

--- a/scripts/build-vpp.sh
+++ b/scripts/build-vpp.sh
@@ -2,13 +2,19 @@
 set -e
 
 VPP_CACHE_DIR=$HOME/build-cache/vpp
-VPP_COMMIT="92b0275a364022af6ab828dfac83e38c0117cfe6"
-VPP_IMG_TAG="92b0275"
+VPP_COMMIT=`git submodule status vpp | awk '{print $1}'`
+VPP_IMG_TAG=`echo ${VPP_COMMIT} | cut -c1-7`
+
+IMG_NAME=ligato/vppdeb:${VPP_IMG_TAG}
+
+#if [ -d "$VPP_CACHE_DIR" ] && [ ! -f ${VPP_CACHE_DIR}/vpp_*${VPP_IMG_TAG}*.deb ]; then
+#    echo "Found old VPP binaries, removing VPP cache folder"
+#    rm -rf "$VPP_CACHE_DIR"
+#fi
 
 if [ ! -d "$VPP_CACHE_DIR" ]; then
-    echo "Building VPP binaries."
+    echo "Pulling fresh VPP binaries from image ${IMG_NAME}"
 
-    IMG_NAME=ligato/vppdeb:${VPP_IMG_TAG}
     docker pull ${IMG_NAME}
     id=$(docker create ${IMG_NAME})
     docker cp $id:/vpp-deb/vpp.tar .
@@ -43,7 +49,7 @@ if [ ! -d "$VPP_CACHE_DIR" ]; then
 #    mkdir $VPP_CACHE_DIR
 #    cp /tmp/vpp/build-root/*.deb $VPP_CACHE_DIR
 else
-    echo "Using cached VPP binaries from $VPP_CACHE_DIR"
+    echo "Using cached VPP binaries from folder $VPP_CACHE_DIR (commit tag ${VPP_IMG_TAG})"
 fi
 
 # install VPP

--- a/scripts/build-vpp.sh
+++ b/scripts/build-vpp.sh
@@ -5,15 +5,15 @@ VPP_CACHE_DIR=$HOME/build-cache/vpp
 VPP_COMMIT=`git submodule status vpp | awk '{print $1}'`
 VPP_IMG_TAG=`echo ${VPP_COMMIT} | cut -c1-7`
 
-IMG_NAME=ligato/vppdeb:${VPP_IMG_TAG}
+if [ -d "$VPP_CACHE_DIR" ] && [ ! -f ${VPP_CACHE_DIR}/vpp_*${VPP_IMG_TAG}*.deb ]; then
+    echo "Found different VPP version in cache, removing folderr"
+    rm -rf "$VPP_CACHE_DIR"
+fi
 
-#if [ -d "$VPP_CACHE_DIR" ] && [ ! -f ${VPP_CACHE_DIR}/vpp_*${VPP_IMG_TAG}*.deb ]; then
-#    echo "Found old VPP binaries, removing VPP cache folder"
-#    rm -rf "$VPP_CACHE_DIR"
-#fi
 
 if [ ! -d "$VPP_CACHE_DIR" ]; then
-    echo "Pulling fresh VPP binaries from image ${IMG_NAME}"
+    IMG_NAME=ligato/vppdeb:${VPP_IMG_TAG}
+    echo "Pulling VPP binaries (commit ${VPP_IMG_TAG})"
 
     docker pull ${IMG_NAME}
     id=$(docker create ${IMG_NAME})
@@ -49,7 +49,7 @@ if [ ! -d "$VPP_CACHE_DIR" ]; then
 #    mkdir $VPP_CACHE_DIR
 #    cp /tmp/vpp/build-root/*.deb $VPP_CACHE_DIR
 else
-    echo "Using cached VPP binaries from folder $VPP_CACHE_DIR (commit tag ${VPP_IMG_TAG})"
+    echo "Using cached VPP binaries from $VPP_CACHE_DIR (commit ${VPP_IMG_TAG})"
 fi
 
 # install VPP


### PR DESCRIPTION
This should fix build issues that occur when the VPP version is updated and Travis tries to use old cached VPP deb packages from previous build, thus failing on step `make test-examples`. 
Now the script will check the VPP cache folder if it contains version that doesn't match and removes it.

I also changed `VPP_COMMIT` variable to retrieve the commit hash directly from vpp submodule. 
Now it is only required to change version at one place during VPP version change, by updating vpp submodule to desired version.

I also added `git -> depth` parameter to **5** in Travis config to save some time when cloning the repository since by default it retrieves **50**. This decreases cloning step by ~10 seconds.