### PR TITLE
Support for building of docker images for ARM64 platform

### DIFF
--- a/docker/dev/build.sh
+++ b/docker/dev/build.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Before run of this script you can set environmental variables
+# IMAGE_TAG, DOCKERFILE, BASE_IMG, GOLANG_OS_ARCH, .. then  export them
+# and to use defined values instead of default ones
 
 cd "$(dirname "$0")"
 
@@ -17,17 +20,22 @@ BASE_IMG=${BASE_IMG:-'ubuntu:18.04'}
 
 BUILDARCH=`uname -m`
 
-if [ ${BUILDARCH} = "aarch64" ] ; then
-  IMAGE_TAG=${IMAGE_TAG:-'dev_vpp_agent-arm64'}
-  GOLANG_OS_ARCH=${GOLANG_OS_ARCH:-'linux-arm64'}
-fi
+case "$BUILDARCH" in
+  "aarch64" )
+    IMAGE_TAG=${IMAGE_TAG:-'dev_vpp_agent-arm64'}
+    GOLANG_OS_ARCH=${GOLANG_OS_ARCH:-'linux-arm64'}
+    ;;
 
-
-if [ ${BUILDARCH} = "x86_64" ] ; then
-  # for AMD64 platform is used the default image (without suffix -amd64)
-  IMAGE_TAG=${IMAGE_TAG:-'dev_vpp_agent'}
-  GOLANG_OS_ARCH=${GOLANG_OS_ARCH:-'linux-amd64'}
-fi
+  "x86_64" )
+    # for AMD64 platform is used the default image (without suffix -amd64)
+    IMAGE_TAG=${IMAGE_TAG:-'dev_vpp_agent'}
+    GOLANG_OS_ARCH=${GOLANG_OS_ARCH:-'linux-amd64'}
+    ;;
+  * )
+    echo "Architecture ${BUILDARCH} is not supported."
+    exit
+    ;;
+esac
 
 
 source ../../vpp.env
@@ -61,6 +69,6 @@ docker build -f ${DOCKERFILE} \
     ${DOCKER_BUILD_ARGS} ../..
 
 if [[ ${BUILDARCH} = "x86_64" && ${IMAGE_TAG} = "dev_vpp_agent" ]] ; then
-  # tag also explicit docker image on AMD64 platform
+  # create docker image tagged with -amd64 suffix for AMD64 platform
   docker tag  ${IMAGE_TAG}:latest dev_vpp_agent-amd64:latest
 fi

--- a/docker/dev/build.sh
+++ b/docker/dev/build.sh
@@ -4,11 +4,31 @@ cd "$(dirname "$0")"
 
 set -e
 
-IMAGE_TAG=${IMAGE_TAG:-'dev_vpp_agent'}
+#IMAGE_TAG=${IMAGE_TAG:-'dev_vpp_agent'}
 DOCKERFILE=${DOCKERFILE:-'Dockerfile'}
 
 BASE_IMG=${BASE_IMG:-'ubuntu:18.04'}
-GOLANG_OS_ARCH=${GOLANG_OS_ARCH:-'linux-amd64'}
+#GOLANG_OS_ARCH=${GOLANG_OS_ARCH:-'linux-amd64'}
+
+#To prepare for future fat manifest image by multi-arch manifest,
+#now build the docker image with its arch
+#For fat manifest, please refer
+#https://docs.docker.com/registry/spec/manifest-v2-2/#example-manifest-list
+
+BUILDARCH=`uname -m`
+
+if [ ${BUILDARCH} = "aarch64" ] ; then
+  IMAGE_TAG=${IMAGE_TAG:-'dev_vpp_agent-arm64'}
+  GOLANG_OS_ARCH=${GOLANG_OS_ARCH:-'linux-arm64'}
+fi
+
+
+if [ ${BUILDARCH} = "x86_64" ] ; then
+  # for AMD64 platform is used the default image (without suffix -amd64)
+  IMAGE_TAG=${IMAGE_TAG:-'dev_vpp_agent'}
+  GOLANG_OS_ARCH=${GOLANG_OS_ARCH:-'linux-amd64'}
+fi
+
 
 source ../../vpp.env
 VPP_DEBUG_DEB=${VPP_DEBUG_DEB:-}
@@ -17,6 +37,8 @@ VERSION=$(git describe --always --tags --dirty)
 COMMIT=$(git rev-parse HEAD)
 
 echo "=============================="
+echo "Architecture: ${BUILDARCH}"
+echo
 echo "VPP repo URL: ${VPP_REPO_URL}"
 echo "VPP commit:   ${VPP_COMMIT}"
 echo
@@ -37,3 +59,8 @@ docker build -f ${DOCKERFILE} \
     --build-arg VERSION=${VERSION} \
     --build-arg COMMIT=${COMMIT} \
     ${DOCKER_BUILD_ARGS} ../..
+
+if [[ ${BUILDARCH} = "x86_64" && ${IMAGE_TAG} = "dev_vpp_agent" ]] ; then
+  # tag also explicit docker image on AMD64 platform
+  docker tag  ${IMAGE_TAG}:latest dev_vpp_agent-amd64:latest
+fi

--- a/docker/dev/build.sh
+++ b/docker/dev/build.sh
@@ -72,12 +72,15 @@ echo "To push to repository please use command:"
 case "$BUILDARCH" in
   "aarch64" )
     echo "docker tag ${IMAGE_TAG}:latest ligato/dev-vpp-agent-arm64:$(git describe --always --tags)"
+    echo "docker tag ${IMAGE_TAG}:latest ligato/dev-vpp-agent-arm64:latest"
     ;;
 
   "x86_64" )
     # create docker image tagged with -amd64 suffix for AMD64 platform
     echo "docker tag ${IMAGE_TAG}:latest ligato/dev-vpp-agent-amd64:$(git describe --always --tags)"
     echo "docker tag ${IMAGE_TAG}:latest ligato/dev-vpp-agent:$(git describe --always --tags)"
+    echo "docker tag ${IMAGE_TAG}:latest ligato/dev-vpp-agent-amd64:latest"
+    echo "docker tag ${IMAGE_TAG}:latest ligato/dev-vpp-agent:latest"
     ;;
   * )
     echo "Architecture ${BUILDARCH} is not supported."

--- a/docker/dev/build.sh
+++ b/docker/dev/build.sh
@@ -7,28 +7,19 @@ cd "$(dirname "$0")"
 
 set -e
 
-#IMAGE_TAG=${IMAGE_TAG:-'dev_vpp_agent'}
+IMAGE_TAG=${IMAGE_TAG:-'dev_vpp_agent'}
 DOCKERFILE=${DOCKERFILE:-'Dockerfile'}
 
 BASE_IMG=${BASE_IMG:-'ubuntu:18.04'}
-#GOLANG_OS_ARCH=${GOLANG_OS_ARCH:-'linux-amd64'}
-
-#To prepare for future fat manifest image by multi-arch manifest,
-#now build the docker image with its arch
-#For fat manifest, please refer
-#https://docs.docker.com/registry/spec/manifest-v2-2/#example-manifest-list
 
 BUILDARCH=`uname -m`
-
 case "$BUILDARCH" in
   "aarch64" )
-    IMAGE_TAG=${IMAGE_TAG:-'dev_vpp_agent-arm64'}
     GOLANG_OS_ARCH=${GOLANG_OS_ARCH:-'linux-arm64'}
     ;;
 
   "x86_64" )
     # for AMD64 platform is used the default image (without suffix -amd64)
-    IMAGE_TAG=${IMAGE_TAG:-'dev_vpp_agent'}
     GOLANG_OS_ARCH=${GOLANG_OS_ARCH:-'linux-amd64'}
     ;;
   * )
@@ -67,23 +58,3 @@ docker build -f ${DOCKERFILE} \
     --build-arg VERSION=${VERSION} \
     --build-arg COMMIT=${COMMIT} \
     ${DOCKER_BUILD_ARGS} ../..
-
-echo "To push to repository please use command:"
-case "$BUILDARCH" in
-  "aarch64" )
-    echo "docker tag ${IMAGE_TAG}:latest ligato/dev-vpp-agent-arm64:$(git describe --always --tags)"
-    echo "docker tag ${IMAGE_TAG}:latest ligato/dev-vpp-agent-arm64:latest"
-    ;;
-
-  "x86_64" )
-    # create docker image tagged with -amd64 suffix for AMD64 platform
-    echo "docker tag ${IMAGE_TAG}:latest ligato/dev-vpp-agent-amd64:$(git describe --always --tags)"
-    echo "docker tag ${IMAGE_TAG}:latest ligato/dev-vpp-agent:$(git describe --always --tags)"
-    echo "docker tag ${IMAGE_TAG}:latest ligato/dev-vpp-agent-amd64:latest"
-    echo "docker tag ${IMAGE_TAG}:latest ligato/dev-vpp-agent:latest"
-    ;;
-  * )
-    echo "Architecture ${BUILDARCH} is not supported."
-    exit
-    ;;
-esac

--- a/docker/dev/build.sh
+++ b/docker/dev/build.sh
@@ -68,7 +68,19 @@ docker build -f ${DOCKERFILE} \
     --build-arg COMMIT=${COMMIT} \
     ${DOCKER_BUILD_ARGS} ../..
 
-if [[ ${BUILDARCH} = "x86_64" && ${IMAGE_TAG} = "dev_vpp_agent" ]] ; then
-  # create docker image tagged with -amd64 suffix for AMD64 platform
-  docker tag  ${IMAGE_TAG}:latest dev_vpp_agent-amd64:latest
-fi
+echo "To push to repository please use command:"
+case "$BUILDARCH" in
+  "aarch64" )
+    echo "docker tag ${IMAGE_TAG}:latest ligato/dev-vpp-agent-arm64:$(git describe --always --tags)"
+    ;;
+
+  "x86_64" )
+    # create docker image tagged with -amd64 suffix for AMD64 platform
+    echo "docker tag ${IMAGE_TAG}:latest ligato/dev-vpp-agent-amd64:$(git describe --always --tags)"
+    echo "docker tag ${IMAGE_TAG}:latest ligato/dev-vpp-agent:$(git describe --always --tags)"
+    ;;
+  * )
+    echo "Architecture ${BUILDARCH} is not supported."
+    exit
+    ;;
+esac

--- a/docker/dev/push_image.sh
+++ b/docker/dev/push_image.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -e
+
+REPO_OWNER='ligato'
+IMAGE_TAG_LOCAL='dev_vpp_agent'
+
+#To prepare for future fat manifest image by multi-arch manifest,
+#now build the docker image with its arch
+#For fat manifest, please refer
+#https://docs.docker.com/registry/spec/manifest-v2-2/#example-manifest-list
+
+BUILDARCH=`uname -m`
+
+case "$BUILDARCH" in
+  "aarch64" )
+    IMAGE_TAG='dev-vpp-agent-arm64'
+    ;;
+
+  "x86_64" )
+    # for AMD64 platform is also used the default image (without suffix -amd64)
+    DEFAULT_IMAGE_TAG='dev-vpp-agent'
+    IMAGE_TAG='dev-vpp-agent-amd64'
+    ;;
+  * )
+    echo "Architecture ${BUILDARCH} is not supported."
+    exit
+    ;;
+esac
+
+VERSION=$(git describe --always --tags --dirty)
+COMMIT=$(git rev-parse HEAD)
+
+echo "=============================="
+echo "Architecture: ${BUILDARCH}"
+echo
+echo "VPP repo URL: ${VPP_REPO_URL}"
+echo "VPP commit:   ${VPP_COMMIT}"
+echo
+echo "Agent version: ${VERSION}"
+echo "Agent commit:  ${COMMIT}"
+echo
+echo "image tag:  ${IMAGE_TAG}"
+echo "=============================="
+
+if [ ${BUILDARCH} = "x86_64" ] ; then
+  # for AMD64 platform is used also the default image (without suffix -amd64)
+  docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:${VERSION}
+  docker push ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:${VERSION}
+  docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:latest
+  docker push ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:latest
+fi
+
+docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${IMAGE_TAG}:${VERSION}
+docker push ${REPO_OWNER}/${IMAGE_TAG}:${VERSION}
+docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${IMAGE_TAG}:latest
+docker push ${REPO_OWNER}/${IMAGE_TAG}:latest

--- a/docker/dev/push_image.sh
+++ b/docker/dev/push_image.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
+# Usage: examples
+#    ./push_image.sh
+#    BRANCH_HEAD_TAG='git describe' ./push_image.sh
 
 set -e
 
 # detect branch name
 BRANCH_NAME="$(git symbolic-ref HEAD 2>/dev/null)" || BRANCH_NAME="(unnamed branch)"     # detached HEAD
 BRANCH_NAME=${BRANCH_NAME##refs/heads/}
-BRANCH_HEAD_TAG=`git name-rev --name-only --tags HEAD`
+BRANCH_HEAD_TAG=${BRANCH_HEAD_TAG:-"`git name-rev --name-only --tags HEAD`"}
+VERSION=$(git describe --always --tags --dirty)
 
 REPO_OWNER=${REPO_OWNER:-'ligato'}
-IMAGE_TAG_LOCAL='dev_vpp_agent'
+LOCAL_IMAGE='dev_vpp_agent'
 
 #To prepare for future fat manifest image by multi-arch manifest,
 #now build the docker image with its arch
@@ -19,13 +23,13 @@ BUILDARCH=`uname -m`
 
 case "$BUILDARCH" in
   "aarch64" )
-    IMAGE_TAG='dev-vpp-agent-arm64'
+    IMAGE_NAME='dev-vpp-agent-arm64'
     ;;
 
   "x86_64" )
     # for AMD64 platform is also used the default image (without suffix -amd64)
-    DEFAULT_IMAGE_TAG='dev-vpp-agent'
-    IMAGE_TAG='dev-vpp-agent-amd64'
+    DEFAULT_IMAGE_NAME='dev-vpp-agent'
+    IMAGE_NAME='dev-vpp-agent-amd64'
     ;;
   * )
     echo "Architecture ${BUILDARCH} is not supported."
@@ -33,33 +37,36 @@ case "$BUILDARCH" in
     ;;
 esac
 
-VERSION=$(git describe --always --tags --dirty)
 
 echo "=============================="
 echo "Architecture: ${BUILDARCH}"
 echo "=============================="
 
-case "${BRANCH_NAME} " in
-  "pantheon-dev" )
-    docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:pantheon-dev
-    docker push ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:pantheon-dev
-    ;;
+case "${BRANCH_NAME}" in
   "master" )
-    if [ ${BRANCH_HEAD_TAG} != "undefined" ]	  
+    if [ ${BRANCH_HEAD_TAG} != "undefined" ] ; then
       if [ ${BUILDARCH} = "x86_64" ] ; then
         # for AMD64 platform is used also the default image (without suffix -amd64)
-        docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:${VERSION}
-        docker push ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:${VERSION}
-        docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:latest
-        docker push ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:latest
+        docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:${BRANCH_HEAD_TAG}
+        docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:${BRANCH_HEAD_TAG}
+        docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:latest
+        docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:latest
       fi
-    
-      docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${IMAGE_TAG}:${VERSION}
-      docker push ${REPO_OWNER}/${IMAGE_TAG}:${VERSION}
-      docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${IMAGE_TAG}:latest
-      docker push ${REPO_OWNER}/${IMAGE_TAG}:latest
+      docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_HEAD_TAG}
+      docker push ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_HEAD_TAG}
+      docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:latest
+      docker push ${REPO_OWNER}/${IMAGE_NAME}:latest
+    else
+      echo "For branch ${BRANCH_NAME} is no setup for tagging and pushing docker images because HEAD has no tag."
     fi
     ;;
+  "(unnamed branch)" )
+    docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:${VERSION}
+    echo "Repository is in detached state - please push manually:"
+    echo docker push ${REPO_OWNER}/${IMAGE_NAME}:${VERSION}
+    ;;
   * )
-    echo "For branch ${BRANCH_NAME} is no setup for tagging and pushing docker images."  
+    docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_NAME}
+    docker push ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_NAME}
+    ;;
 esac

--- a/docker/dev/push_image.sh
+++ b/docker/dev/push_image.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Usage: examples
 #    ./push_image.sh
-#    BRANCH_HEAD_TAG='git describe' ./push_image.sh
+#    BRANCH_HEAD_TAG=`git describe` ./push_image.sh
 #    REPO_OWNER=stanislavchlebec BRANCH_HEAD_TAG=`git describe` ./push_image.sh
-#    LOCAL_IMAGE='prod_vpp_agent:latest' DEFAULT_IMAGE_NAME='vpp-agent' ./push_image.sh
+#    LOCAL_IMAGE='prod_vpp_agent:latest' IMAGE_NAME='vpp-agent' ./push_image.sh
 
 # Warning: use only IMMEDIATELY after docker/dev/build.sh to prevent INCONSISTENCIES such as 
 #          a) after building image you switch to other branch which will result in mismatch of version of image and its tag
@@ -19,7 +19,7 @@ VERSION=$(git describe --always --tags --dirty)
 
 LOCAL_IMAGE=${LOCAL_IMAGE:-'dev_vpp_agent:latest'}
 REPO_OWNER=${REPO_OWNER:-'ligato'}
-DEFAULT_IMAGE_NAME=${DEFAULT_IMAGE_NAME:-'dev-vpp-agent'}
+IMAGE_NAME=${IMAGE_NAME:-'dev-vpp-agent'}
 
 #To prepare for future fat manifest image by multi-arch manifest,
 #now build the docker image with its arch
@@ -53,26 +53,26 @@ case "${BRANCH_NAME}" in
     if [ ${BRANCH_HEAD_TAG} != "undefined" ] ; then
       if [ ${BUILDARCH} = "x86_64" ] ; then
         # for AMD64 platform is used also the default image (without suffix -amd64)
-        docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:${BRANCH_HEAD_TAG}
-        docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:${BRANCH_HEAD_TAG}
-        docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:latest
-        docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:latest
+        docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_HEAD_TAG}
+        docker push ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_HEAD_TAG}
+        docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${IMAGE_NAME}:latest
+        docker push ${REPO_OWNER}/${IMAGE_NAME}:latest
       fi
-      docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_HEAD_TAG}
-      docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_HEAD_TAG}
-      docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:latest
-      docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:latest
+      docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_HEAD_TAG}
+      docker push ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_HEAD_TAG}
+      docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:latest
+      docker push ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:latest
     else
       echo "For branch ${BRANCH_NAME} is no setup for tagging and pushing docker images because HEAD has no tag."
     fi
     ;;
   "(unnamed branch)" )
-    docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:${VERSION}
+    docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:${VERSION}
     echo "Repository is in detached HEAD state - please push manually:"
-    echo docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:${VERSION}
+    echo docker push ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:${VERSION}
     ;;
   * )
-    docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_NAME}
-    docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_NAME}
+    docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_NAME}
+    docker push ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_NAME}
     ;;
 esac

--- a/docker/dev/push_image.sh
+++ b/docker/dev/push_image.sh
@@ -2,6 +2,11 @@
 # Usage: examples
 #    ./push_image.sh
 #    BRANCH_HEAD_TAG='git describe' ./push_image.sh
+#    REPO_OWNER=stanislavchlebec BRANCH_HEAD_TAG=`git describe` ./push_image.sh
+#
+# Warning: use only IMMEDIATELY after docker/dev/build.sh to prevent INCONSISTENCIES such as 
+#          a) after building image you switch to other branch which will result in mismatch of version of image and its tag
+#          b) you do not build the new image but only simply run this script which will result in mismatch version of image and its tag because the image is older than repository 
 
 set -e
 

--- a/docker/dev/push_image.sh
+++ b/docker/dev/push_image.sh
@@ -3,7 +3,8 @@
 #    ./push_image.sh
 #    BRANCH_HEAD_TAG='git describe' ./push_image.sh
 #    REPO_OWNER=stanislavchlebec BRANCH_HEAD_TAG=`git describe` ./push_image.sh
-#
+#    LOCAL_IMAGE='prod_vpp_agent:latest' DEFAULT_IMAGE_NAME='vpp-agent' ./push_image.sh
+
 # Warning: use only IMMEDIATELY after docker/dev/build.sh to prevent INCONSISTENCIES such as 
 #          a) after building image you switch to other branch which will result in mismatch of version of image and its tag
 #          b) you do not build the new image but only simply run this script which will result in mismatch version of image and its tag because the image is older than repository 
@@ -16,8 +17,9 @@ BRANCH_NAME=${BRANCH_NAME##refs/heads/}
 BRANCH_HEAD_TAG=${BRANCH_HEAD_TAG:-"`git name-rev --name-only --tags HEAD`"}
 VERSION=$(git describe --always --tags --dirty)
 
+LOCAL_IMAGE=${LOCAL_IMAGE:-'dev_vpp_agent:latest'}
 REPO_OWNER=${REPO_OWNER:-'ligato'}
-LOCAL_IMAGE='dev_vpp_agent'
+DEFAULT_IMAGE_NAME=${DEFAULT_IMAGE_NAME:-'dev-vpp-agent'}
 
 #To prepare for future fat manifest image by multi-arch manifest,
 #now build the docker image with its arch
@@ -28,17 +30,16 @@ BUILDARCH=`uname -m`
 
 case "$BUILDARCH" in
   "aarch64" )
-    IMAGE_NAME='dev-vpp-agent-arm64'
+    ARCH_SUFFIX='arm64'
     ;;
 
   "x86_64" )
     # for AMD64 platform is also used the default image (without suffix -amd64)
-    DEFAULT_IMAGE_NAME='dev-vpp-agent'
-    IMAGE_NAME='dev-vpp-agent-amd64'
+    ARCH_SUFFIX='amd64'
     ;;
   * )
     echo "Architecture ${BUILDARCH} is not supported."
-    exit
+    exit 1
     ;;
 esac
 
@@ -52,26 +53,26 @@ case "${BRANCH_NAME}" in
     if [ ${BRANCH_HEAD_TAG} != "undefined" ] ; then
       if [ ${BUILDARCH} = "x86_64" ] ; then
         # for AMD64 platform is used also the default image (without suffix -amd64)
-        docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:${BRANCH_HEAD_TAG}
+        docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:${BRANCH_HEAD_TAG}
         docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:${BRANCH_HEAD_TAG}
-        docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:latest
+        docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:latest
         docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:latest
       fi
-      docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_HEAD_TAG}
-      docker push ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_HEAD_TAG}
-      docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:latest
-      docker push ${REPO_OWNER}/${IMAGE_NAME}:latest
+      docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_HEAD_TAG}
+      docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_HEAD_TAG}
+      docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:latest
+      docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:latest
     else
       echo "For branch ${BRANCH_NAME} is no setup for tagging and pushing docker images because HEAD has no tag."
     fi
     ;;
   "(unnamed branch)" )
-    docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:${VERSION}
-    echo "Repository is in detached state - please push manually:"
-    echo docker push ${REPO_OWNER}/${IMAGE_NAME}:${VERSION}
+    docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:${VERSION}
+    echo "Repository is in detached HEAD state - please push manually:"
+    echo docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:${VERSION}
     ;;
   * )
-    docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_NAME}
-    docker push ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_NAME}
+    docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_NAME}
+    docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_NAME}
     ;;
 esac

--- a/docker/prod/build.sh
+++ b/docker/prod/build.sh
@@ -4,6 +4,35 @@ cd "$(dirname "$0")"
 
 set -e
 
-IMAGE_TAG=${IMAGE_TAG:-'prod_vpp_agent'}
+#To prepare for future fat manifest image by multi-arch manifest,
+#now build the docker image with its arch
+#For fat manifest, please refer
+#https://docs.docker.com/registry/spec/manifest-v2-2/#example-manifest-list
+
+BUILDARCH=`uname -m`
+
+if [ ${BUILDARCH} = "aarch64" ] ; then
+  IMAGE_TAG=${IMAGE_TAG:-'prod_vpp_agent-arm64'}
+  # Dockerfile  for prod_vpp_agent expects that dev-vpp-agent:latest image is built
+  sudo docker tag dev_vpp_agent-arm64:latest dev_vpp_agent:latest
+fi
+
+
+if [ ${BUILDARCH} = "x86_64" ] ; then
+  # for AMD64 platform is used the default image (without suffix -amd64)
+  IMAGE_TAG=${IMAGE_TAG:-'prod_vpp_agent'}
+  # Dockerfile expects that dev-vpp-agent:latest image is built
+  # Here it is granted
+fi
 
 sudo docker build  ${DOCKER_BUILD_ARGS} --tag ${IMAGE_TAG} .
+
+if [[ ${BUILDARCH} = "x86_64" && ${IMAGE_TAG} = "prod_vpp_agent" ]] ; then
+  # tag also explicit docker image on AMD64 platform
+  docker tag  ${IMAGE_TAG}:latest prod_vpp_agent-amd64:latest
+fi
+
+# cleaning
+if [ ${BUILDARCH} = "aarch64" ] ; then
+  sudo docker rmi dev_vpp_agent:latest
+fi

--- a/docker/prod/build.sh
+++ b/docker/prod/build.sh
@@ -39,14 +39,18 @@ echo "To push to repository please use command:"
 case "$BUILDARCH" in
   "aarch64" )
     echo "docker tag ${IMAGE_TAG}:latest ligato/prod-vpp-agent-arm64:$(git describe --always --tags)"
+    echo "docker tag ${IMAGE_TAG}:latest ligato/prod-vpp-agent-arm64:latest"
+
     # cleaning for arm64 platform
-    docker rmi dev_vpp_agent:latest
+    docker rmi dev_vpp_agent:latest > /dev/null 2>&1 
     ;;
 
   "x86_64" )
     # create docker image tagged with -amd64 suffix for AMD64 platform
     echo "docker tag ${IMAGE_TAG}:latest ligato/prod-vpp-agent-amd64:$(git describe --always --tags)"
     echo "docker tag ${IMAGE_TAG}:latest ligato/prod-vpp-agent:$(git describe --always --tags)"
+    echo "docker tag ${IMAGE_TAG}:latest ligato/prod-vpp-agent-amd64:latest"
+    echo "docker tag ${IMAGE_TAG}:latest ligato/prod-vpp-agent:latest"
     ;;
   * )
     echo "Architecture ${BUILDARCH} is not supported."

--- a/docker/prod/build.sh
+++ b/docker/prod/build.sh
@@ -7,25 +7,14 @@ cd "$(dirname "$0")"
 
 set -e
 
-#To prepare for future fat manifest image by multi-arch manifest,
-#now build the docker image with its arch
-#For fat manifest, please refer
-#https://docs.docker.com/registry/spec/manifest-v2-2/#example-manifest-list
+IMAGE_TAG=${IMAGE_TAG:-'prod_vpp_agent'}
 
 BUILDARCH=`uname -m`
-
 case "$BUILDARCH" in
   "aarch64" )
-    IMAGE_TAG=${IMAGE_TAG:-'prod_vpp_agent-arm64'}
-    # Dockerfile  for prod_vpp_agent expects that dev-vpp-agent:latest image is built
-    docker tag dev_vpp_agent-arm64:latest dev_vpp_agent:latest
     ;;
 
   "x86_64" )
-    # for AMD64 platform is used the default image (without suffix -amd64)
-    IMAGE_TAG=${IMAGE_TAG:-'prod_vpp_agent'}
-    # Dockerfile expects that dev-vpp-agent:latest image is built
-    # Here it is granted
     ;;
   * )
     echo "Architecture ${BUILDARCH} is not supported."
@@ -34,26 +23,3 @@ case "$BUILDARCH" in
 esac
 
 docker build  ${DOCKER_BUILD_ARGS} --tag ${IMAGE_TAG} .
-
-echo "To push to repository please use command:"
-case "$BUILDARCH" in
-  "aarch64" )
-    echo "docker tag ${IMAGE_TAG}:latest ligato/prod-vpp-agent-arm64:$(git describe --always --tags)"
-    echo "docker tag ${IMAGE_TAG}:latest ligato/prod-vpp-agent-arm64:latest"
-
-    # cleaning for arm64 platform
-    docker rmi dev_vpp_agent:latest > /dev/null 2>&1 
-    ;;
-
-  "x86_64" )
-    # create docker image tagged with -amd64 suffix for AMD64 platform
-    echo "docker tag ${IMAGE_TAG}:latest ligato/prod-vpp-agent-amd64:$(git describe --always --tags)"
-    echo "docker tag ${IMAGE_TAG}:latest ligato/prod-vpp-agent:$(git describe --always --tags)"
-    echo "docker tag ${IMAGE_TAG}:latest ligato/prod-vpp-agent-amd64:latest"
-    echo "docker tag ${IMAGE_TAG}:latest ligato/prod-vpp-agent:latest"
-    ;;
-  * )
-    echo "Architecture ${BUILDARCH} is not supported."
-    exit
-    ;;
-esac

--- a/docker/prod/push_image.sh
+++ b/docker/prod/push_image.sh
@@ -3,9 +3,9 @@
 #    ./push_image.sh
 #    BRANCH_HEAD_TAG='git describe' ./push_image.sh
 #    REPO_OWNER=stanislavchlebec BRANCH_HEAD_TAG=`git describe` ./push_image.sh
-#    LOCAL_IMAGE='prod_vpp_agent:latest' DEFAULT_IMAGE_NAME='vpp-agent' ./push_image.sh
+#    LOCAL_IMAGE='prod_vpp_agent:latest' IMAGE_NAME='vpp-agent' ./push_image.sh
 
 # Warning: use only IMMEDIATELY after docker/dev/build.sh to prevent INCONSISTENCIES such as 
 #          a) after building image you switch to other branch which will result in mismatch of version of image and its tag
 #          b) you do not build the new image but only simply run this script which will result in mismatch version of image and its tag because the image is older than repository 
-LOCAL_IMAGE='prod_vpp_agent:latest' DEFAULT_IMAGE_NAME='vpp-agent' ../dev/push_image.sh
+LOCAL_IMAGE='prod_vpp_agent:latest' IMAGE_NAME='vpp-agent' ../dev/push_image.sh

--- a/docker/prod/push_image.sh
+++ b/docker/prod/push_image.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
+# Usage: examples
+#    ./push_image.sh
+#    BRANCH_HEAD_TAG='git describe' ./push_image.sh
+#    REPO_OWNER=stanislavchlebec BRANCH_HEAD_TAG=`git describe` ./push_image.sh
+#
+# Warning: use only IMMEDIATELY after docker/dev/build.sh to prevent INCONSISTENCIES such as
+#          a) after building image you switch to other branch which will result in mismatch of version of image and its tag
+#          b) you do not build the new image but only simply run this script which will result in mismatch version of image and its tag because the image is older than repository
 
 set -e
 
-REPO_OWNER='ligato'
-IMAGE_TAG_LOCAL='prod_vpp_agent'
+# detect branch name
+BRANCH_NAME="$(git symbolic-ref HEAD 2>/dev/null)" || BRANCH_NAME="(unnamed branch)"     # detached HEAD
+BRANCH_NAME=${BRANCH_NAME##refs/heads/}
+BRANCH_HEAD_TAG=${BRANCH_HEAD_TAG:-"`git name-rev --name-only --tags HEAD`"}
+VERSION=$(git describe --always --tags --dirty)
+
+REPO_OWNER=${REPO_OWNER:-'ligato'}
+LOCAL_IMAGE='prod_vpp_agent'
 
 #To prepare for future fat manifest image by multi-arch manifest,
 #now build the docker image with its arch
@@ -14,13 +28,13 @@ BUILDARCH=`uname -m`
 
 case "$BUILDARCH" in
   "aarch64" )
-    IMAGE_TAG='vpp-agent-arm64'
+    IMAGE_NAME='vpp-agent-arm64'
     ;;
 
   "x86_64" )
     # for AMD64 platform is also used the default image (without suffix -amd64)
-    DEFAULT_IMAGE_TAG='vpp-agent'
-    IMAGE_TAG='vpp-agent-amd64'
+    DEFAULT_IMAGE_NAME='vpp-agent'
+    IMAGE_NAME='vpp-agent-amd64'
     ;;
   * )
     echo "Architecture ${BUILDARCH} is not supported."
@@ -28,30 +42,36 @@ case "$BUILDARCH" in
     ;;
 esac
 
-VERSION=$(git describe --always --tags --dirty)
-COMMIT=$(git rev-parse HEAD)
 
 echo "=============================="
 echo "Architecture: ${BUILDARCH}"
-echo
-echo "VPP repo URL: ${VPP_REPO_URL}"
-echo "VPP commit:   ${VPP_COMMIT}"
-echo
-echo "Agent version: ${VERSION}"
-echo "Agent commit:  ${COMMIT}"
-echo
-echo "image tag:  ${IMAGE_TAG}"
 echo "=============================="
 
-if [ ${BUILDARCH} = "x86_64" ] ; then
-  # for AMD64 platform is used also the default image (without suffix -amd64)
-  docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:${VERSION}
-  docker push ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:${VERSION}
-  docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:latest
-  docker push ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:latest
-fi
-
-docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${IMAGE_TAG}:${VERSION}
-docker push ${REPO_OWNER}/${IMAGE_TAG}:${VERSION}
-docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${IMAGE_TAG}:latest
-docker push ${REPO_OWNER}/${IMAGE_TAG}:latest
+case "${BRANCH_NAME}" in
+  "master" )
+    if [ ${BRANCH_HEAD_TAG} != "undefined" ] ; then
+      if [ ${BUILDARCH} = "x86_64" ] ; then
+        # for AMD64 platform is used also the default image (without suffix -amd64)
+        docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:${BRANCH_HEAD_TAG}
+        docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:${BRANCH_HEAD_TAG}
+        docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:latest
+        docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:latest
+      fi
+      docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_HEAD_TAG}
+      docker push ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_HEAD_TAG}
+      docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:latest
+      docker push ${REPO_OWNER}/${IMAGE_NAME}:latest
+    else
+      echo "For branch ${BRANCH_NAME} is no setup for tagging and pushing docker images because HEAD has no tag."
+    fi
+    ;;
+  "(unnamed branch)" )
+    docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:${VERSION}
+    echo "Repository is in detached state - please push manually:"
+    echo docker push ${REPO_OWNER}/${IMAGE_NAME}:${VERSION}
+    ;;
+  * )
+    docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_NAME}
+    docker push ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_NAME}
+    ;;
+esac

--- a/docker/prod/push_image.sh
+++ b/docker/prod/push_image.sh
@@ -3,75 +3,9 @@
 #    ./push_image.sh
 #    BRANCH_HEAD_TAG='git describe' ./push_image.sh
 #    REPO_OWNER=stanislavchlebec BRANCH_HEAD_TAG=`git describe` ./push_image.sh
-#
-# Warning: use only IMMEDIATELY after docker/dev/build.sh to prevent INCONSISTENCIES such as
+#    LOCAL_IMAGE='prod_vpp_agent:latest' DEFAULT_IMAGE_NAME='vpp-agent' ./push_image.sh
+
+# Warning: use only IMMEDIATELY after docker/dev/build.sh to prevent INCONSISTENCIES such as 
 #          a) after building image you switch to other branch which will result in mismatch of version of image and its tag
-#          b) you do not build the new image but only simply run this script which will result in mismatch version of image and its tag because the image is older than repository
-
-set -e
-
-# detect branch name
-BRANCH_NAME="$(git symbolic-ref HEAD 2>/dev/null)" || BRANCH_NAME="(unnamed branch)"     # detached HEAD
-BRANCH_NAME=${BRANCH_NAME##refs/heads/}
-BRANCH_HEAD_TAG=${BRANCH_HEAD_TAG:-"`git name-rev --name-only --tags HEAD`"}
-VERSION=$(git describe --always --tags --dirty)
-
-REPO_OWNER=${REPO_OWNER:-'ligato'}
-LOCAL_IMAGE='prod_vpp_agent'
-
-#To prepare for future fat manifest image by multi-arch manifest,
-#now build the docker image with its arch
-#For fat manifest, please refer
-#https://docs.docker.com/registry/spec/manifest-v2-2/#example-manifest-list
-
-BUILDARCH=`uname -m`
-
-case "$BUILDARCH" in
-  "aarch64" )
-    IMAGE_NAME='vpp-agent-arm64'
-    ;;
-
-  "x86_64" )
-    # for AMD64 platform is also used the default image (without suffix -amd64)
-    DEFAULT_IMAGE_NAME='vpp-agent'
-    IMAGE_NAME='vpp-agent-amd64'
-    ;;
-  * )
-    echo "Architecture ${BUILDARCH} is not supported."
-    exit
-    ;;
-esac
-
-
-echo "=============================="
-echo "Architecture: ${BUILDARCH}"
-echo "=============================="
-
-case "${BRANCH_NAME}" in
-  "master" )
-    if [ ${BRANCH_HEAD_TAG} != "undefined" ] ; then
-      if [ ${BUILDARCH} = "x86_64" ] ; then
-        # for AMD64 platform is used also the default image (without suffix -amd64)
-        docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:${BRANCH_HEAD_TAG}
-        docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:${BRANCH_HEAD_TAG}
-        docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:latest
-        docker push ${REPO_OWNER}/${DEFAULT_IMAGE_NAME}:latest
-      fi
-      docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_HEAD_TAG}
-      docker push ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_HEAD_TAG}
-      docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:latest
-      docker push ${REPO_OWNER}/${IMAGE_NAME}:latest
-    else
-      echo "For branch ${BRANCH_NAME} is no setup for tagging and pushing docker images because HEAD has no tag."
-    fi
-    ;;
-  "(unnamed branch)" )
-    docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:${VERSION}
-    echo "Repository is in detached state - please push manually:"
-    echo docker push ${REPO_OWNER}/${IMAGE_NAME}:${VERSION}
-    ;;
-  * )
-    docker tag ${LOCAL_IMAGE}:latest ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_NAME}
-    docker push ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_NAME}
-    ;;
-esac
+#          b) you do not build the new image but only simply run this script which will result in mismatch version of image and its tag because the image is older than repository 
+LOCAL_IMAGE='prod_vpp_agent:latest' DEFAULT_IMAGE_NAME='vpp-agent' ../dev/push_image.sh

--- a/docker/prod/push_image.sh
+++ b/docker/prod/push_image.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -e
+
+REPO_OWNER='ligato'
+IMAGE_TAG_LOCAL='prod_vpp_agent'
+
+#To prepare for future fat manifest image by multi-arch manifest,
+#now build the docker image with its arch
+#For fat manifest, please refer
+#https://docs.docker.com/registry/spec/manifest-v2-2/#example-manifest-list
+
+BUILDARCH=`uname -m`
+
+case "$BUILDARCH" in
+  "aarch64" )
+    IMAGE_TAG='vpp-agent-arm64'
+    ;;
+
+  "x86_64" )
+    # for AMD64 platform is also used the default image (without suffix -amd64)
+    DEFAULT_IMAGE_TAG='vpp-agent'
+    IMAGE_TAG='vpp-agent-amd64'
+    ;;
+  * )
+    echo "Architecture ${BUILDARCH} is not supported."
+    exit
+    ;;
+esac
+
+VERSION=$(git describe --always --tags --dirty)
+COMMIT=$(git rev-parse HEAD)
+
+echo "=============================="
+echo "Architecture: ${BUILDARCH}"
+echo
+echo "VPP repo URL: ${VPP_REPO_URL}"
+echo "VPP commit:   ${VPP_COMMIT}"
+echo
+echo "Agent version: ${VERSION}"
+echo "Agent commit:  ${COMMIT}"
+echo
+echo "image tag:  ${IMAGE_TAG}"
+echo "=============================="
+
+if [ ${BUILDARCH} = "x86_64" ] ; then
+  # for AMD64 platform is used also the default image (without suffix -amd64)
+  docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:${VERSION}
+  docker push ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:${VERSION}
+  docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:latest
+  docker push ${REPO_OWNER}/${DEFAULT_IMAGE_TAG}:latest
+fi
+
+docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${IMAGE_TAG}:${VERSION}
+docker push ${REPO_OWNER}/${IMAGE_TAG}:${VERSION}
+docker tag ${IMAGE_TAG_LOCAL}:latest ${REPO_OWNER}/${IMAGE_TAG}:latest
+docker push ${REPO_OWNER}/${IMAGE_TAG}:latest


### PR DESCRIPTION
The changes are inspired by this pull request 
https://github.com/contiv/vpp/commit/535b0614eec1ba8cd0b743d040ead7742c43b14c

There are covered both docker/dev and docker/prod images.

The scripts were rewritten with effort to preserve the previous behaviour when it is possible to pre-set some environment variables then export them and use the newly defined values in scripts instead of defined default values.

Warning: there was removed the sudo command while calling docker command in docker/prod/build.sh what can make problem on not sufficiently set up machines...