### PR TITLE
Add yamllint to our travis-ci runs

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,2 +1,3 @@
+---
 require:
   members: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 dist: trusty
 sudo: required
 
@@ -34,6 +35,7 @@ before_install:
   - go get github.com/mattn/goveralls
 
 script:
+  - make yamllint
   - make check-links || true
   - make lint
   - make dep-check

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,8 @@
+---
+extends: default
+
+rules:
+  # 80 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 80
+    level: warning

--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,14 @@ travis:
 	@echo "Files:"
 	@echo "$$(git diff --name-only $$TRAVIS_COMMIT_RANGE)"
 
+# Install yamllint
+get-yamllint:
+	pip install --user yamllint
+
+# Lint the yaml files
+yamllint: get-yamllint
+	@echo "=> linting the yaml files"
+	yamllint -c .yamllint.yml $(shell git ls-files '*.yaml' '*.yml' | grep -v 'vendor/')
 
 .PHONY: build clean \
 	install cmd examples clean-examples test \
@@ -235,4 +243,5 @@ travis:
 	get-dep dep-install dep-update dep-check \
 	get-linters lint format \
 	get-linkcheck check-links \
-	travis
+	travis \
+	get-yamllint yamllint

--- a/k8s/dev-setup/vnf-vpp.yaml
+++ b/k8s/dev-setup/vnf-vpp.yaml
@@ -53,12 +53,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vnf-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vnf-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
+    - name: vpp-config
+      configMap:
+        name: vnf-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vnf-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/dev-setup/vswitch-vpp.yaml
+++ b/k8s/dev-setup/vswitch-vpp.yaml
@@ -52,12 +52,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vswitch-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vswitch-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
+    - name: vpp-config
+      configMap:
+        name: vswitch-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vswitch-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/etcd.yaml
+++ b/k8s/perf-demo/etcd.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -5,20 +6,20 @@ metadata:
 spec:
   hostNetwork: true
   containers:
-  - image: quay.io/coreos/etcd:v3.0.16
-    name: etcd
-    command:
+    - image: quay.io/coreos/etcd:v3.0.16
+      name: etcd
+      command:
     - /usr/local/bin/etcd
-    - --advertise-client-urls 
+    - --advertise-client-urls
     - http://0.0.0.0:22379
-    - --listen-client-urls 
+    - --listen-client-urls
     - http://0.0.0.0:22379
     - --listen-peer-urls
     - http://0.0.0.0:22380
-    ports:
+  ports:
     - containerPort: 22379
       hostPort: 22379
       name: serverport
-    env:
-      - name: ETCDCTL_API
-        value: "3"
+  env:
+    - name: ETCDCTL_API
+      value: "3"

--- a/k8s/perf-demo/kafka.yaml
+++ b/k8s/perf-demo/kafka.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -5,17 +6,17 @@ metadata:
 spec:
   hostNetwork: true
   containers:
-  - image: spotify/kafka
-    name: kafka
-    ports:
+    - image: spotify/kafka
+      name: kafka
+      ports:
     - containerPort: 2181
       hostPort: 2181
       name: zookeeper
     - containerPort: 9092
       hostPort: 9092
       name: kafka
-    env:
-      - name: ADVERTISED_HOST
-        value: "172.17.0.1"
-      - name: ADVERTISED_PORT
-        value: "9092"
+  env:
+    - name: ADVERTISED_HOST
+      value: "172.17.0.1"
+    - name: ADVERTISED_PORT
+      value: "9092"

--- a/k8s/perf-demo/scenario1/vnf/vnf-agent-cfg.yaml
+++ b/k8s/perf-demo/scenario1/vnf/vnf-agent-cfg.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,3 @@ data:
   kafka.conf: |
     addrs:
      - "172.17.0.1:9092"
-

--- a/k8s/perf-demo/scenario1/vnf/vnf.yaml
+++ b/k8s/perf-demo/scenario1/vnf/vnf.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -33,13 +34,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vnf-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vnf-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vnf-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vnf-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/scenario1/vswitch/vswitch-agent-cfg.yaml
+++ b/k8s/perf-demo/scenario1/vswitch/vswitch-agent-cfg.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,3 @@ data:
   kafka.conf: |
     addrs:
      - "172.17.0.1:9092"
-

--- a/k8s/perf-demo/scenario1/vswitch/vswitch.yaml
+++ b/k8s/perf-demo/scenario1/vswitch/vswitch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -35,13 +36,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vswitch-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vswitch-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vswitch-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vswitch-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/scenario2/vnf/vnf-agent-cfg.yaml
+++ b/k8s/perf-demo/scenario2/vnf/vnf-agent-cfg.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,3 @@ data:
   kafka.conf: |
     addrs:
      - "172.17.0.1:9092"
-

--- a/k8s/perf-demo/scenario2/vnf/vnf1.yaml
+++ b/k8s/perf-demo/scenario2/vnf/vnf1.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -33,13 +34,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vnf1-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vnf-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vnf1-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vnf-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/scenario2/vnf/vnf2.yaml
+++ b/k8s/perf-demo/scenario2/vnf/vnf2.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -33,13 +34,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vnf2-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vnf-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vnf2-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vnf-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/scenario2/vswitch/vswitch-agent-cfg.yaml
+++ b/k8s/perf-demo/scenario2/vswitch/vswitch-agent-cfg.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,3 @@ data:
   kafka.conf: |
     addrs:
      - "172.17.0.1:9092"
-

--- a/k8s/perf-demo/scenario2/vswitch/vswitch-vpp-cfg.yaml
+++ b/k8s/perf-demo/scenario2/vswitch/vswitch-vpp-cfg.yaml
@@ -23,4 +23,3 @@ data:
         workers 0
       }
     }
-

--- a/k8s/perf-demo/scenario2/vswitch/vswitch.yaml
+++ b/k8s/perf-demo/scenario2/vswitch/vswitch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -35,13 +36,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vswitch-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vswitch-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vswitch-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vswitch-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/scenario4/vnf/vnf-agent-cfg.yaml
+++ b/k8s/perf-demo/scenario4/vnf/vnf-agent-cfg.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,3 @@ data:
   kafka.conf: |
     addrs:
      - "172.17.0.1:9092"
-

--- a/k8s/perf-demo/scenario4/vnf/vnf.yaml
+++ b/k8s/perf-demo/scenario4/vnf/vnf.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -33,13 +34,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vnf-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vnf-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vnf-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vnf-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/scenario4/vswitch/vswitch-agent-cfg.yaml
+++ b/k8s/perf-demo/scenario4/vswitch/vswitch-agent-cfg.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,3 @@ data:
   kafka.conf: |
     addrs:
      - "172.17.0.1:9092"
-

--- a/k8s/perf-demo/scenario4/vswitch/vswitch.yaml
+++ b/k8s/perf-demo/scenario4/vswitch/vswitch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -38,16 +39,15 @@ spec:
         - name: docker-socket
           mountPath: /var/run/docker.sock
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vswitch-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vswitch-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-  - name: docker-socket
-    hostPath:
-      path: /var/run/docker.sock
-
+    - name: vpp-config
+      configMap:
+        name: vswitch-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vswitch-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp
+    - name: docker-socket
+      hostPath:
+        path: /var/run/docker.sock

--- a/k8s/perf-demo/with-controller/scenario1/sfc/sfc-cfg.yaml
+++ b/k8s/perf-demo/with-controller/scenario1/sfc/sfc-cfg.yaml
@@ -51,4 +51,3 @@ data:
           - port_labels:
             - port1
             - port2
-

--- a/k8s/perf-demo/with-controller/scenario1/sfc/sfc.yaml
+++ b/k8s/perf-demo/with-controller/scenario1/sfc/sfc.yaml
@@ -17,6 +17,6 @@ spec:
         - name: controller-config
           mountPath: /opt/sfc-controller/dev
   volumes:
-  - name: controller-config
-    configMap:
-      name: sfc-controller-cfg
+    - name: controller-config
+      configMap:
+        name: sfc-controller-cfg

--- a/k8s/perf-demo/with-controller/scenario1/vnf/vnf-agent-cfg.yaml
+++ b/k8s/perf-demo/with-controller/scenario1/vnf/vnf-agent-cfg.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,3 @@ data:
   kafka.conf: |
     addrs:
      - "172.17.0.1:9092"
-

--- a/k8s/perf-demo/with-controller/scenario1/vnf/vnf-vpp-cfg.yaml
+++ b/k8s/perf-demo/with-controller/scenario1/vnf/vnf-vpp-cfg.yaml
@@ -18,4 +18,3 @@ data:
         disable
       }
     }
-

--- a/k8s/perf-demo/with-controller/scenario1/vnf/vnf.yaml
+++ b/k8s/perf-demo/with-controller/scenario1/vnf/vnf.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -33,13 +34,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vnf-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vnf-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vnf-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vnf-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/with-controller/scenario1/vswitch/vswitch-agent-cfg.yaml
+++ b/k8s/perf-demo/with-controller/scenario1/vswitch/vswitch-agent-cfg.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,3 @@ data:
   kafka.conf: |
     addrs:
      - "172.17.0.1:9092"
-

--- a/k8s/perf-demo/with-controller/scenario1/vswitch/vswitch.yaml
+++ b/k8s/perf-demo/with-controller/scenario1/vswitch/vswitch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -35,13 +36,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vswitch-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vswitch-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vswitch-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vswitch-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/with-controller/scenario2/sfc/sfc-cfg.yaml
+++ b/k8s/perf-demo/with-controller/scenario2/sfc/sfc-cfg.yaml
@@ -73,4 +73,3 @@ data:
           - port_labels:
             - port1
             - port2
-

--- a/k8s/perf-demo/with-controller/scenario2/sfc/sfc.yaml
+++ b/k8s/perf-demo/with-controller/scenario2/sfc/sfc.yaml
@@ -17,6 +17,6 @@ spec:
         - name: controller-config
           mountPath: /opt/sfc-controller/dev
   volumes:
-  - name: controller-config
-    configMap:
-      name: sfc-controller-cfg
+    - name: controller-config
+      configMap:
+        name: sfc-controller-cfg

--- a/k8s/perf-demo/with-controller/scenario2/vnf/vnf-agent-cfg.yaml
+++ b/k8s/perf-demo/with-controller/scenario2/vnf/vnf-agent-cfg.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,3 @@ data:
   kafka.conf: |
     addrs:
      - "172.17.0.1:9092"
-

--- a/k8s/perf-demo/with-controller/scenario2/vnf/vnf1.yaml
+++ b/k8s/perf-demo/with-controller/scenario2/vnf/vnf1.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -33,13 +34,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vnf1-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vnf-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vnf1-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vnf-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/with-controller/scenario2/vnf/vnf2.yaml
+++ b/k8s/perf-demo/with-controller/scenario2/vnf/vnf2.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -33,13 +34,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vnf2-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vnf-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vnf2-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vnf-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/with-controller/scenario2/vswitch/vswitch-agent-cfg.yaml
+++ b/k8s/perf-demo/with-controller/scenario2/vswitch/vswitch-agent-cfg.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,3 @@ data:
   kafka.conf: |
     addrs:
      - "172.17.0.1:9092"
-

--- a/k8s/perf-demo/with-controller/scenario2/vswitch/vswitch.yaml
+++ b/k8s/perf-demo/with-controller/scenario2/vswitch/vswitch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -35,13 +36,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vswitch-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vswitch-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vswitch-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vswitch-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/with-controller/scenario23/sfc/sfc.yaml
+++ b/k8s/perf-demo/with-controller/scenario23/sfc/sfc.yaml
@@ -17,6 +17,6 @@ spec:
         - name: controller-config
           mountPath: /opt/sfc-controller/dev
   volumes:
-  - name: controller-config
-    configMap:
-      name: sfc-controller-cfg
+    - name: controller-config
+      configMap:
+        name: sfc-controller-cfg

--- a/k8s/perf-demo/with-controller/scenario23/vnf/vnf-agent-cfg.yaml
+++ b/k8s/perf-demo/with-controller/scenario23/vnf/vnf-agent-cfg.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,3 @@ data:
   kafka.conf: |
     addrs:
      - "172.17.0.1:9092"
-

--- a/k8s/perf-demo/with-controller/scenario23/vnf/vnf1.yaml
+++ b/k8s/perf-demo/with-controller/scenario23/vnf/vnf1.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -33,13 +34,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vnf1-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vnf-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vnf1-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vnf-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/with-controller/scenario23/vnf/vnf2.yaml
+++ b/k8s/perf-demo/with-controller/scenario23/vnf/vnf2.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -33,13 +34,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vnf2-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vnf-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vnf2-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vnf-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/with-controller/scenario23/vnf/vnf3.yaml
+++ b/k8s/perf-demo/with-controller/scenario23/vnf/vnf3.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -33,13 +34,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vnf3-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vnf-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vnf3-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vnf-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/with-controller/scenario23/vswitch/vswitch-agent-cfg.yaml
+++ b/k8s/perf-demo/with-controller/scenario23/vswitch/vswitch-agent-cfg.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,3 @@ data:
   kafka.conf: |
     addrs:
      - "172.17.0.1:9092"
-

--- a/k8s/perf-demo/with-controller/scenario23/vswitch/vswitch.yaml
+++ b/k8s/perf-demo/with-controller/scenario23/vswitch/vswitch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -35,13 +36,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vswitch-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vswitch-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vswitch-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vswitch-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/with-controller/scenario4/sfc/sfc-cfg.yaml
+++ b/k8s/perf-demo/with-controller/scenario4/sfc/sfc-cfg.yaml
@@ -51,4 +51,3 @@ data:
           - port_labels:
             - port1
             - port2
-

--- a/k8s/perf-demo/with-controller/scenario4/sfc/sfc.yaml
+++ b/k8s/perf-demo/with-controller/scenario4/sfc/sfc.yaml
@@ -17,6 +17,6 @@ spec:
         - name: controller-config
           mountPath: /opt/sfc-controller/dev
   volumes:
-  - name: controller-config
-    configMap:
-      name: sfc-controller-cfg
+    - name: controller-config
+      configMap:
+        name: sfc-controller-cfg

--- a/k8s/perf-demo/with-controller/scenario4/vnf/vnf-agent-cfg.yaml
+++ b/k8s/perf-demo/with-controller/scenario4/vnf/vnf-agent-cfg.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,3 @@ data:
   kafka.conf: |
     addrs:
      - "172.17.0.1:9092"
-

--- a/k8s/perf-demo/with-controller/scenario4/vnf/vnf.yaml
+++ b/k8s/perf-demo/with-controller/scenario4/vnf/vnf.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -33,13 +34,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vnf-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vnf-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-
+    - name: vpp-config
+      configMap:
+        name: vnf-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vnf-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/k8s/perf-demo/with-controller/scenario4/vswitch/vswitch-agent-cfg.yaml
+++ b/k8s/perf-demo/with-controller/scenario4/vswitch/vswitch-agent-cfg.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,3 @@ data:
   kafka.conf: |
     addrs:
      - "172.17.0.1:9092"
-

--- a/k8s/perf-demo/with-controller/scenario4/vswitch/vswitch.yaml
+++ b/k8s/perf-demo/with-controller/scenario4/vswitch/vswitch.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -38,16 +39,15 @@ spec:
         - name: docker-socket
           mountPath: /var/run/docker.sock
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vswitch-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vswitch-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
-  - name: docker-socket
-    hostPath:
-      path: /var/run/docker.sock
-
+    - name: vpp-config
+      configMap:
+        name: vswitch-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vswitch-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp
+    - name: docker-socket
+      hostPath:
+        path: /var/run/docker.sock

--- a/tests/perf/vnf-vpp.yaml
+++ b/tests/perf/vnf-vpp.yaml
@@ -53,12 +53,12 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vnf-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vnf-agent-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
+    - name: vpp-config
+      configMap:
+        name: vnf-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vnf-agent-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/tests/perf/vpp.yaml
+++ b/tests/perf/vpp.yaml
@@ -38,7 +38,7 @@ kind: ConfigMap
 metadata:
   name: vswitch-supervisord-cfg
 data:
-  supervisord.conf: | 
+  supervisord.conf: |
     [supervisord]
     logfile=/var/log/supervisord.log
     loglevel=debug
@@ -56,13 +56,13 @@ data:
     autorestart=false
     redirect_stderr=true
     priority=2
-    
+
     ; This event listener waits for event of vpp or agent  exitting. Once received, it kills supervisord process and this makes
     ; subsequently the exit of docker container. You should also set agent autorestart=false.
     [eventlistener:vpp_or_agent_not_running]
     command=/usr/bin/supervisord_kill.py
     events=PROCESS_STATE_EXITED
----   
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -89,15 +89,15 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vswitch-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vswitch-agent-cfg
-  - name: supervisor-config
-    configMap:  
-      name: vswitch-supervisord-cfg
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
+    - name: vpp-config
+      configMap:
+        name: vswitch-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vswitch-agent-cfg
+    - name: supervisor-config
+      configMap:
+        name: vswitch-supervisord-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/tests/perf/vswitch-vpp.yaml
+++ b/tests/perf/vswitch-vpp.yaml
@@ -30,14 +30,14 @@ data:
   vppplugin.conf: |
     stopwatch: true
   linuxplugin.conf: |
-    stopwatch: true   
+    stopwatch: true
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: vswitch-supervisord-cfg
 data:
-  supervisord.conf: | 
+  supervisord.conf: |
     [supervisord]
     logfile=/var/log/supervisord.log
     loglevel=debug
@@ -55,7 +55,7 @@ data:
     autorestart=false
     redirect_stderr=true
     priority=2
-    
+
     ; This event listener waits for event of vpp or agent  exitting. Once received, it kills supervisord process and this makes
     ; subsequently the exit of docker container. You should also set agent autorestart=false.
     [eventlistener:vpp_or_agent_not_running]
@@ -89,15 +89,15 @@ spec:
         - name: memif-sockets
           mountPath: /tmp
   volumes:
-  - name: vpp-config
-    configMap:
-      name: vswitch-vpp-cfg
-  - name: agent-config
-    configMap:
-      name: vswitch-agent-cfg
-  - name: supervisor-config
-    configMap:  
-      name: vswitch-supervisord-cfg    
-  - name: memif-sockets
-    hostPath:
-      path: /tmp
+    - name: vpp-config
+      configMap:
+        name: vswitch-vpp-cfg
+    - name: agent-config
+      configMap:
+        name: vswitch-agent-cfg
+    - name: supervisor-config
+      configMap:
+        name: vswitch-supervisord-cfg
+    - name: memif-sockets
+      hostPath:
+        path: /tmp

--- a/tests/robot/resources/k8-yaml/etcd-k8.yaml
+++ b/tests/robot/resources/k8-yaml/etcd-k8.yaml
@@ -6,21 +6,21 @@ metadata:
 spec:
   hostNetwork: true
   containers:
-  - image: quay.io/coreos/etcd:v3.0.16
-    imagePullPolicy: IfNotPresent
-    name: etcd
-    command:
-    - /usr/local/bin/etcd
-    - --advertise-client-urls
-    - http://0.0.0.0:22379
-    - --listen-client-urls
-    - http://0.0.0.0:22379
-    - --listen-peer-urls
-    - http://0.0.0.0:22380
-    ports:
-    - containerPort: 22379
-      hostPort: 22379
-      name: serverport
-    env:
-      - name: ETCDCTL_API
-        value: "3"
+    - image: quay.io/coreos/etcd:v3.0.16
+      imagePullPolicy: IfNotPresent
+      name: etcd
+      command:
+        - /usr/local/bin/etcd
+        - --advertise-client-urls
+        - http://0.0.0.0:22379
+        - --listen-client-urls
+        - http://0.0.0.0:22379
+        - --listen-peer-urls
+        - http://0.0.0.0:22380
+      ports:
+        - containerPort: 22379
+          hostPort: 22379
+          name: serverport
+      env:
+        - name: ETCDCTL_API
+          value: "3"

--- a/tests/robot/resources/k8-yaml/novpp.yaml
+++ b/tests/robot/resources/k8-yaml/novpp.yaml
@@ -30,6 +30,6 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
       volumes:
-      - name: veth-pair
-        hostPath:
-          path: /var/run/docker.sock
+        - name: veth-pair
+          hostPath:
+            path: /var/run/docker.sock

--- a/tests/robot/resources/k8-yaml/sfc-k8.yaml
+++ b/tests/robot/resources/k8-yaml/sfc-k8.yaml
@@ -32,6 +32,6 @@ spec:
         - name: controller-config
           mountPath: /opt/sfc-controller/dev
   volumes:
-  - name: controller-config
-    configMap:
-      name: sfc-controller-cfg
+    - name: controller-config
+      configMap:
+        name: sfc-controller-cfg

--- a/tests/robot/resources/k8-yaml/vnf-vpp.yaml
+++ b/tests/robot/resources/k8-yaml/vnf-vpp.yaml
@@ -102,15 +102,15 @@ spec:
             - name: memif-sockets
               mountPath: /tmp
       volumes:
-      - name: vpp-config
-        configMap:
-          name: vnf-vpp-cfg
-      - name: agent-config
-        configMap:
-          name: vswitch-k8-agent-cfg
-      - name: memif-sockets
-        hostPath:
-          path: /tmp
-      - name: supervisor-config
-        configMap:
-          name: vnf-supervisord-cfg
+        - name: vpp-config
+          configMap:
+            name: vnf-vpp-cfg
+        - name: agent-config
+          configMap:
+            name: vswitch-k8-agent-cfg
+        - name: memif-sockets
+          hostPath:
+            path: /tmp
+        - name: supervisor-config
+          configMap:
+            name: vnf-supervisord-cfg

--- a/tests/robot/resources/k8-yaml/vswitch.yaml
+++ b/tests/robot/resources/k8-yaml/vswitch.yaml
@@ -131,19 +131,18 @@ spec:
               mountPath: /var/run/docker.sock
 
       volumes:
-      - name: vpp-config
-        configMap:
-          name: vswitch-k8-vpp-cfg
-      - name: agent-config
-        configMap:
-          name: vswitch-k8-agent-cfg
-      - name: supervisor-config
-        configMap:
-          name: vswitch-k8-supervisord-cfg
-      - name: memif-sockets
-        hostPath:
-          path: /tmp
-      - name: veth-pair
-        hostPath:
-          path: /var/run/docker.sock
-
+        - name: vpp-config
+          configMap:
+            name: vswitch-k8-vpp-cfg
+        - name: agent-config
+          configMap:
+            name: vswitch-k8-agent-cfg
+        - name: supervisor-config
+          configMap:
+            name: vswitch-k8-supervisord-cfg
+        - name: memif-sockets
+          hostPath:
+            path: /tmp
+        - name: veth-pair
+          hostPath:
+            path: /var/run/docker.sock


### PR DESCRIPTION
This commit is inspired by a similar commit to Network Service Mesh [1] and
this commit [2] from cn-infra.

Since we are making heavy use of yaml files for Network Service Mesh, we should
ensure these are syntactically correct. We'll use yamllint [3] for this.

This commit adds running of yamllint into our travis-ci runs. It also adds a
custom configuration file which turns the yamllint line length check into a
warning. And finally, it fixes a large amount of yamllint errors in our
existing yaml files.

[1] https://github.com/ligato/networkservicemesh/pull/263
[2] https://github.com/ligato/cn-infra/pull/333
[3] https://github.com/adrienverge/yamllint

Signed-off-by: Kyle Mestery <mestery@mestery.com>