### PR TITLE
register bd after all interfaces are set

### DIFF
--- a/plugins/defaultplugins/l2plugin/bd_config.go
+++ b/plugins/defaultplugins/l2plugin/bd_config.go
@@ -115,10 +115,6 @@ func (plugin *BDConfigurator) ConfigureBridgeDomain(bridgeDomainInput *l2.Bridge
 		return err
 	}
 
-	// Register created bridge domain.
-	plugin.BdIndexes.RegisterName(bridgeDomainInput.Name, bridgeDomainIndex, nil)
-	plugin.Log.WithFields(logging.Fields{"Name": bridgeDomainInput.Name, "Index": bridgeDomainIndex}).Debug("Bridge domain registered.")
-
 	// Find all interfaces belonging to this bridge domain and set them up.
 	allInterfaces, configuredInterfaces, bviInterfaceName := vppcalls.VppSetAllInterfacesToBridgeDomain(bridgeDomainInput, bridgeDomainIndex,
 		plugin.SwIfIndexes, plugin.Log, plugin.vppChan, measure.GetTimeLog(vpe.SwInterfaceSetL2Bridge{}, plugin.Stopwatch))
@@ -138,6 +134,10 @@ func (plugin *BDConfigurator) ConfigureBridgeDomain(bridgeDomainInput *l2.Bridge
 	} else {
 		plugin.Log.WithField("Bridge domain name", bridgeDomainInput.Name).Debug("No ARP termination entries to set")
 	}
+
+	// Register created bridge domain.
+	plugin.BdIndexes.RegisterName(bridgeDomainInput.Name, bridgeDomainIndex, nil)
+	plugin.Log.WithFields(logging.Fields{"Name": bridgeDomainInput.Name, "Index": bridgeDomainIndex}).Debug("Bridge domain registered.")
 
 	// Push to bridge domain state.
 	errLookup := plugin.LookupBridgeDomainDetails(bridgeDomainIndex, bridgeDomainInput.Name)

--- a/plugins/defaultplugins/l2plugin/fib_config.go
+++ b/plugins/defaultplugins/l2plugin/fib_config.go
@@ -410,17 +410,17 @@ func (plugin *FIBConfigurator) ResolveCreatedBridgeDomain(domainName string, dom
 			}
 			if !validated {
 				plugin.Log.Infof("FIB entry %v - required interface %v is not a part of bridge domain %v",
-					mac, domainID)
+					mac, fibInterface, domainID)
 				continue
 			} else {
 				fibBvi := meta.(*FIBMeta).BVI
 				fibStatic := meta.(*FIBMeta).StaticConfig
 				err := plugin.vppcalls.Add(mac, domainID, ifIndex, fibBvi, fibStatic, func(err error) {
-					plugin.Log.Infof("Previously not configurable FIB entry with MAC %v is now configured", mac)
+					plugin.Log.Debugf("Previously not configurable FIB entry with MAC %v is now configured", mac)
 					// Resolve registration.
 					plugin.FibIndexes.RegisterName(mac, plugin.FibIndexSeq, meta)
 					plugin.FibIndexSeq++
-					plugin.Log.Debug("Registering FIB table entry with MAC ", mac)
+					plugin.Log.Debugf("Registering FIB table entry with MAC %v", mac)
 					plugin.FibDesIndexes.UnregisterName(mac)
 					plugin.Log.Debugf("Unconfigured FIB entry with MAC %v removed from cache", mac)
 					callback(err)
@@ -431,7 +431,7 @@ func (plugin *FIBConfigurator) ResolveCreatedBridgeDomain(domainName string, dom
 			}
 		}
 	}
-	plugin.Log.Infof("FIB: resolution of created bridge domain %v is done", domainName)
+	plugin.Log.Debugf("FIB: resolution of created bridge domain %v is done", domainName)
 	return wasError
 }
 


### PR DESCRIPTION
To configure FIB entry, it is required to have desired bridge domain and interface already configured on the VPP and also the interface has to be set as a part of the bridge domain. 
In rare cases, the FIB configurator may react on new bridge domain sooner that the bridge domain has all interfaces set and the FIB entry won't be configured. 


Signed-off-by: Vladimir Lavor <vlavor@cisco.com>