### PR TITLE
Some tests for TAP interfaces started failing

### DIFF
--- a/plugins/linux/ifplugin/interface_config.go
+++ b/plugins/linux/ifplugin/interface_config.go
@@ -156,7 +156,7 @@ func (plugin *LinuxInterfaceConfigurator) ConfigureLinuxInterface(linuxIf *inter
 
 		return plugin.configureVethInterface(ifConfig, peerConfig)
 	case interfaces.LinuxInterfaces_AUTO_TAP:
-		var hostIfName string = ""
+		var hostIfName string
 		if linuxIf.Tap != nil  {
 			hostIfName = linuxIf.GetTap().GetTempIfName()
 		}
@@ -989,7 +989,7 @@ func (plugin *LinuxInterfaceConfigurator) ResolveCreatedVPPInterface(ifConfigMet
 		return nil
 	}
 
-	var hostIfName string = ""
+	var hostIfName string
 	if ifConfigMetaData.Tap != nil  {
 		hostIfName = ifConfigMetaData.GetTap().GetHostIfName()
 	}
@@ -1001,7 +1001,7 @@ func (plugin *LinuxInterfaceConfigurator) ResolveCreatedVPPInterface(ifConfigMet
 		return nil
 	}
 
-	var linuxIf *interfaces.LinuxInterfaces_Interface = nil
+	var linuxIf *interfaces.LinuxInterfaces_Interface
 	_, data, exists := plugin.ifCachedConfigs.LookupIdx(hostIfName)
 	if exists && data != nil {
 		linuxIf = data.Data
@@ -1023,7 +1023,7 @@ func (plugin *LinuxInterfaceConfigurator) ResolveDeletedVPPInterface(ifConfigMet
 		return nil
 	}
 
-	var hostIfName string = ""
+	var hostIfName string
 	if ifConfigMetaData.Tap != nil  {
 		hostIfName = ifConfigMetaData.GetTap().GetHostIfName()
 	}

--- a/plugins/linux/ifplugin/interface_config.go
+++ b/plugins/linux/ifplugin/interface_config.go
@@ -156,14 +156,11 @@ func (plugin *LinuxInterfaceConfigurator) ConfigureLinuxInterface(linuxIf *inter
 
 		return plugin.configureVethInterface(ifConfig, peerConfig)
 	case interfaces.LinuxInterfaces_AUTO_TAP:
-		var hostIfName string
-		if linuxIf.Tap != nil  {
-			hostIfName = linuxIf.GetTap().GetTempIfName()
+		if linuxIf.Tap != nil && linuxIf.Tap.TempIfName != "" {
+			return plugin.configureTapInterface(linuxIf.Tap.TempIfName, linuxIf)
+		} else {
+			return plugin.configureTapInterface(linuxIf.HostIfName, linuxIf)
 		}
-		if hostIfName == "" {
-			hostIfName = linuxIf.GetHostIfName()
-		}
-		return plugin.configureTapInterface(hostIfName, linuxIf)
 	default:
 		return fmt.Errorf("unknown linux interface type: %v", linuxIf.Type)
 	}

--- a/plugins/linux/ifplugin/interface_config_test.go
+++ b/plugins/linux/ifplugin/interface_config_test.go
@@ -461,6 +461,43 @@ func TestLinuxConfiguratorAddVethPairError(t *testing.T) {
 	Expect(err).Should(HaveOccurred())
 }
 
+// Configure Tap with hostIfName
+func TestLinuxConfiguratorAddTap_TempIfName(t *testing.T) {
+	plugin, _, nsMock, msChan, msNotif := ifTestSetup(t)
+	defer ifTestTeardown(plugin, msChan, msNotif)
+
+	// Linux/namespace calls
+	nsMock.When("IsNamespaceAvailable").ThenReturn(true)
+
+	data := getTapInterface("tap1", "", "TempIfName")
+	err := plugin.ConfigureLinuxInterface(data)
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(plugin.GetLinuxInterfaceIndexes().GetMapping().ListNames()).To(HaveLen(0))
+	Expect(plugin.GetCachedLinuxIfIndexes().GetMapping().ListNames()).To(HaveLen(1))
+	// Verify registration
+	_, _, found := plugin.GetCachedLinuxIfIndexes().LookupIdx("TempIfName")
+	Expect(found).To(BeTrue())
+
+}
+
+// Configure Tap with hostIfName
+func TestLinuxConfiguratorAddTap_HostIfName(t *testing.T) {
+	plugin, _, nsMock, msChan, msNotif := ifTestSetup(t)
+	defer ifTestTeardown(plugin, msChan, msNotif)
+
+	// Linux/namespace calls
+	nsMock.When("IsNamespaceAvailable").ThenReturn(true)
+
+	data := getTapInterface("tap1", "HostIfName", "")
+	err := plugin.ConfigureLinuxInterface(data)
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(plugin.GetLinuxInterfaceIndexes().GetMapping().ListNames()).To(HaveLen(0))
+	Expect(plugin.GetCachedLinuxIfIndexes().GetMapping().ListNames()).To(HaveLen(1))
+	// Verify registration
+	_, _, found := plugin.GetCachedLinuxIfIndexes().LookupIdx("HostIfName")
+	Expect(found).To(BeTrue())
+}
+
 // Todo
 
 /* Interface Test Setup */
@@ -518,6 +555,22 @@ func getVethInterface(ifName, peerName string, namespaceType interfaces.LinuxInt
 		}(namespaceType),
 		Veth: &interfaces.LinuxInterfaces_Interface_Veth{
 			PeerIfName: peerName,
+		},
+	}
+}
+
+func getTapInterface(ifName, hostIfName string, tempIfName string) *interfaces.LinuxInterfaces_Interface {
+	return &interfaces.LinuxInterfaces_Interface{
+		Name:        ifName,
+		Enabled:     true,
+		Type:        interfaces.LinuxInterfaces_AUTO_TAP,
+		PhysAddress: "12:E4:0E:D5:BC:DC",
+		IpAddresses: []string{
+			"192.168.20.3/24",
+		},
+		HostIfName: hostIfName,
+		Tap: &interfaces.LinuxInterfaces_Interface_Tap{
+			TempIfName: tempIfName,
 		},
 	}
 }

--- a/plugins/linux/ifplugin/interface_config_test.go
+++ b/plugins/linux/ifplugin/interface_config_test.go
@@ -475,9 +475,9 @@ func TestLinuxConfiguratorAddTap_TempIfName(t *testing.T) {
 	Expect(plugin.GetLinuxInterfaceIndexes().GetMapping().ListNames()).To(HaveLen(0))
 	Expect(plugin.GetCachedLinuxIfIndexes().GetMapping().ListNames()).To(HaveLen(1))
 	// Verify registration
-	_, _, found := plugin.GetCachedLinuxIfIndexes().LookupIdx("TempIfName")
+	_, metadata, found := plugin.GetCachedLinuxIfIndexes().LookupIdx("TempIfName")
 	Expect(found).To(BeTrue())
-
+	Expect(metadata).ToNot(BeNil())
 }
 
 // Configure Tap with hostIfName
@@ -494,8 +494,9 @@ func TestLinuxConfiguratorAddTap_HostIfName(t *testing.T) {
 	Expect(plugin.GetLinuxInterfaceIndexes().GetMapping().ListNames()).To(HaveLen(0))
 	Expect(plugin.GetCachedLinuxIfIndexes().GetMapping().ListNames()).To(HaveLen(1))
 	// Verify registration
-	_, _, found := plugin.GetCachedLinuxIfIndexes().LookupIdx("HostIfName")
+	_, metadata, found := plugin.GetCachedLinuxIfIndexes().LookupIdx("HostIfName")
 	Expect(found).To(BeTrue())
+	Expect(metadata).ToNot(BeNil())
 }
 
 // Todo


### PR DESCRIPTION
Some tests for TAP interfaces started failing recently. Probably after
this change: https://github.com/ligato/vpp-agent/pull/691

Signed-off-by: Pavel Kotucek <pkotucek@cisco.com>