### PR TITLE
Configuring routes waits for outgoing interface (VPP plugin)

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -14,6 +14,8 @@
 
 package errors
 
+//SwIndexNotFound is specific error type used to differentiate state when software index associated with name
+// wasn't found in register
 type SwIndexNotFound struct {
 	error
 	OriginalError error

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+type SwIndexNotFound struct {
+	error
+	OriginalError error
+}
+
+func (swIndexNotFound SwIndexNotFound) Error() string {
+	return swIndexNotFound.OriginalError.Error()
+}

--- a/plugins/defaultplugins/l3plugin/l3idx/l3_route_index.go
+++ b/plugins/defaultplugins/l3plugin/l3idx/l3_route_index.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package l3idx
+
+import (
+	"github.com/ligato/vpp-agent/idxvpp"
+	"github.com/ligato/vpp-agent/plugins/defaultplugins/l3plugin/model/l3"
+)
+
+// RouteIndex provides read-only access to mapping between routes data and route names
+type RouteIndex interface {
+	// GetMapping returns internal read-only mapping with metadata of l3.StaticRoutes_Route type.
+	GetMapping() idxvpp.NameToIdxRW
+
+	// LookupIdx looks up previously stored item identified by index in mapping.
+	LookupIdx(name string) (idx uint32, metadata *l3.StaticRoutes_Route, exists bool)
+
+	// LookupName looks up previously stored item identified by name in mapping.
+	LookupName(idx uint32) (name string, metadata *l3.StaticRoutes_Route, exists bool)
+
+	// LookupRouteAndIdByOutgoingIfc returns structure with route name and data which contains specified ifName
+	// in metadata as outgoing interface
+	LookupRouteAndIdByOutgoingIfc(ifName string) []StaticRoutesRouteAndIdx
+}
+
+// RouteIndexRW is mapping between routes data (metadata) and routes entry names.
+type RouteIndexRW interface {
+	RouteIndex
+
+	// RegisterName adds new item into name-to-index mapping.
+	RegisterName(name string, idx uint32, ifMeta *l3.StaticRoutes_Route)
+
+	// UnregisterName removes an item identified by name from mapping
+	UnregisterName(name string) (idx uint32, metadata *l3.StaticRoutes_Route, exists bool)
+}
+
+// routeIndex is type-safe implementation of mapping between routeId and route data.
+type routeIndex struct {
+	mapping idxvpp.NameToIdxRW
+}
+
+// NewRouteIndex creates new instance of routeIndex.
+func NewRouteIndex(mapping idxvpp.NameToIdxRW) RouteIndexRW {
+	return &routeIndex{mapping: mapping}
+}
+
+// GetMapping returns internal read-only mapping. It is used in tests to inspect the content of the linuxArpIndex.
+func (routeIndex *routeIndex) GetMapping() idxvpp.NameToIdxRW {
+	return routeIndex.mapping
+}
+
+// LookupIdx looks up previously stored item identified by index in mapping.
+func (routeIndex *routeIndex) LookupIdx(name string) (idx uint32, metadata *l3.StaticRoutes_Route, exists bool) {
+	idx, meta, exists := routeIndex.mapping.LookupIdx(name)
+	if exists {
+		metadata = routeIndex.castMetadata(meta)
+	}
+	return idx, metadata, exists
+}
+
+// LookupName looks up previously stored item identified by name in mapping.
+func (routeIndex *routeIndex) LookupName(idx uint32) (name string, metadata *l3.StaticRoutes_Route, exists bool) {
+	name, meta, exists := routeIndex.mapping.LookupName(idx)
+	if exists {
+		metadata = routeIndex.castMetadata(meta)
+	}
+	return name, metadata, exists
+}
+
+// StaticRoutesRouteAndIdx is used for associating route with route name in func return value
+// It is used as container to return more values
+type StaticRoutesRouteAndIdx struct {
+	Route   *l3.StaticRoutes_Route
+	RouteID string
+}
+
+// LookupRouteAndIdByOutgoingIfc returns all names related to the provided interface
+func (routeIndex *routeIndex) LookupRouteAndIdByOutgoingIfc(outgoingIfName string) []StaticRoutesRouteAndIdx {
+	var result []StaticRoutesRouteAndIdx
+	for _, routeId := range routeIndex.mapping.ListNames() {
+		_, route, found := routeIndex.LookupIdx(routeId)
+		if found && route != nil && route.OutgoingInterface == outgoingIfName {
+			result = append(result, StaticRoutesRouteAndIdx{route, routeId})
+		}
+	}
+	return result
+}
+
+// RegisterName adds new item into name-to-index mapping.
+func (routeIndex *routeIndex) RegisterName(name string, idx uint32, ifMeta *l3.StaticRoutes_Route) {
+	routeIndex.mapping.RegisterName(name, idx, ifMeta)
+}
+
+// UnregisterName removes an item identified by name from mapping
+func (routeIndex *routeIndex) UnregisterName(name string) (idx uint32, metadata *l3.StaticRoutes_Route, exists bool) {
+	idx, meta, exists := routeIndex.mapping.UnregisterName(name)
+	return idx, routeIndex.castMetadata(meta), exists
+}
+
+func (routeIndex *routeIndex) castMetadata(meta interface{}) *l3.StaticRoutes_Route {
+	if ifMeta, ok := meta.(*l3.StaticRoutes_Route); ok {
+		return ifMeta
+	}
+
+	return nil
+}

--- a/plugins/defaultplugins/l3plugin/l3idx/l3_route_index.go
+++ b/plugins/defaultplugins/l3plugin/l3idx/l3_route_index.go
@@ -30,9 +30,9 @@ type RouteIndex interface {
 	// LookupName looks up previously stored item identified by name in mapping.
 	LookupName(idx uint32) (name string, metadata *l3.StaticRoutes_Route, exists bool)
 
-	// LookupRouteAndIdByOutgoingIfc returns structure with route name and data which contains specified ifName
+	// LookupRouteAndIDByOutgoingIfc returns structure with route name and data which contains specified ifName
 	// in metadata as outgoing interface
-	LookupRouteAndIdByOutgoingIfc(ifName string) []StaticRoutesRouteAndIdx
+	LookupRouteAndIDByOutgoingIfc(ifName string) []StaticRoutesRouteAndIdx
 }
 
 // RouteIndexRW is mapping between routes data (metadata) and routes entry names.
@@ -86,13 +86,13 @@ type StaticRoutesRouteAndIdx struct {
 	RouteID string
 }
 
-// LookupRouteAndIdByOutgoingIfc returns all names related to the provided interface
-func (routeIndex *routeIndex) LookupRouteAndIdByOutgoingIfc(outgoingIfName string) []StaticRoutesRouteAndIdx {
+// LookupRouteAndIDByOutgoingIfc returns all names related to the provided interface
+func (routeIndex *routeIndex) LookupRouteAndIDByOutgoingIfc(outgoingIfName string) []StaticRoutesRouteAndIdx {
 	var result []StaticRoutesRouteAndIdx
-	for _, routeId := range routeIndex.mapping.ListNames() {
-		_, route, found := routeIndex.LookupIdx(routeId)
+	for _, routeID := range routeIndex.mapping.ListNames() {
+		_, route, found := routeIndex.LookupIdx(routeID)
 		if found && route != nil && route.OutgoingInterface == outgoingIfName {
-			result = append(result, StaticRoutesRouteAndIdx{route, routeId})
+			result = append(result, StaticRoutesRouteAndIdx{route, routeID})
 		}
 	}
 	return result

--- a/plugins/defaultplugins/l3plugin/route_config.go
+++ b/plugins/defaultplugins/l3plugin/route_config.go
@@ -32,9 +32,6 @@ import (
 	"github.com/ligato/vpp-agent/plugins/defaultplugins/l3plugin/model/l3"
 	"github.com/ligato/vpp-agent/plugins/defaultplugins/l3plugin/vppcalls"
 	"github.com/ligato/vpp-agent/plugins/govppmux"
-	"github.com/ligato/vpp-agent/errors"
-	"github.com/gogo/protobuf/test/indeximport-issue72/index"
-	"github.com/prometheus/common/route"
 	"github.com/ligato/vpp-agent/plugins/defaultplugins/l3plugin/l3idx"
 )
 

--- a/plugins/defaultplugins/l3plugin/route_utils.go
+++ b/plugins/defaultplugins/l3plugin/route_utils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ligato/vpp-agent/plugins/defaultplugins/ifplugin/ifaceidx"
 	"github.com/ligato/vpp-agent/plugins/defaultplugins/l3plugin/model/l3"
 	"github.com/ligato/vpp-agent/plugins/defaultplugins/l3plugin/vppcalls"
+	"github.com/ligato/vpp-agent/errors"
 )
 
 // SortedRoutes type is used to implement sort interface for slice of Route.
@@ -98,16 +99,7 @@ func TransformRoute(routeInput *l3.StaticRoutes_Route, index ifaceidx.SwIfIndex,
 	}
 	vrfID := routeInput.VrfId
 
-	ifName := routeInput.OutgoingInterface
-
 	ifIndex := vppcalls.NextHopOutgoingIfUnset
-	if ifName != "" {
-		var exists bool
-		ifIndex, _, exists = index.LookupIdx(ifName)
-		if !exists {
-			return nil, fmt.Errorf("route outgoing interface %v not found", ifName)
-		}
-	}
 
 	nextHopIP := net.ParseIP(routeInput.NextHopAddr)
 	if isIpv6 {
@@ -119,10 +111,23 @@ func TransformRoute(routeInput *l3.StaticRoutes_Route, index ifaceidx.SwIfIndex,
 		VrfID:       vrfID,
 		DstAddr:     *parsedDestIP,
 		NextHopAddr: nextHopIP,
-		OutIface:    ifIndex,
 		Weight:      routeInput.Weight,
 		Preference:  routeInput.Preference,
 	}
+
+	ifName := routeInput.OutgoingInterface
+	if ifName != "" {
+		var exists bool
+		ifIndex, _, exists = index.LookupIdx(ifName)
+		if !exists {
+			var err error
+			err = errors.SwIndexNotFound{OriginalError:fmt.Errorf("route outgoing interface %v not found", ifName)}
+			return route, err
+		}
+	}
+
+	route.OutIface = ifIndex
+
 	return route, nil
 }
 

--- a/plugins/defaultplugins/plugin_impl_vpp.go
+++ b/plugins/defaultplugins/plugin_impl_vpp.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ligato/vpp-agent/plugins/govppmux"
 	ifaceLinux "github.com/ligato/vpp-agent/plugins/linuxplugin/ifplugin/ifaceidx"
 	"github.com/namsral/flag"
+	"github.com/ligato/vpp-agent/plugins/defaultplugins/l3plugin/l3idx"
 )
 
 // defaultpluigns specific flags
@@ -596,7 +597,8 @@ func (plugin *Plugin) initL2(ctx context.Context) error {
 func (plugin *Plugin) initL3(ctx context.Context) error {
 	routeLogger := plugin.Log.NewLogger("-l3-route-conf")
 	plugin.routeIndexes = nametoidx.NewNameToIdx(routeLogger, plugin.PluginName, "route_indexes", nil)
-	routeCachedIndexes := nametoidx.NewNameToIdx(plugin.Log, plugin.PluginName, "route_cached_indexes", nil)
+	routeCachedIndexes := l3idx.NewRouteIndex(
+		nametoidx.NewNameToIdx(plugin.Log, plugin.PluginName, "route_cached_indexes", nil))
 
 	var stopwatch *measure.Stopwatch
 	if plugin.enableStopwatch {

--- a/plugins/defaultplugins/plugin_impl_vpp.go
+++ b/plugins/defaultplugins/plugin_impl_vpp.go
@@ -596,18 +596,20 @@ func (plugin *Plugin) initL2(ctx context.Context) error {
 func (plugin *Plugin) initL3(ctx context.Context) error {
 	routeLogger := plugin.Log.NewLogger("-l3-route-conf")
 	plugin.routeIndexes = nametoidx.NewNameToIdx(routeLogger, plugin.PluginName, "route_indexes", nil)
+	routeCachedIndexes := nametoidx.NewNameToIdx(plugin.Log, plugin.PluginName, "route_cached_indexes", nil)
 
 	var stopwatch *measure.Stopwatch
 	if plugin.enableStopwatch {
 		stopwatch = measure.NewStopwatch("RouteConfigurator", routeLogger)
 	}
 	plugin.routeConfigurator = &l3plugin.RouteConfigurator{
-		Log:           routeLogger,
-		GoVppmux:      plugin.GoVppmux,
-		RouteIndexes:  plugin.routeIndexes,
-		RouteIndexSeq: 1,
-		SwIfIndexes:   plugin.swIfIndexes,
-		Stopwatch:     stopwatch,
+		Log:              routeLogger,
+		GoVppmux:         plugin.GoVppmux,
+		RouteIndexes:     plugin.routeIndexes,
+		RouteIndexSeq:    1,
+		SwIfIndexes:      plugin.swIfIndexes,
+		RouteCachedIndex: routeCachedIndexes,
+		Stopwatch:        stopwatch,
 	}
 
 	arpLogger := plugin.Log.NewLogger("-l3-arp-conf")

--- a/plugins/defaultplugins/plugin_impl_vpp.go
+++ b/plugins/defaultplugins/plugin_impl_vpp.go
@@ -124,7 +124,7 @@ type Plugin struct {
 
 	// L3 route fields
 	routeConfigurator *l3plugin.RouteConfigurator
-	routeIndexes      idxvpp.NameToIdxRW
+	routeIndexes      l3idx.RouteIndexRW
 
 	// L3 arp fields
 	arpConfigurator *l3plugin.ArpConfigurator
@@ -596,7 +596,8 @@ func (plugin *Plugin) initL2(ctx context.Context) error {
 
 func (plugin *Plugin) initL3(ctx context.Context) error {
 	routeLogger := plugin.Log.NewLogger("-l3-route-conf")
-	plugin.routeIndexes = nametoidx.NewNameToIdx(routeLogger, plugin.PluginName, "route_indexes", nil)
+	plugin.routeIndexes = l3idx.NewRouteIndex(
+		nametoidx.NewNameToIdx(routeLogger, plugin.PluginName, "route_indexes", nil))
 	routeCachedIndexes := l3idx.NewRouteIndex(
 		nametoidx.NewNameToIdx(plugin.Log, plugin.PluginName, "route_cached_indexes", nil))
 

--- a/plugins/defaultplugins/watch_events.go
+++ b/plugins/defaultplugins/watch_events.go
@@ -104,6 +104,7 @@ func (plugin *Plugin) watchEvents(ctx context.Context) {
 				plugin.xcConfigurator.ResolveCreatedInterface(ifIdxEv.Name, ifIdxEv.Idx)
 				plugin.l4Configurator.ResolveCreatedInterface(ifIdxEv.Name, ifIdxEv.Idx)
 				plugin.stnConfigurator.ResolveCreatedInterface(ifIdxEv.Name)
+				plugin.routeConfigurator.ResolveCreatedInterface(ifIdxEv.Name, ifIdxEv.Idx)
 				// TODO propagate error
 			} else {
 				plugin.bdConfigurator.ResolveDeletedInterface(ifIdxEv.Name) //TODO ifIdxEv.Idx to not process data events

--- a/plugins/defaultplugins/watch_events.go
+++ b/plugins/defaultplugins/watch_events.go
@@ -116,6 +116,7 @@ func (plugin *Plugin) watchEvents(ctx context.Context) {
 				plugin.xcConfigurator.ResolveDeletedInterface(ifIdxEv.Name)
 				plugin.l4Configurator.ResolveDeletedInterface(ifIdxEv.Name, ifIdxEv.Idx)
 				plugin.stnConfigurator.ResolveDeletedInterface(ifIdxEv.Name)
+				plugin.routeConfigurator.ResolveDeletedInterface(ifIdxEv.Name, ifIdxEv.Idx)
 				// TODO propagate error
 			}
 			ifIdxEv.Done()


### PR DESCRIPTION
It is possible to specify set of routes for not existing
outgoing interface.
Once interface is created than this routes are automatically
configured on VPP.

In case of modification of cached route it is replaced with
new route (if there are same changes in priority or weight fields)

Signed-off-by: Jozef Gloncak <jozef.gloncak@pantheon.tech>