### PR TITLE
ODPM-668: Robot tests: Added parameter MTU to  vpp_ctl: Put Memif Interface

### DIFF
--- a/tests/robot/libraries/vpp_ctl.robot
+++ b/tests/robot/libraries/vpp_ctl.robot
@@ -8,7 +8,7 @@ Library        String
 
 *** Keywords ***
 
-vpp_ctl: Put Json 
+vpp_ctl: Put Json
     [Arguments]        ${key}    ${json}    ${container}=vpp_agent_ctl
     Log Many           ${key}    ${json}    ${container}
     ${command}=        Set Variable    echo '${json}' | vpp-agent-ctl ${AGENT_VPP_ETCD_CONF_PATH} -put ${key} -
@@ -24,8 +24,8 @@ vpp_ctl: Read Key
     [Return]           ${out}
 
 vpp_ctl: Put Memif Interface
-    [Arguments]    ${node}    ${name}    ${mac}    ${master}    ${id}    ${socket}=default.sock    ${enabled}=true
-    Log Many    ${node}    ${name}    ${mac}    ${master}    ${id}    ${socket}    ${enabled}
+    [Arguments]    ${node}    ${name}    ${mac}    ${master}    ${id}    ${socket}=default.sock    ${mtu}=1500    ${enabled}=true
+    Log Many    ${node}    ${name}    ${mac}    ${master}    ${id}    ${socket}    ${mtu}    ${enabled}
     ${socket}=            Set Variable                  ${${node}_SOCKET_FOLDER}/${socket}
     Log                   ${socket}
     ${data}=              OperatingSystem.Get File      ${CURDIR}/../resources/memif_interface.json

--- a/tests/robot/resources/memif_interface.json
+++ b/tests/robot/resources/memif_interface.json
@@ -3,7 +3,7 @@
   "type": 2,
   "enabled": ${enabled},
   "phys_address": "${mac}",
-  "mtu": 1500,
+  "mtu": ${mtu},
   "memif": {
     "master": ${master},
     "id": ${id},


### PR DESCRIPTION
The hard-coded value of mtu parameter in memif_interface.json was changed to the more flexible variable notation and this change is taken into account in the definition of the keyword vpp_ctl: Put Memif Interface