### PR TITLE
Do not send interface DOWN when deleting VPP int

### DIFF
--- a/plugins/vpp/ifplugin/interface_config.go
+++ b/plugins/vpp/ifplugin/interface_config.go
@@ -755,10 +755,14 @@ func (plugin *InterfaceConfigurator) deleteVPPInterface(oldConfig *intf.Interfac
 	plugin.log.WithFields(logging.Fields{"ifname": oldConfig.Name, "swIfIndex": ifIdx}).
 		Debug("deleteVPPInterface begin")
 
-	// let's try to do following even if previously error occurred
-	if err := vppcalls.InterfaceAdminDown(ifIdx, plugin.vppCh, plugin.stopwatch); err != nil {
-		plugin.log.Error(err)
-		wasError = err
+	// Skip setting interface to ADMIN_DOWN unless the type ETHERNET_CSMACD because that one cannot be removed
+	// so at least put it down
+	if oldConfig.Type == intf.InterfaceType_ETHERNET_CSMACD {
+		// Let's try to do following even if previously error occurred
+		if err := vppcalls.InterfaceAdminDown(ifIdx, plugin.vppCh, plugin.stopwatch); err != nil {
+			plugin.log.Error(err)
+			wasError = err
+		}
 	}
 
 	// Remove DHCP if it was set

--- a/plugins/vpp/ifplugin/interface_config_test.go
+++ b/plugins/vpp/ifplugin/interface_config_test.go
@@ -582,8 +582,7 @@ func TestInterfacesModifyTapV1TapData(t *testing.T) {
 	ctx, connection, plugin := ifTestSetup(t)
 	defer ifTestTeardown(connection, plugin)
 	// Reply set
-	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{}) // Delete
-	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{})
+	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{}) // Delete
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceAddDelAddressReply{})
 	ctx.MockVpp.MockReply(&tap.TapDeleteReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceTagAddDelReply{})
@@ -668,8 +667,7 @@ func TestInterfacesModifyMemifData(t *testing.T) {
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetMtuReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&vpe.ControlPingReply{})
-	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{}) // Modify - delete old data
-	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{})
+	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{}) // Modify - delete old data
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceAddDelAddressReply{})
 	ctx.MockVpp.MockReply(&memif.MemifDeleteReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceTagAddDelReply{})
@@ -757,8 +755,7 @@ func TestInterfacesModifyVxLanData(t *testing.T) {
 	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&vpe.ControlPingReply{})
-	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{}) // Modify - delete old data
-	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{})
+	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{}) // Modify - delete old data
 	ctx.MockVpp.MockReply(&vxlan.VxlanAddDelTunnelReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceTagAddDelReply{})
 	ctx.MockVpp.MockReply(&vxlan.VxlanAddDelTunnelReply{ // Modify - configure new data
@@ -990,7 +987,6 @@ func TestInterfacesDeleteTapInterface(t *testing.T) {
 	ctx, connection, plugin := ifTestSetup(t)
 	defer ifTestTeardown(connection, plugin)
 	// Reply set
-	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&dhcp_api.DhcpClientConfigReply{})
 	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceAddDelAddressReply{})
@@ -1014,7 +1010,6 @@ func TestInterfacesDeleteMemifInterface(t *testing.T) {
 	ctx, connection, plugin := ifTestSetup(t)
 	defer ifTestTeardown(connection, plugin)
 	// Reply set
-	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceAddDelAddressReply{})
 	ctx.MockVpp.MockReply(&memif.MemifDeleteReply{})
@@ -1036,7 +1031,6 @@ func TestInterfacesDeleteVxlanInterface(t *testing.T) {
 	ctx, connection, plugin := ifTestSetup(t)
 	defer ifTestTeardown(connection, plugin)
 	// Reply set
-	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceAddDelAddressReply{})
 	ctx.MockVpp.MockReply(&vxlan.VxlanAddDelTunnelReply{})
@@ -1059,7 +1053,6 @@ func TestInterfacesDeleteLoopbackInterface(t *testing.T) {
 	ctx, connection, plugin := ifTestSetup(t)
 	defer ifTestTeardown(connection, plugin)
 	// Reply set
-	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceAddDelAddressReply{})
 	ctx.MockVpp.MockReply(&interfaces.DeleteLoopbackReply{})
@@ -1081,7 +1074,6 @@ func TestInterfacesDeleteEthernetInterface(t *testing.T) {
 	ctx, connection, plugin := ifTestSetup(t)
 	defer ifTestTeardown(connection, plugin)
 	// Reply set
-	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceAddDelAddressReply{})
 	// Data


### PR DESCRIPTION
When deleting VPP interface (specifically afpacket) when interface
state DOWN is sent before deletion, it will set connected veth interface
to DOWN too. To prevent this and revert to behaviour before creation of
afpacket, do not send DOWN and just delete the interface.

After this change, the afpacket interface is being correctly deleted and veth interfaces stay in correct state (e.g both are UP instead of one being DOWN and other being LOWERLAYERDOWN). I am not sure why is this happening, maybe another solution is to just not send DOWN only for afpacket and not delete this part of logic completely.

This is what happens currently on `pantheon-dev` when/after DOWN is sent (ignore the error messages, they were only added locally to properly determine starting point of action):

```
DEBU[0044] deleteVPPInterface begin                      ifname=afpacket1 loc="ifplugin/interface_config.go(755)" logger=vpp-plugin-if-conf swIfIndex=1
ERRO[0044] Making 1 int down                             loc="ifplugin/interface_config.go(758)" logger=vpp-plugin-if-conf
DEBU[0044] processIfStateNotification but the swIfIndex is not event registered  loc="ifplugin/interface_state.go(251)" logger=vpp-plugin-if-state swIfIndex=1
DEBU[0044] Processing Linux link update: Name=veth1Name Type=veth OperState=down Index=2 HwAddr=62:54:cb:4c:eb:53  loc="ifplugin/interface_state.go(118)" logger=linux-plugin-if-state
ERRO[0044] Checking dhcp client false int 1              loc="ifplugin/interface_config.go(765)" logger=vpp-plugin-if-conf
```