### PR TITLE
Change url for VPP submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vpp"]
 	path = vpp
-	url = https://gerrit.fd.io/r/vpp
+	url = https://github.com/vpp-dev/vpp.git


### PR DESCRIPTION
This change is required for using vpp-agent as [[constraint]] in Gopkg.toml (dep), since we changed submodule url in pantheon-dev branch.

Without this dep ensure will fail with following error:
```
Solving failure: No versions of github.com/ligato/vpp-agent met constraints:
	6203f5baed2c475ef06ae42a8ee23599fc0b6db3: unexpected error while defensively updating submodules: error: no such remote ref 954d43767061e7f78a9080313d645192e3029789
Fetched in submodule path 'vpp', but it did not contain 954d43767061e7f78a9080313d645192e3029789. Direct fetching of that commit failed.
: command failed: [git submodule update --init --recursive]: exit status 1
```