### PR TITLE
Skip link check for external links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ format:
 # Get link check tool
 get-linkcheck:
 	sudo apt-get install npm
-	npm install -g markdown-link-check@3.6.2
+	npm install -g markdown-link-check
 
 # Validate links in markdown files
 check-links: get-linkcheck

--- a/scripts/check_links.sh
+++ b/scripts/check_links.sh
@@ -8,7 +8,7 @@ do
         continue
     fi
 
-    if ! markdown-link-check --config ./scripts/link-check-config.json $i; then
+    if ! markdown-link-check -v $i; then
         res=1
     fi
     echo "";

--- a/scripts/check_links.sh
+++ b/scripts/check_links.sh
@@ -8,8 +8,7 @@ do
         continue
     fi
 
-    echo $i;
-    if ! markdown-link-check $i; then
+    if ! markdown-link-check --config ./scripts/link-check-config.json $i; then
         res=1
     fi
     echo "";

--- a/scripts/check_links.sh
+++ b/scripts/check_links.sh
@@ -8,7 +8,8 @@ do
         continue
     fi
 
-    if ! markdown-link-check -v $i; then
+    echo "$i"
+    if ! markdown-link-check -v "$i"; then
         res=1
     fi
     echo "";

--- a/scripts/link-check-config.json
+++ b/scripts/link-check-config.json
@@ -1,0 +1,7 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "^http"
+        }
+    ]
+}


### PR DESCRIPTION
Latest version (3.7.1) of markdown-link-check is broken and gets stuck while checking.

This has to wait until this gets fixed:
https://github.com/tcort/markdown-link-check/issues/59