### PR TITLE
grpc service registration moved to Init()

### DIFF
--- a/plugins/vpp/ifplugin/vppcalls/vrf_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vrf_vppcalls.go
@@ -107,7 +107,7 @@ func (h *IfVppHandler) setInterfaceVrf(ifIdx, vrfID uint32, isIPv6 bool) error {
 		return fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
 	}
 
-	h.log.Debugf("Interface %s set to VRF %d", ifIdx, vrfID)
+	h.log.Debugf("Interface %d set to VRF %d", ifIdx, vrfID)
 
 	return nil
 }

--- a/plugins/vpp/rpc/services.go
+++ b/plugins/vpp/rpc/services.go
@@ -64,15 +64,8 @@ func (plugin *Plugin) Init() error {
 	// Notification service (represents GRPC client)
 	plugin.notifSvc.log = plugin.Log.NewLogger("notifSvc")
 
-	return nil
-}
-
-// AfterInit registers all GRPC services in vppscv package
-// (be sure that defaultvppplugins are completely initialized).
-func (plugin *Plugin) AfterInit() error {
-	if plugin.GRPCServer == nil {
-		return nil
-	}
+	// Register all GRPC services if server is available. Register needs to be done
+	// before 'ListenAndServe' is called in GRPC plugin
 	grpcServer := plugin.GRPCServer.GetServer()
 	if grpcServer != nil {
 		rpc.RegisterDataChangeServiceServer(grpcServer, &plugin.changeVppSvc)


### PR DESCRIPTION
GRPC registration should be done before GRPC server starts listen and serve. Since the GRPC plugin (cn-infra) is started before the GRPC service plugin (vpp-agent), 'ListenAndServe' is called first and all the services are registered after.

Mostly it works because the method 'Serve' from GRPC dependency is called in separate go routine, so services have some time to register in the meantime. But if the startup is fast enough, vpp-agent crashes with the error:

FATA[0000] grpc: Server.RegisterService after Server.Serve for "rpc.DataChangeService"  loc="grpclog/grpclog.go(94)" logger=grpcgrpc-server

Moving service registration to Init() is safe since the GRPC server is already initialized.

Signed-off-by: Vladimir Lavor <vlavor@cisco.com>