### PR TITLE
Minor fixes in the NAT configurator.

### DIFF
--- a/plugins/defaultplugins/ifplugin/nat_config.go
+++ b/plugins/defaultplugins/ifplugin/nat_config.go
@@ -748,7 +748,7 @@ func diffAddressPools(oldAPs, newAPs []*nat.Nat44Global_AddressPools, log loggin
 	for _, oldAp := range oldAPs {
 		// If new address pool is a range, remove it
 		if oldAp.LastSrcAddress != "" {
-			toRemove = append(toAdd, oldAp)
+			toRemove = append(toRemove, oldAp)
 			continue
 		}
 		// Otherwise try to find the same address pool

--- a/plugins/defaultplugins/ifplugin/vppcalls/nat_vppcalls.go
+++ b/plugins/defaultplugins/ifplugin/vppcalls/nat_vppcalls.go
@@ -183,6 +183,7 @@ func handleNat44StaticMapping(ctx *StaticMappingContext, isAdd, addrOnly bool, v
 		ExternalSwIfIndex: ctx.ExternalIfIdx,
 		VrfID:             ctx.Vrf,
 		TwiceNat:          boolToUint(ctx.TwiceNat),
+		Out2inOnly:        1,
 		IsAdd:             boolToUint(isAdd),
 	}
 	if addrOnly {
@@ -229,6 +230,7 @@ func handleNat44StaticMappingLb(ctx *StaticMappingLbContext, isAdd bool, vppChan
 		Protocol:     ctx.Protocol,
 		VrfID:        ctx.Vrf,
 		TwiceNat:     boolToUint(ctx.TwiceNat),
+		Out2inOnly:   1,
 		IsAdd:        boolToUint(isAdd),
 	}
 


### PR DESCRIPTION
Regarding Out2inOnly parameter: if not enabled, connections initiated from any of the local IPs will be source NATed to the associated external IP, which is super confusing for any use-case IMHO, especially if is denoted as "DNAT" (quite frankly "1" should be the default in VPP).

We could add the parameter to the model, but I would leave this more natural DNAT-only behaviour until there is a requirement...