### PR TITLE
Always run all unit tests recursively

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,14 @@ env:
 before_install:
   - make get-linkcheck
   - make get-linters
+  - make get-dep
   - go get github.com/mattn/goveralls
 
 script:
   - make check-links
   - make lint
   - make verify-binapi
+  - make dep-check
   - make
   - make test-cover
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,10 @@ env:
 before_install:
   - make get-linkcheck
   - make get-linters
-  - make get-covtools
-  - go get -v github.com/mattn/goveralls
+  - go get github.com/mattn/goveralls
 
 script:
-  - make check-links || true
+  - make check-links
   - make lint
   - make verify-binapi
   - make

--- a/Makefile
+++ b/Makefile
@@ -72,12 +72,8 @@ test:
 	@echo "=> running unit tests"
 	go test -tags="${GO_BUILD_TAGS}" ./...
 
-# Get coverage report tools
-get-covtools:
-	go get -v github.com/wadey/gocovmerge
-
 # Run coverage report
-test-cover: get-covtools
+test-cover:
 	@echo "=> running unit tests with coverage"
 	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/coverage.out ./...
 	@echo "=> coverage data generated into ${COVER_DIR}/coverage.out"

--- a/Makefile
+++ b/Makefile
@@ -70,23 +70,7 @@ clean-examples:
 # Run tests
 test:
 	@echo "=> running unit tests"
-	go test -tags="${GO_BUILD_TAGS}" ./tests/go/itest
-	go test -tags="${GO_BUILD_TAGS}" ./cmd/agentctl/utils
-	go test -tags="${GO_BUILD_TAGS}" ./plugins/govppmux/vppcalls
-	go test -tags="${GO_BUILD_TAGS}" ./idxvpp/nametoidx
-	go test -tags="${GO_BUILD_TAGS}" ./plugins/vpp/aclplugin/vppcalls
-	go test -tags="${GO_BUILD_TAGS}" ./plugins/vpp/aclplugin/vppdump
-	go test -tags="${GO_BUILD_TAGS}" ./plugins/vpp/ifplugin
-	go test -tags="${GO_BUILD_TAGS}" ./plugins/vpp/ifplugin/ifaceidx
-	go test -tags="${GO_BUILD_TAGS}" ./plugins/vpp/ifplugin/vppcalls
-	go test -tags="${GO_BUILD_TAGS}" ./plugins/vpp/ifplugin/vppdump
-	go test -tags="${GO_BUILD_TAGS}" ./plugins/vpp/l2plugin
-	go test -tags="${GO_BUILD_TAGS}" ./plugins/vpp/l2plugin/l2idx
-	go test -tags="${GO_BUILD_TAGS}" ./plugins/vpp/l2plugin/vppcalls
-	go test -tags="${GO_BUILD_TAGS}" ./plugins/vpp/l2plugin/vppdump
-	go test -tags="${GO_BUILD_TAGS}" ./plugins/vpp/rpc
-	go test -tags="${GO_BUILD_TAGS}" ./plugins/vpp/srplugin
-	go test -tags="${GO_BUILD_TAGS}" ./plugins/vpp/srplugin/vppcalls
+	go test -tags="${GO_BUILD_TAGS}" ./...
 
 # Get coverage report tools
 get-covtools:
@@ -99,6 +83,7 @@ test-cover: get-covtools
 	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/agentctl_utils.cov 		./cmd/agentctl/utils
 	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/govpp_vppcalls.cov			./plugins/govppmux/vppcalls
 	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/idxvpp_nametoidx.cov 		./idxvpp/nametoidx
+	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_aclplugin.cov			./plugins/vpp/aclplugin
 	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_aclplugin_vppcalls.cov	./plugins/vpp/aclplugin/vppcalls
 	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_aclplugin_vppdump.cov	./plugins/vpp/aclplugin/vppdump
 	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_ifplugin.cov 			./plugins/vpp/ifplugin
@@ -118,6 +103,7 @@ test-cover: get-covtools
 			${COVER_DIR}/agentctl_utils.cov \
 			${COVER_DIR}/idxvpp_nametoidx.cov \
 			${COVER_DIR}/govpp_vppcalls.cov \
+			${COVER_DIR}/vpp_aclplugin.cov \
 			${COVER_DIR}/vpp_aclplugin_vppcalls.cov \
 			${COVER_DIR}/vpp_aclplugin_vppdump.cov \
 			${COVER_DIR}/vpp_ifplugin.cov \

--- a/Makefile
+++ b/Makefile
@@ -158,12 +158,16 @@ get-dep:
 # Install the project's dependencies
 dep-install: get-dep
 	@echo "=> installing project's dependencies"
-	dep ensure
+	dep ensure -v
 
 # Update the locked versions of all dependencies
 dep-update: get-dep
 	@echo "=> updating all dependencies"
 	dep ensure -update
+
+# Check state of dependencies
+dep-check: get-dep
+	dep ensure -dry-run -no-vendor
 
 # Get linter tools
 get-linters:
@@ -192,8 +196,8 @@ check-links: get-linkcheck
 
 .PHONY: build clean \
 	install cmd examples clean-examples test \
-	get-covtools test-cover test-cover-html test-cover-xml \
+	test-cover test-cover-html test-cover-xml \
 	generate genereate-binapi generate-proto get-binapi-generators get-proto-generators \
-	get-dep dep-install dep-update \
+	get-dep dep-install dep-update dep-check \
 	get-linters lint format \
 	get-linkcheck check-links

--- a/Makefile
+++ b/Makefile
@@ -79,45 +79,7 @@ get-covtools:
 # Run coverage report
 test-cover: get-covtools
 	@echo "=> running unit tests with coverage"
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/scenario.cov 				./tests/go/itest
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/agentctl_utils.cov 		./cmd/agentctl/utils
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/govpp_vppcalls.cov			./plugins/govppmux/vppcalls
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/idxvpp_nametoidx.cov 		./idxvpp/nametoidx
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_aclplugin.cov			./plugins/vpp/aclplugin
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_aclplugin_vppcalls.cov	./plugins/vpp/aclplugin/vppcalls
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_aclplugin_vppdump.cov	./plugins/vpp/aclplugin/vppdump
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_ifplugin.cov 			./plugins/vpp/ifplugin
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_ifplugin_ifaceidx.cov 	./plugins/vpp/ifplugin/ifaceidx
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_ifplugin_vppcalls.cov 	./plugins/vpp/ifplugin/vppcalls
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_ifplugin_vppdump.cov 	./plugins/vpp/ifplugin/vppdump
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_l2plugin.cov 			./plugins/vpp/l2plugin
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_l2plugin_l2idx.cov 	./plugins/vpp/l2plugin/l2idx
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_l2plugin_vppcalls.cov 	./plugins/vpp/l2plugin/vppcalls
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_l2plugin_vppdump.cov 	./plugins/vpp/l2plugin/vppdump
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_rpc.cov 				./plugins/vpp/rpc
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_srplugin.cov 			./plugins/vpp/srplugin
-	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/vpp_srplugin_vppcalls.cov	./plugins/vpp/srplugin/vppcalls
-	@echo "=> merging coverage results"
-	gocovmerge \
-			${COVER_DIR}/scenario.cov \
-			${COVER_DIR}/agentctl_utils.cov \
-			${COVER_DIR}/idxvpp_nametoidx.cov \
-			${COVER_DIR}/govpp_vppcalls.cov \
-			${COVER_DIR}/vpp_aclplugin.cov \
-			${COVER_DIR}/vpp_aclplugin_vppcalls.cov \
-			${COVER_DIR}/vpp_aclplugin_vppdump.cov \
-			${COVER_DIR}/vpp_ifplugin.cov \
-			${COVER_DIR}/vpp_ifplugin_ifaceidx.cov \
-			${COVER_DIR}/vpp_ifplugin_vppcalls.cov \
-			${COVER_DIR}/vpp_ifplugin_vppdump.cov \
-			${COVER_DIR}/vpp_l2plugin.cov \
-			${COVER_DIR}/vpp_l2plugin_l2idx.cov \
-			${COVER_DIR}/vpp_l2plugin_vppcalls.cov \
-			${COVER_DIR}/vpp_l2plugin_vppdump.cov \
-			${COVER_DIR}/vpp_rpc.cov \
-			${COVER_DIR}/vpp_srplugin.cov \
-			${COVER_DIR}/vpp_srplugin_vppcalls.cov \
-		> ${COVER_DIR}/coverage.out
+	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/coverage.out ./...
 	@echo "=> coverage data generated into ${COVER_DIR}/coverage.out"
 
 test-cover-html: test-cover

--- a/docker/prod/README.md
+++ b/docker/prod/README.md
@@ -92,6 +92,6 @@ sudo docker exec -it vpp_agent bash
 
 ### Running VPP and the Agent
 You can use the image the same way as the development image, see this
-[README](../dev_vpp_agent/README.md).
+[README](../dev/README.md).
 
 [1]: https://github.com/moby/moby/issues/26173

--- a/plugins/vpp/aclplugin/acl_config_test.go
+++ b/plugins/vpp/aclplugin/acl_config_test.go
@@ -52,7 +52,7 @@ func TestDiffInterfaces(t *testing.T) {
 	} {
 		added, removed := diffInterfaces(test.oldIfaces, test.newIfaces)
 
-		Expect(added).To(Equal(test.expectAdded))
-		Expect(removed).To(Equal(test.expectRemoved))
+		Expect(added).To(ConsistOf(test.expectAdded))
+		Expect(removed).To(ConsistOf(test.expectRemoved))
 	}
 }


### PR DESCRIPTION
This PR changes both make targets `test`/`test-cover` to run all tests recursively. This will eliminate forgotten tests and count the real coverage.

And this also makes `check-links` target mandatory for Travis check.