### PR TITLE
Skip checking external links with markdown-link-check

### DIFF
--- a/scripts/check_links.sh
+++ b/scripts/check_links.sh
@@ -8,8 +8,7 @@ do
         continue
     fi
 
-    echo $i;
-    if ! markdown-link-check $i; then
+    if ! markdown-link-check --config ./scripts/link-check-config.json $i; then
         res=1
     fi
     echo "";

--- a/scripts/link-check-config.json
+++ b/scripts/link-check-config.json
@@ -1,0 +1,7 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^http"
+        }
+    ]
+}


### PR DESCRIPTION
Currently won't work, because there is an issue in makrdown-link-check. I opened PR to fix it and waiting until it gets merged.
https://github.com/tcort/markdown-link-check/issues/52