### PR TITLE
NAT configurator bug fixes

### DIFF
--- a/plugins/defaultplugins/ifplugin/nat_config.go
+++ b/plugins/defaultplugins/ifplugin/nat_config.go
@@ -40,9 +40,9 @@ import (
 
 // Mapping labels
 const (
-	static   = "-static-"
-	staticLb = "-staticLb-"
-	identity = "-identity-"
+	static   = "|static|"
+	staticLb = "|staticLb|"
+	identity = "|identity|"
 	dummyTag = "dummy-tag" // used for deletion where tag is not needed
 )
 


### PR DESCRIPTION
- use "|" instead of "-" for separator of DNAT labels (dash is allowed character for K8s service name)
- output features are now separate from the rest of NAT interface features
- Nat44InterfaceDetails with isInside==2 means the interface is both "in" and "out"
