### PR TITLE
fix IPv6 VRF for VxLAN

### DIFF
--- a/plugins/vpp/ifplugin/vppcalls/dump_interface_vppcalls_test.go
+++ b/plugins/vpp/ifplugin/vppcalls/dump_interface_vppcalls_test.go
@@ -329,6 +329,7 @@ func TestDumpInterfacesFull(t *testing.T) {
 	Expect(intfs).To(HaveLen(1))
 
 	intface := intfs[0].Interface
+	intMeta := intfs[0].Meta
 
 	// This is last checked type, so it will be equal to that
 	Expect(intface.Type).To(Equal(interfaces2.InterfaceType_VXLAN_TUNNEL))
@@ -338,6 +339,8 @@ func TestDumpInterfacesFull(t *testing.T) {
 	Expect(intface.Enabled).To(BeTrue())
 	Expect(intface.Vrf).To(Equal(uint32(42)))
 	Expect(intface.SetDhcpClient).To(BeTrue())
+	Expect(intMeta.VrfIPv4).To(Equal(uint32(42)))
+	Expect(intMeta.VrfIPv4).To(Equal(uint32(0)))
 
 	// Check memif
 	Expect(intface.Memif.SocketFilename).To(Equal("test"))

--- a/plugins/vpp/ifplugin/vppcalls/dump_interface_vppcalls_test.go
+++ b/plugins/vpp/ifplugin/vppcalls/dump_interface_vppcalls_test.go
@@ -340,7 +340,7 @@ func TestDumpInterfacesFull(t *testing.T) {
 	Expect(intface.Vrf).To(Equal(uint32(42)))
 	Expect(intface.SetDhcpClient).To(BeTrue())
 	Expect(intMeta.VrfIPv4).To(Equal(uint32(42)))
-	Expect(intMeta.VrfIPv4).To(Equal(uint32(0)))
+	Expect(intMeta.VrfIPv6).To(Equal(uint32(42)))
 
 	// Check memif
 	Expect(intface.Memif.SocketFilename).To(Equal("test"))


### PR DESCRIPTION
- IPv6 VRF is created if VxLAN is evaluated as IPv6
- In interface dump, VRF is no longer stored in the field within the proto model but was moved to metadata. The reason is that the IPv4 and IPv6 VRFs are dumped separately and both should be visible in the result.

Signed-off-by: Vladimir Lavor <vlavor@cisco.com>