### PR TITLE
Enable apt update option for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ dist: trusty
 sudo: required
 language: go
 
+addons:
+  apt:
+    update: true
+
 go_import_path: github.com/ligato/vpp-agent
 
 git:


### PR DESCRIPTION
Running apt-get update by default has been disabled in Travis recently.

Signed-off-by: Ondrej Fabry <ofabry@cisco.com>