### PR TITLE
switch to namespace handles IPv6 addresses

### DIFF
--- a/plugins/linux/nsplugin/ns_handler_test.go
+++ b/plugins/linux/nsplugin/ns_handler_test.go
@@ -17,18 +17,23 @@ package nsplugin_test
 import (
 	"testing"
 
+	"net"
+
 	"github.com/ligato/cn-infra/logging"
+	"github.com/ligato/vpp-agent/plugins/linux/model/interfaces"
 	"github.com/ligato/vpp-agent/plugins/linux/nsplugin"
 	"github.com/ligato/vpp-agent/tests/linuxmock"
 	. "github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
+	"github.com/ligato/cn-infra/utils/safeclose"
 )
 
 /* Linux namespace handler init and close */
 
 // Test init function
 func TestNsHandlerInit(t *testing.T) {
-	plugin, _, _, _, _ := nsHandlerTestSetup(t)
-	defer nsHandlerTestTeardown(plugin)
+	plugin, ifHandler, sysHandler, msChan, ifNotif := nsHandlerTestSetup(t)
+	defer nsHandlerTestTeardown(plugin, ifHandler, sysHandler, msChan, ifNotif)
 
 	// Base fields
 	Expect(plugin).ToNot(BeNil())
@@ -41,6 +46,109 @@ func TestNsHandlerInit(t *testing.T) {
 }
 
 /* Namespace handler Test Setup */
+
+func TestSetInterfaceNamespace(t *testing.T) {
+	plugin, ifHandler, sysHandler, msChan, ifNotif := nsHandlerTestSetup(t)
+	defer nsHandlerTestTeardown(plugin, ifHandler, sysHandler, msChan, ifNotif)
+
+	// IP address list
+	var ipAddresses []netlink.Addr
+	ipAddresses = append(ipAddresses,
+		netlink.Addr{IPNet: getIPNetAddress("10.0.0.1/24")},
+		netlink.Addr{IPNet: getIPNetAddress("172.168.0.1/24")},
+		netlink.Addr{IPNet: getIPNetAddress("192.168.0.1/24")},
+		// Link local address which should be skipped
+		netlink.Addr{IPNet: getIPNetAddress("fe80::883f:c3ff:fe9e:fba/64")})
+	ifHandler.When("GetLinkByName").ThenReturn(&netlink.Tuntap{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:  "if1",
+			Flags: net.FlagUp,
+		},
+	})
+	ifHandler.When("GetAddressList").ThenReturn(ipAddresses)
+	sysHandler.When("LinkSetNsFd").ThenReturn()
+
+	// Context and namespace
+	ctx := nsplugin.NewNamespaceMgmtCtx()
+	ns := &interfaces.LinuxInterfaces_Interface_Namespace{
+		Type: interfaces.LinuxInterfaces_Interface_Namespace_NAMED_NS,
+	}
+
+	err := plugin.SetInterfaceNamespace(ctx, "if1", ns)
+	Expect(err).To(BeNil())
+
+	// Check calls to ensure that only required IP addresses were configured
+	num, calls := ifHandler.GetCallsFor("AddInterfaceIP")
+	Expect(num).To(Equal(3))
+	Expect(calls).ToNot(BeNil())
+	for callIdx, call := range calls {
+		ifName := call[0].(string)
+		Expect(ifName).To(Equal("if1"))
+		ipAdd := call[1].(*net.IPNet)
+		if callIdx == 1 {
+			Expect(ipAdd.String()).To(Equal("10.0.0.1/24"))
+		}
+		if callIdx == 2 {
+			Expect(ipAdd.String()).To(Equal("172.168.0.1/24"))
+		}
+		if callIdx == 3 {
+			Expect(ipAdd.String()).To(Equal("192.168.0.1/24"))
+		}
+	}
+}
+
+func TestSetInterfaceNamespaceIPv6(t *testing.T) {
+	plugin, ifHandler, sysHandler, msChan, ifNotif := nsHandlerTestSetup(t)
+	defer nsHandlerTestTeardown(plugin, ifHandler, sysHandler, msChan, ifNotif)
+
+	// IP address list
+	var ipAddresses []netlink.Addr
+	ipAddresses = append(ipAddresses,
+		netlink.Addr{IPNet: getIPNetAddress("10.0.0.1/24")},
+		netlink.Addr{IPNet: getIPNetAddress("172.168.0.1/24")},
+		// Link local address should not be skipped if there is another non-link-local IPv6
+		netlink.Addr{IPNet: getIPNetAddress("fe80::883f:c3ff:fe9e:fba/64")},
+		netlink.Addr{IPNet: getIPNetAddress("ad48::42:e8ff:feb1:e976/64")})
+	ifHandler.When("GetLinkByName").ThenReturn(&netlink.Tuntap{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:  "if1",
+			Flags: net.FlagUp,
+		},
+	})
+	ifHandler.When("GetAddressList").ThenReturn(ipAddresses)
+	sysHandler.When("LinkSetNsFd").ThenReturn()
+
+	// Context and namespace
+	ctx := nsplugin.NewNamespaceMgmtCtx()
+	ns := &interfaces.LinuxInterfaces_Interface_Namespace{
+		Type: interfaces.LinuxInterfaces_Interface_Namespace_NAMED_NS,
+	}
+
+	err := plugin.SetInterfaceNamespace(ctx, "if1", ns)
+	Expect(err).To(BeNil())
+
+	// Check calls to ensure that only required IP addresses were configured
+	num, calls := ifHandler.GetCallsFor("AddInterfaceIP")
+	Expect(num).To(Equal(4))
+	Expect(calls).ToNot(BeNil())
+	for callIdx, call := range calls {
+		ifName := call[0].(string)
+		Expect(ifName).To(Equal("if1"))
+		ipAdd := call[1].(*net.IPNet)
+		if callIdx == 1 {
+			Expect(ipAdd.String()).To(Equal("10.0.0.1/24"))
+		}
+		if callIdx == 2 {
+			Expect(ipAdd.String()).To(Equal("172.168.0.1/24"))
+		}
+		if callIdx == 3 {
+			Expect(ipAdd.String()).To(Equal("fe80::883f:c3ff:fe9e:fba/64"))
+		}
+		if callIdx == 4 {
+			Expect(ipAdd.String()).To(Equal("ad48::42:e8ff:feb1:e976/64"))
+		}
+	}
+}
 
 func nsHandlerTestSetup(t *testing.T) (*nsplugin.NsHandler, *linuxmock.IfNetlinkHandlerMock, *linuxmock.SystemMock,
 	chan *nsplugin.MicroserviceCtx, chan *nsplugin.MicroserviceEvent) {
@@ -63,6 +171,17 @@ func nsHandlerTestSetup(t *testing.T) (*nsplugin.NsHandler, *linuxmock.IfNetlink
 	return plugin, ifHandler, sysHandler, msChan, ifNotif
 }
 
-func nsHandlerTestTeardown(plugin *nsplugin.NsHandler) {
+func nsHandlerTestTeardown(plugin *nsplugin.NsHandler, ifHnadler *linuxmock.IfNetlinkHandlerMock, sysHnadler *linuxmock.SystemMock,
+	msChan chan *nsplugin.MicroserviceCtx, msEventChan chan *nsplugin.MicroserviceEvent) {
 	Expect(plugin.Close()).To(Succeed())
+	err := safeclose.Close(ifHnadler, sysHnadler, msChan, msEventChan)
+	Expect(err).To(BeNil())
+	logging.DefaultRegistry.ClearRegistry()
+}
+
+func getIPNetAddress(ipAddr string) *net.IPNet {
+	ip, ipNet, err := net.ParseCIDR(ipAddr)
+	ipNet.IP = ip
+	Expect(err).To(BeNil())
+	return ipNet
 }

--- a/tests/linuxmock/system_mock.go
+++ b/tests/linuxmock/system_mock.go
@@ -15,8 +15,10 @@
 package linuxmock
 
 import (
-	"github.com/vishvananda/netns"
 	"os"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
 )
 
 // SystemMock allows to mock netlink-related methods
@@ -157,6 +159,14 @@ func (mock *SystemMock) GetNamespaceFromName(name string) (netns.NsHandle, error
 
 func (mock *SystemMock) SetNamespace(ns netns.NsHandle) error {
 	items := mock.getReturnValues("SetNamespace")
+	if len(items) >= 1 {
+		return items[0].(error)
+	}
+	return nil
+}
+
+func (mock *SystemMock) LinkSetNsFd(link netlink.Link, fd int) error {
+	items := mock.getReturnValues("LinkSetNsFd")
 	if len(items) >= 1 {
 		return items[0].(error)
 	}


### PR DESCRIPTION
created Linux interface gets a link-local IPv6 address by default. This address could cause problems while the interface is switched between namespaces because the IP is not a part of the NB config, and IPv6 may not be enabled in the destination namespace.
Change skips link-local address (it will be not switched between namespaces) if it is the only IPv6 address configured on the interface. 

Signed-off-by: Vladimir Lavor <vlavor@cisco.com>