### PR TITLE
Correctly set afpacket mac

### DIFF
--- a/plugins/vpp/ifplugin/afpacket_config.go
+++ b/plugins/vpp/ifplugin/afpacket_config.go
@@ -115,7 +115,7 @@ func (plugin *AFPacketConfigurator) ConfigureAfPacketInterface(afpacket *intf.In
 			return 0, true, nil
 		}
 	}
-	swIdx, err := vppcalls.AddAfPacketInterface(afpacket.Name, afpacket.Afpacket, plugin.vppCh, plugin.stopwatch)
+	swIdx, err := vppcalls.AddAfPacketInterface(afpacket.Name, afpacket.PhysAddress, afpacket.Afpacket, plugin.vppCh, plugin.stopwatch)
 	if err != nil {
 		plugin.addToCache(afpacket, true)
 		return 0, true, err

--- a/plugins/vpp/ifplugin/interface_config.go
+++ b/plugins/vpp/ifplugin/interface_config.go
@@ -281,8 +281,8 @@ func (plugin *InterfaceConfigurator) ConfigureVPPInterface(iface *intf.Interface
 		}
 	}
 
-	// configure optional mac address
-	if iface.PhysAddress != "" {
+	// configure optional mac address (for af packet it is configured in different way)
+	if iface.PhysAddress != "" && iface.Type != intf.InterfaceType_AF_PACKET_INTERFACE {
 		if err := vppcalls.SetInterfaceMac(ifIdx, iface.PhysAddress, plugin.vppCh, plugin.stopwatch); err != nil {
 			errs = append(errs, err)
 		}

--- a/plugins/vpp/ifplugin/vppcalls/afpacket_vppcalls_test.go
+++ b/plugins/vpp/ifplugin/vppcalls/afpacket_vppcalls_test.go
@@ -32,7 +32,7 @@ func TestAddAfPacketInterface(t *testing.T) {
 	ctx.MockVpp.MockReply(&af_packet.AfPacketCreateReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceTagAddDelReply{})
 
-	ifIndex, err := vppcalls.AddAfPacketInterface("if1", &if_api.Interfaces_Interface_Afpacket{
+	ifIndex, err := vppcalls.AddAfPacketInterface("if1", "", &if_api.Interfaces_Interface_Afpacket{
 		HostIfName: "host1",
 	}, ctx.MockChannel, nil)
 
@@ -58,7 +58,7 @@ func TestAddAfPacketInterfaceError(t *testing.T) {
 
 	ctx.MockVpp.MockReply(&af_packet.AfPacketDeleteReply{})
 
-	_, err := vppcalls.AddAfPacketInterface("if1", &if_api.Interfaces_Interface_Afpacket{
+	_, err := vppcalls.AddAfPacketInterface("if1", "", &if_api.Interfaces_Interface_Afpacket{
 		HostIfName: "host1",
 	}, ctx.MockChannel, nil)
 
@@ -74,7 +74,7 @@ func TestAddAfPacketInterfaceRetval(t *testing.T) {
 	})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceTagAddDelReply{})
 
-	_, err := vppcalls.AddAfPacketInterface("if1", &if_api.Interfaces_Interface_Afpacket{
+	_, err := vppcalls.AddAfPacketInterface("if1", "", &if_api.Interfaces_Interface_Afpacket{
 		HostIfName: "host1",
 	}, ctx.MockChannel, nil)
 


### PR DESCRIPTION
Instead of using VPP call to set afpacket hardware address after
creation, do it when creating afpacket interface using afpacket-specific
calls. This prevents afpacket setting its own MAC address to bound veth.

Signed-off-by: Tomas Slusny <tslusny@cisco.com>