### PR TITLE
Optimize production image size

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,6 +1,6 @@
 FROM dev_vpp_agent as devimg
 
-FROM ubuntu:18.04
+FROM ubuntu:18.04 as base
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -30,14 +30,16 @@ COPY --from=devimg \
     /opt/vpp-agent/dev/vpp/build-root/vpp-plugins*.deb \
  /opt/vpp/
 
-RUN cd /opt/vpp/ && dpkg -i vpp_*.deb vpp-lib_*.deb vpp-plugins_*.deb
+RUN cd /opt/vpp/ \
+ && dpkg -i vpp_*.deb vpp-lib_*.deb vpp-plugins_*.deb \
+ && rm vpp*.deb
+
+FROM scratch
+
+COPY --from=base / /
 
 # install agent
-COPY --from=devimg \
-    /go/bin/vpp-agent \
-    /go/bin/vpp-agent-ctl \
-    /go/bin/agentctl \
- /bin/
+COPY --from=devimg /go/bin/vpp-agent /bin/
 
 # copy configs
 COPY \


### PR DESCRIPTION
This PR reduces production image size by ~22% (220MB -> 172MB) by using multi-stage to get rid of removed files from previous layers.