### PR TITLE
l3plugin static route dump should return all paths

### DIFF
--- a/plugins/vpp/l3plugin/data_resync.go
+++ b/plugins/vpp/l3plugin/data_resync.go
@@ -35,11 +35,11 @@ func (plugin *RouteConfigurator) Resync(nbRoutes []*l3.StaticRoutes_Route) error
 	plugin.clearMapping()
 
 	// Retrieve VPP route configuration
-	vppRoutes, err := vppdump.DumpStaticRoutes(plugin.log, plugin.vppChan, measure.GetTimeLog(l3ba.IPFibDump{}, plugin.stopwatch))
+	vppRoutesList, err := vppdump.DumpStaticRoutes(plugin.log, plugin.vppChan, measure.GetTimeLog(l3ba.IPFibDump{}, plugin.stopwatch))
 	if err != nil {
 		return err
 	}
-	plugin.log.Debugf("Found %d routes configured on the VPP", len(vppRoutes))
+	plugin.log.Debugf("Found %d routes configured on the VPP", len(vppRoutesList))
 
 	// Correlate NB and VPP configuration
 	for _, nbRoute := range nbRoutes {
@@ -56,44 +56,46 @@ func (plugin *RouteConfigurator) Resync(nbRoutes []*l3.StaticRoutes_Route) error
 			nbRoute.Weight = 1
 		}
 		// Look for the same route in the configuration
-		for _, vppRoute := range vppRoutes {
-			vppRouteID := routeIdentifier(vppRoute.VrfID, vppRoute.DstAddr.String(), vppRoute.NextHopAddr.String())
-			plugin.log.Debugf("RESYNC routes: comparing %s and %s", nbRouteID, vppRouteID)
-			if vppRoute.OutIface != nbIfIdx {
-				plugin.log.Debugf("RESYNC routes: interface index is different (NB: %d, VPP %d)",
-					nbIfIdx, vppRoute.OutIface)
-				continue
+		for _, vppRoutes := range vppRoutesList {
+			for _, vppRoute := range vppRoutes {
+				vppRouteID := routeIdentifier(vppRoute.VrfID, vppRoute.DstAddr.String(), vppRoute.NextHopAddr.String())
+				plugin.log.Debugf("RESYNC routes: comparing %s and %s", nbRouteID, vppRouteID)
+				if vppRoute.OutIface != nbIfIdx {
+					plugin.log.Debugf("RESYNC routes: interface index is different (NB: %d, VPP %d)",
+						nbIfIdx, vppRoute.OutIface)
+					continue
+				}
+				if vppRoute.DstAddr.String() != nbRoute.DstIpAddr {
+					plugin.log.Debugf("RESYNC routes: dst address is different (NB: %s, VPP %s)",
+						nbRoute.DstIpAddr, vppRoute.DstAddr.String())
+					continue
+				}
+				if vppRoute.VrfID != nbRoute.VrfId {
+					plugin.log.Debugf("RESYNC routes: VRF ID is different (NB: %d, VPP %d)",
+						nbRoute.VrfId, vppRoute.VrfID)
+					continue
+				}
+				if vppRoute.Weight != nbRoute.Weight {
+					plugin.log.Debugf("RESYNC routes: weight is different (NB: %d, VPP %d)",
+						nbRoute.Weight, vppRoute.Weight)
+					continue
+				}
+				if vppRoute.Preference != nbRoute.Preference {
+					plugin.log.Debugf("RESYNC routes: preference is different (NB: %d, VPP %d)",
+						nbRoute.Preference, vppRoute.Preference)
+					continue
+				}
+				if vppRoute.NextHopAddr.String() != nbRoute.NextHopAddr {
+					plugin.log.Debugf("RESYNC routes: next hop address is different (NB: %d, VPP %d)",
+						nbRoute.NextHopAddr, vppRoute.NextHopAddr.String())
+					continue
+				}
+				// Register existing routes
+				plugin.rtIndexes.RegisterName(nbRouteID, plugin.rtIndexSeq, nbRoute)
+				plugin.rtIndexSeq++
+				plugin.log.Debugf("RESYNC routes: route %s registered without additional changes", nbRouteID)
+				break
 			}
-			if vppRoute.DstAddr.String() != nbRoute.DstIpAddr {
-				plugin.log.Debugf("RESYNC routes: dst address is different (NB: %s, VPP %s)",
-					nbRoute.DstIpAddr, vppRoute.DstAddr.String())
-				continue
-			}
-			if vppRoute.VrfID != nbRoute.VrfId {
-				plugin.log.Debugf("RESYNC routes: VRF ID is different (NB: %d, VPP %d)",
-					nbRoute.VrfId, vppRoute.VrfID)
-				continue
-			}
-			if vppRoute.Weight != nbRoute.Weight {
-				plugin.log.Debugf("RESYNC routes: weight is different (NB: %d, VPP %d)",
-					nbRoute.Weight, vppRoute.Weight)
-				continue
-			}
-			if vppRoute.Preference != nbRoute.Preference {
-				plugin.log.Debugf("RESYNC routes: preference is different (NB: %d, VPP %d)",
-					nbRoute.Preference, vppRoute.Preference)
-				continue
-			}
-			if vppRoute.NextHopAddr.String() != nbRoute.NextHopAddr {
-				plugin.log.Debugf("RESYNC routes: next hop address is different (NB: %d, VPP %d)",
-					nbRoute.NextHopAddr, vppRoute.NextHopAddr.String())
-				continue
-			}
-			// Register existing routes
-			plugin.rtIndexes.RegisterName(nbRouteID, plugin.rtIndexSeq, nbRoute)
-			plugin.rtIndexSeq++
-			plugin.log.Debugf("RESYNC routes: route %s registered without additional changes", nbRouteID)
-			break
 		}
 	}
 


### PR DESCRIPTION
The l3plugin static route dump currently returns only the first hop in given route.
Fix returns all hops in route

Signed-off-by: Pavel Kotucek <pkotucek@cisco.com>