### PR TITLE
Remove deprecated delay flag

### DIFF
--- a/docker/dev_vpp_agent/supervisord.conf
+++ b/docker/dev_vpp_agent/supervisord.conf
@@ -10,7 +10,7 @@ redirect_stderr=true
 priority=1
 
 [program:agent]
-command=/root/go/bin/vpp-agent --etcdv3-config=/opt/vpp-agent/dev/etcd.conf --kafka-config=/opt/vpp-agent/dev/kafka.conf --default-plugins-config=/opt/vpp-agent/dev/defaultplugins.conf --linuxplugin-config=/opt/vpp-agent/dev/linuxplugin.conf --delay=80
+command=/root/go/bin/vpp-agent --etcdv3-config=/opt/vpp-agent/dev/etcd.conf --kafka-config=/opt/vpp-agent/dev/kafka.conf --default-plugins-config=/opt/vpp-agent/dev/defaultplugins.conf --linuxplugin-config=/opt/vpp-agent/dev/linuxplugin.conf
 autorestart=false
 redirect_stderr=true
 priority=2

--- a/docker/prod_vpp_agent/supervisord.conf
+++ b/docker/prod_vpp_agent/supervisord.conf
@@ -10,7 +10,7 @@ redirect_stderr=true
 priority=1
 
 [program:agent]
-command=/bin/vpp-agent --etcdv3-config=/opt/vpp-agent/dev/etcd.conf --kafka-config=/opt/vpp-agent/dev/kafka.conf --default-plugins-config=/opt/vpp-agent/dev/defaultplugins.conf --linuxplugin-config=/opt/vpp-agent/dev/linuxplugin.conf --delay=80
+command=/bin/vpp-agent --etcdv3-config=/opt/vpp-agent/dev/etcd.conf --kafka-config=/opt/vpp-agent/dev/kafka.conf --default-plugins-config=/opt/vpp-agent/dev/defaultplugins.conf --linuxplugin-config=/opt/vpp-agent/dev/linuxplugin.conf
 autorestart=false
 redirect_stderr=true
 priority=2

--- a/tests/perf/vpp.yaml
+++ b/tests/perf/vpp.yaml
@@ -51,8 +51,8 @@ data:
     priority=1
 
     [program:agent]
-    ;command=/bin/vpp-agent --etcdv3-config=/opt/vpp-agent/dev/etcd.conf --kafka-config=/opt/vpp-agent/dev/kafka.conf --delay=200
-    command=/bin/vpp-agent --etcdv3-config=/opt/vpp-agent/dev/etcd.conf --kafka-config=/opt/vpp-agent/dev/kafka.conf --default-plugins-config=/opt/vpp-agent/dev/defaultplugins.conf --linuxplugin-config=/opt/vpp-agent/dev/linuxplugin.conf --delay=200
+    ;command=/bin/vpp-agent --etcdv3-config=/opt/vpp-agent/dev/etcd.conf --kafka-config=/opt/vpp-agent/dev/kafka.conf
+    command=/bin/vpp-agent --etcdv3-config=/opt/vpp-agent/dev/etcd.conf --kafka-config=/opt/vpp-agent/dev/kafka.conf --default-plugins-config=/opt/vpp-agent/dev/defaultplugins.conf --linuxplugin-config=/opt/vpp-agent/dev/linuxplugin.conf
     autorestart=false
     redirect_stderr=true
     priority=2

--- a/tests/perf/vswitch-vpp.yaml
+++ b/tests/perf/vswitch-vpp.yaml
@@ -50,8 +50,8 @@ data:
     priority=1
 
     [program:agent]
-    ;command=/bin/vpp-agent --etcdv3-config=/opt/vpp-agent/dev/etcd.conf --kafka-config=/opt/vpp-agent/dev/kafka.conf --delay=200
-    command=/bin/vpp-agent --etcdv3-config=/opt/vpp-agent/dev/etcd.conf --kafka-config=/opt/vpp-agent/dev/kafka.conf --default-plugins-config=/opt/vpp-agent/dev/defaultplugins.conf --linuxplugin-config=/opt/vpp-agent/dev/linuxplugin.conf --delay=200
+    ;command=/bin/vpp-agent --etcdv3-config=/opt/vpp-agent/dev/etcd.conf --kafka-config=/opt/vpp-agent/dev/kafka.conf
+    command=/bin/vpp-agent --etcdv3-config=/opt/vpp-agent/dev/etcd.conf --kafka-config=/opt/vpp-agent/dev/kafka.conf --default-plugins-config=/opt/vpp-agent/dev/defaultplugins.conf --linuxplugin-config=/opt/vpp-agent/dev/linuxplugin.conf
     autorestart=false
     redirect_stderr=true
     priority=2


### PR DESCRIPTION
The `delay` flag was removed [here](https://github.com/ligato/vpp-agent/commit/25dbfdacd1213243b25e25efdebfd2fe0ef439e9#diff-f4768196b7566ad9dff98fedd6918a77).

This seems to me that **govpp** in the vendor folder was just not updated and committed with required version.  However the last change of required **govpp** version was on [Sep 13](https://github.com/ligato/vpp-agent/commit/01494a5835bf6c6f8fd38c9a3548c7ce046c4893#diff-395f41b2a27b70ce44399c91c82158c2).