### PR TITLE
Interface being removed before route ends with error

### DIFF
--- a/plugins/vpp/l3plugin/route_config.go
+++ b/plugins/vpp/l3plugin/route_config.go
@@ -181,6 +181,16 @@ func (plugin *RouteConfigurator) ModifyRoute(newConfig *l3.StaticRoutes_Route, o
 }
 
 func (plugin *RouteConfigurator) deleteOldRoute(oldConfig *l3.StaticRoutes_Route, vrfFromKey string) error {
+	// Check if route entry is not just cached
+	routeID := routeIdentifier(oldConfig.VrfId, oldConfig.DstIpAddr, oldConfig.NextHopAddr)
+	_, _, found := plugin.rtCachedIndexes.LookupIdx(routeID)
+	if found {
+		plugin.log.Debugf("Route entry %v found in cache, removed", routeID)
+		plugin.rtCachedIndexes.UnregisterName(routeID)
+		// Cached route is not configured on the VPP, return
+		return nil
+	}
+
 	swIdx, err := resolveInterfaceSwIndex(oldConfig.OutgoingInterface, plugin.ifIndexes)
 	if err != nil {
 		return err
@@ -203,7 +213,7 @@ func (plugin *RouteConfigurator) deleteOldRoute(oldConfig *l3.StaticRoutes_Route
 
 	oldRouteIdentifier := routeIdentifier(oldRoute.VrfID, oldRoute.DstAddr.String(), oldRoute.NextHopAddr.String())
 
-	_, _, found := plugin.rtIndexes.UnregisterName(oldRouteIdentifier)
+	_, _, found = plugin.rtIndexes.UnregisterName(oldRouteIdentifier)
 	if found {
 		plugin.log.Infof("Old route %v unregistered", oldRouteIdentifier)
 	} else {

--- a/plugins/vpp/l3plugin/route_config.go
+++ b/plugins/vpp/l3plugin/route_config.go
@@ -267,7 +267,7 @@ func (plugin *RouteConfigurator) DeleteRoute(config *l3.StaticRoutes_Route, vrfF
 	if found {
 		plugin.log.Debugf("Route entry %v found in cache, removed", routeID)
 		plugin.rtCachedIndexes.UnregisterName(routeID)
-		// Cached ARP is not configured on the VPP, return
+		// Cached route is not configured on the VPP, return
 		return nil
 	}
 


### PR DESCRIPTION
When deleting route prior resolveInterfaceSwIndex() check whether route is not in cache.