### PR TITLE
change the logs.conf's defaultLevel to default-level

### DIFF
--- a/docker/dev/logs.conf
+++ b/docker/dev/logs.conf
@@ -1,1 +1,1 @@
-defaultLevel: debug
+default-level: debug


### PR DESCRIPTION
change the logs.conf's "defaultLevel" to "default-level" in order to match the tag `json:"default-level"` in config.go's Config