### PR TITLE
Set interface down before deleting (except AFPACKET)

### DIFF
--- a/plugins/vpp/ifplugin/interface_config.go
+++ b/plugins/vpp/ifplugin/interface_config.go
@@ -836,12 +836,12 @@ func (plugin *InterfaceConfigurator) deleteVPPInterface(oldConfig *intf.Interfac
 	plugin.log.WithFields(logging.Fields{"ifname": oldConfig.Name, "swIfIndex": ifIdx}).
 		Debug("deleteVPPInterface begin")
 
-	// Skip setting interface to ADMIN_DOWN unless the type ETHERNET_CSMACD because that one cannot be removed
-	// so at least put it down
-	if oldConfig.Type == intf.InterfaceType_ETHERNET_CSMACD {
+	// Skip setting interface to ADMIN_DOWN unless the type AF_PACKET_INTERFACE
+	if oldConfig.Type != intf.InterfaceType_AF_PACKET_INTERFACE {
+		plugin.log.Infof("Setting interface %v down", oldConfig.Name)
 		// Let's try to do following even if previously error occurred
 		if err := vppcalls.InterfaceAdminDown(ifIdx, plugin.vppCh, plugin.stopwatch); err != nil {
-			plugin.log.Error(err)
+			plugin.log.Errorf("Setting interface down failed: %v", err)
 			wasError = err
 		}
 	}

--- a/plugins/vpp/ifplugin/interface_config_test.go
+++ b/plugins/vpp/ifplugin/interface_config_test.go
@@ -749,6 +749,7 @@ func TestInterfacesModifyTapV1TapData(t *testing.T) {
 	ctx, connection, plugin := ifTestSetup(t)
 	defer ifTestTeardown(connection, plugin)
 	// Reply set
+	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{}) // Delete
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceAddDelAddressReply{})
 	ctx.MockVpp.MockReply(&tap.TapDeleteReply{})
@@ -834,6 +835,7 @@ func TestInterfacesModifyMemifData(t *testing.T) {
 	ctx.MockVpp.MockReply(&interfaces.HwInterfaceSetMtuReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&vpe.ControlPingReply{})
+	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{}) // Modify - delete old data
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceAddDelAddressReply{})
 	ctx.MockVpp.MockReply(&memif.MemifDeleteReply{})
@@ -951,6 +953,7 @@ func TestInterfacesModifyVxLanData(t *testing.T) {
 	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&vpe.ControlPingReply{})
+	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{}) // Modify - delete old data
 	ctx.MockVpp.MockReply(&vxlan.VxlanAddDelTunnelReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceTagAddDelReply{})
@@ -1194,6 +1197,7 @@ func TestInterfacesDeleteTapInterface(t *testing.T) {
 	ctx, connection, plugin := ifTestSetup(t)
 	defer ifTestTeardown(connection, plugin)
 	// Reply set
+	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&dhcp_api.DhcpClientConfigReply{})
 	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceAddDelAddressReply{})
@@ -1217,6 +1221,7 @@ func TestInterfacesDeleteMemifInterface(t *testing.T) {
 	ctx, connection, plugin := ifTestSetup(t)
 	defer ifTestTeardown(connection, plugin)
 	// Reply set
+	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceAddDelAddressReply{})
 	ctx.MockVpp.MockReply(&memif.MemifDeleteReply{})
@@ -1238,6 +1243,7 @@ func TestInterfacesDeleteVxlanInterface(t *testing.T) {
 	ctx, connection, plugin := ifTestSetup(t)
 	defer ifTestTeardown(connection, plugin)
 	// Reply set
+	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceAddDelAddressReply{})
 	ctx.MockVpp.MockReply(&vxlan.VxlanAddDelTunnelReply{})
@@ -1260,6 +1266,7 @@ func TestInterfacesDeleteLoopbackInterface(t *testing.T) {
 	ctx, connection, plugin := ifTestSetup(t)
 	defer ifTestTeardown(connection, plugin)
 	// Reply set
+	ctx.MockVpp.MockReply(&interfaces.SwInterfaceSetFlagsReply{})
 	ctx.MockVpp.MockReply(&ip.IPContainerProxyAddDelReply{})
 	ctx.MockVpp.MockReply(&interfaces.SwInterfaceAddDelAddressReply{})
 	ctx.MockVpp.MockReply(&interfaces.DeleteLoopbackReply{})


### PR DESCRIPTION
According VPP guy, an interface has to be set down before deleting.
Test-cases are updated to reflect this change.

Signed-off-by: Pavel Kotucek <pkotucek@cisco.com>