### PR TITLE
Fix parsing billions from VPP stats ('1g' = 1 billion)

### DIFF
--- a/plugins/govppmux/vppcalls/vpe_vppcalls.go
+++ b/plugins/govppmux/vppcalls/vpe_vppcalls.go
@@ -91,7 +91,7 @@ type MemoryThread struct {
 
 var (
 	// Regular expression to parse output from `show memory`
-	memoryRe = regexp.MustCompile(`Thread\s+(\d+)\s+(\w+).?\s+(\d+) objects, ([\dkm\.]+) of ([\dkm\.]+) used, ([\dkm\.]+) free, ([\dkm\.]+) reclaimed, ([\dkm\.]+) overhead, ([\dkm\.]+) capacity`)
+	memoryRe = regexp.MustCompile(`Thread\s+(\d+)\s+(\w+).?\s+(\d+) objects, ([\dkmg\.]+) of ([\dkmg\.]+) used, ([\dkmg\.]+) free, ([\dkmg\.]+) reclaimed, ([\dkmg\.]+) overhead, ([\dkmg\.]+) capacity`)
 )
 
 // GetNodeCounters retrieves node counters info
@@ -313,7 +313,7 @@ type BuffersItem struct {
 
 var (
 	// Regular expression to parse output from `show buffers`
-	buffersRe = regexp.MustCompile(`^\s+(\d+)\s+(\w+(?:[ \-]\w+)*)\s+(\d+)\s+(\d+)\s+([\dkm\.]+)\s+([\dkm\.]+)\s+(\d+)\s+(\d+).*$`)
+	buffersRe = regexp.MustCompile(`^\s+(\d+)\s+(\w+(?:[ \-]\w+)*)\s+(\d+)\s+(\d+)\s+([\dkmg\.]+)\s+([\dkmg\.]+)\s+(\d+)\s+(\d+).*$`)
 )
 
 // GetBuffersInfo retrieves buffers info
@@ -370,6 +370,7 @@ func strToFloat64(s string) float64 {
 	// Replace 'k' (thousands) with 'e3' to make it parsable with strconv
 	s = strings.Replace(s, "k", "e3", 1)
 	s = strings.Replace(s, "m", "e6", 1)
+	s = strings.Replace(s, "g", "e9", 1)
 
 	num, err := strconv.ParseFloat(s, 10)
 	if err != nil {

--- a/plugins/govppmux/vppcalls/vpe_vppcalls_test.go
+++ b/plugins/govppmux/vppcalls/vpe_vppcalls_test.go
@@ -30,7 +30,7 @@ func TestGetBuffers(t *testing.T) {
 	const reply = `Thread             Name                 Index       Size        Alloc       Free       #Alloc       #Free  
      0                       default           0        2048    576k       42.75k        256         19    
      0                 lacp-ethernet           1         256    1.13m        27k         512         12    
-     0               marker-ethernet           2         256      0           0           0           0    
+     0               marker-ethernet           2         256    1.11g         0           0           0    
      0                       ip4 arp           3         256      0           0           0           0    
      0        ip6 neighbor discovery           4         256      0           0           0           0    
      0                  cdp-ethernet           5         256      0           0           0           0    
@@ -65,6 +65,16 @@ func TestGetBuffers(t *testing.T) {
 		Free:     27000,
 		NumAlloc: 512,
 		NumFree:  12,
+	}))
+	Expect(info.Items[2]).To(Equal(vppcalls.BuffersItem{
+		ThreadID: 0,
+		Name:     "marker-ethernet",
+		Index:    2,
+		Size:     256,
+		Alloc:    1110000000,
+		Free:     0,
+		NumAlloc: 0,
+		NumFree:  0,
 	}))
 }
 


### PR DESCRIPTION
|string suffix|amount|integer|
|---|---|---|
| `k` | thousands | 1e3 |
| `m` | millions  | 1e6 |
| `g` | billions  | 1e9 |

Format function in VPP code which formats memory size: https://docs.fd.io/vpp/18.07/d2/d8f/std-formats_8c.html#a447abbd57cc963a3794c825410f626b7