### PR TITLE
Strip go binaries in production image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@ COMMIT	:= $(shell git rev-parse HEAD)
 DATE	:= $(shell date +'%Y-%m-%dT%H:%M%:z')
 
 CNINFRA_CORE := github.com/ligato/vpp-agent/vendor/github.com/ligato/cn-infra/core
-LDFLAGS	= -ldflags '-X $(CNINFRA_CORE).BuildVersion=$(VERSION) -X $(CNINFRA_CORE).CommitHash=$(COMMIT) -X $(CNINFRA_CORE).BuildDate=$(DATE)'
+LDFLAGS	= -X $(CNINFRA_CORE).BuildVersion=$(VERSION) -X $(CNINFRA_CORE).CommitHash=$(COMMIT) -X $(CNINFRA_CORE).BuildDate=$(DATE)
+
+ifeq ($(STRIP), y)
+LDFLAGS += -w -s
+endif
 
 COVER_DIR ?= /tmp/
 
@@ -16,18 +20,18 @@ clean: clean-cmd clean-examples
 # Install commands
 install:
 	@echo "# installing commands"
-	go install -v ${LDFLAGS} -tags="${GO_BUILD_TAGS}" ./cmd/vpp-agent
-	go install -v ${LDFLAGS} -tags="${GO_BUILD_TAGS}" ./cmd/vpp-agent-grpc
-	go install -v ${LDFLAGS} -tags="${GO_BUILD_TAGS}" ./cmd/vpp-agent-ctl
-	go install -v ${LDFLAGS} -tags="${GO_BUILD_TAGS}" ./cmd/agentctl
+	go install -v -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}" ./cmd/vpp-agent
+	go install -v -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}" ./cmd/vpp-agent-grpc
+	go install -v -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}" ./cmd/vpp-agent-ctl
+	go install -v -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}" ./cmd/agentctl
 
 # Build commands
 cmd:
 	@echo "# building commands"
-	cd cmd/vpp-agent 		&& go build -v -i ${LDFLAGS} -tags="$(GO_BUILD_TAGS)"
-	cd cmd/vpp-agent-grpc	&& go build -v -i ${LDFLAGS} -tags="${GO_BUILD_TAGS}"
-	cd cmd/vpp-agent-ctl	&& go build -v -i ${LDFLAGS} -tags="${GO_BUILD_TAGS}"
-	cd cmd/agentctl 		&& go build -v -i ${LDFLAGS} -tags="${GO_BUILD_TAGS}"
+	cd cmd/vpp-agent 		&& go build -v -i -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}"
+	cd cmd/vpp-agent-grpc	&& go build -v -i -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}"
+	cd cmd/vpp-agent-ctl	&& go build -v -i -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}"
+	cd cmd/agentctl 		&& go build -v -i -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}"
 
 # Clean commands
 clean-cmd:

--- a/docker/prod_vpp_agent/Dockerfile
+++ b/docker/prod_vpp_agent/Dockerfile
@@ -1,5 +1,8 @@
 FROM dev_vpp_agent as devimg
 
+RUN cd $GOPATH/src/github.com/ligato/vpp-agent
+ && make STRIP=y install
+
 FROM ubuntu:16.04
 
 RUN apt-get update \


### PR DESCRIPTION
This will build go binaries without debug symbols and DWARF symbol table. Further decreasing production image size.
