### PR TITLE
Revert "Comment out SelfTwiceNat in NAT calls for now"

### DIFF
--- a/plugins/vpp/ifplugin/vppcalls/nat_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/nat_vppcalls.go
@@ -185,9 +185,9 @@ func handleNat44StaticMapping(ctx *StaticMappingContext, isAdd, addrOnly bool, v
 		ExternalSwIfIndex: ctx.ExternalIfIdx,
 		VrfID:             ctx.Vrf,
 		TwiceNat:          boolToUint(ctx.TwiceNat),
-		//SelfTwiceNat:      boolToUint(ctx.SelfTwiceNat), // Not yet officially supported! (probably in 18.07)
-		Out2inOnly: 1,
-		IsAdd:      boolToUint(isAdd),
+		SelfTwiceNat:      boolToUint(ctx.SelfTwiceNat),
+		Out2inOnly:        1,
+		IsAdd:             boolToUint(isAdd),
 	}
 	if addrOnly {
 		req.AddrOnly = 1
@@ -233,9 +233,9 @@ func handleNat44StaticMappingLb(ctx *StaticMappingLbContext, isAdd bool, vppChan
 		Protocol:     ctx.Protocol,
 		VrfID:        ctx.Vrf,
 		TwiceNat:     boolToUint(ctx.TwiceNat),
-		//SelfTwiceNat: boolToUint(ctx.SelfTwiceNat), // Not yet officially supported! (probably in 18.07)
-		Out2inOnly: 1,
-		IsAdd:      boolToUint(isAdd),
+		SelfTwiceNat: boolToUint(ctx.SelfTwiceNat),
+		Out2inOnly:   1,
+		IsAdd:        boolToUint(isAdd),
 	}
 
 	reply := &nat.Nat44AddDelLbStaticMappingReply{}

--- a/plugins/vpp/ifplugin/vppdump/dump_nat_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppdump/dump_nat_vppcalls.go
@@ -199,7 +199,7 @@ func nat44StaticMappingDump(swIfIndices ifaceidx.SwIfIndex, log logging.Logger, 
 				LocalPort: uint32(msg.LocalPort),
 			}),
 			Protocol: getNatProtocol(msg.Protocol, log),
-			//TwiceNat: getTwiceNatMode(msg.TwiceNat, msg.SelfTwiceNat, log), // Not yet officially supported! (probably in 18.07)
+			TwiceNat: getTwiceNatMode(msg.TwiceNat, msg.SelfTwiceNat, log),
 		}
 	}
 
@@ -250,7 +250,7 @@ func nat44StaticMappingLbDump(log logging.Logger, vppChan vppcalls.VPPChannel,
 			ExternalPort: uint32(msg.ExternalPort),
 			LocalIps:     locals,
 			Protocol:     getNatProtocol(msg.Protocol, log),
-			//TwiceNat:     getTwiceNatMode(msg.TwiceNat, msg.SelfTwiceNat, log), // Not yet officially supported! (probably in 18.07)
+			TwiceNat:     getTwiceNatMode(msg.TwiceNat, msg.SelfTwiceNat, log),
 		}
 	}
 


### PR DESCRIPTION
This reverts commit 974aaf62f0ce6ef06c75c0eabcb0e3b7a66a7931.
SelfTwiceNAT is now supported in the currently used VPP.