### PR TITLE
Retrieve the physical VPP interface details via VPP-Agent

### DIFF
--- a/plugins/vpp/ifplugin/data_resync.go
+++ b/plugins/vpp/ifplugin/data_resync.go
@@ -168,6 +168,9 @@ func (plugin *InterfaceConfigurator) Resync(nbIfs []*intf.Interfaces_Interface) 
 		}
 	}
 
+	// update the interfaces state data in memory
+	plugin.PropagateIfDetailsToStatus()
+
 	plugin.log.WithField("cfg", plugin).Debug("RESYNC Interface end.")
 
 	return


### PR DESCRIPTION
The physical interface details get by "dump" were not updated after VPP
restart. Now VPP interface details are updated in ETCD after
synchronization.

Signed-off-by: Pavel Kotucek <pkotucek@cisco.com>