### PR TITLE
Fix bdf_config func

### DIFF
--- a/plugins/defaultplugins/ifplugin/bfd_config.go
+++ b/plugins/defaultplugins/ifplugin/bfd_config.go
@@ -70,8 +70,9 @@ func (plugin *BFDConfigurator) Init(bfdSessionIndexes idxvpp.NameToIdxRW, bfdKey
 	if err != nil {
 		return err
 	}
-	err = vppcalls.CheckMsgCompatibilityForBfd(plugin.Log, plugin.vppChannel)
+	err = vppcalls.CheckMsgCompatibilityForBfd(plugin.vppChannel)
 	if err != nil {
+		plugin.Log.Error(err)
 		return err
 	}
 

--- a/plugins/defaultplugins/ifplugin/stn_config.go
+++ b/plugins/defaultplugins/ifplugin/stn_config.go
@@ -33,7 +33,6 @@ import (
 	modelStn "github.com/ligato/vpp-agent/plugins/defaultplugins/ifplugin/model/stn"
 	"github.com/ligato/vpp-agent/plugins/defaultplugins/ifplugin/vppcalls"
 	"github.com/ligato/vpp-agent/plugins/govppmux"
-	"github.com/prometheus/common/log"
 )
 
 // StnConfigurator runs in the background in its own goroutine where it watches for any changes
@@ -134,7 +133,7 @@ func (plugin *StnConfigurator) Delete(rule *modelStn.StnRule) error {
 	withoutIf, _ := plugin.removeRuleFromIndex(rule.Interface)
 
 	if withoutIf {
-		log.Debug("STN rule was not stored into VPP, removed only from indexes.")
+		plugin.Log.Debug("STN rule was not stored into VPP, removed only from indexes.")
 		return nil
 	}
 	plugin.Log.Debugf("STN rule: %+v was stored in VPP, trying to delete it. %+v", stnRule)

--- a/plugins/defaultplugins/ifplugin/vppcalls/compat_vppcalls.go
+++ b/plugins/defaultplugins/ifplugin/vppcalls/compat_vppcalls.go
@@ -81,7 +81,7 @@ func CheckMsgCompatibilityForInterface(log logging.Logger, vppChan *govppapi.Cha
 }
 
 // CheckMsgCompatibilityForBfd checks if bfd CRSs are compatible with VPP in runtime.
-func CheckMsgCompatibilityForBfd(log logging.Logger, vppChan *govppapi.Channel) error {
+func CheckMsgCompatibilityForBfd(vppChan *govppapi.Channel) error {
 	msgs := []govppapi.Message{
 		&bfd.BfdUDPAdd{},
 		&bfd.BfdUDPAddReply{},
@@ -94,9 +94,5 @@ func CheckMsgCompatibilityForBfd(log logging.Logger, vppChan *govppapi.Channel) 
 		&bfd.BfdAuthDelKey{},
 		&bfd.BfdAuthDelKeyReply{},
 	}
-	err := vppChan.CheckMessageCompatibility(msgs...)
-	if err != nil {
-		log.Error(err)
-	}
-	return err
+	return vppChan.CheckMessageCompatibility(msgs...)
 }


### PR DESCRIPTION
- func CheckMsgCompatibilityForBfd passes log but it is not needed. It can be logged into bfd_config

Signed-off-by: Jozef Bacigal <jozef.bacigal@pantheon.tech>