### PR TITLE
adding non-bvi interfaces does not crash the agent

### DIFF
--- a/plugins/defaultplugins/l2plugin/bd_config.go
+++ b/plugins/defaultplugins/l2plugin/bd_config.go
@@ -400,7 +400,7 @@ func (plugin *BDConfigurator) calculateIfaceDiff(newIfaces, oldIfaces []*l2.Brid
 	// If BVI was set/unset in general or the BVI interface was changed, pass the knowledge to the diff
 	// resolution
 	var bviChanged bool
-	if (oldBVI == nil && newBVI != nil) || (oldBVI != nil && newBVI == nil) || (oldBVI.Name != newBVI.Name) {
+	if (oldBVI == nil && newBVI != nil) || (oldBVI != nil && newBVI == nil) || (oldBVI != nil && newBVI != nil && oldBVI.Name != newBVI.Name) {
 		bviChanged = true
 	}
 


### PR DESCRIPTION
Signed-off-by: Vladimir Lavor <vlavor@cisco.com>