### PR TITLE
Fixes for bugs in v2 plugins found with Contiv

### DIFF
--- a/examples/kvscheduler/acls/main.go
+++ b/examples/kvscheduler/acls/main.go
@@ -133,6 +133,23 @@ func (p *ExamplePlugin) testLocalClientWithScheduler() {
 			Ingress: []string{"memif0"},
 		},
 	}
+	acl3 := &acl.Acl{
+		Name: "acl3",
+		Rules: []*acl.Acl_Rule{
+			{
+				Action: acl.Acl_Rule_DENY,
+				IpRule: &acl.Acl_Rule_IpRule{
+					Ip: &acl.Acl_Rule_IpRule_Ip{
+						// SourceNetwork is unspecified (ANY)
+						DestinationNetwork: "30.0.0.0/8",
+					},
+				},
+			},
+		},
+		Interfaces: &acl.Acl_Interfaces{
+			Egress:  []string{"memif0"},
+		},
+	}
 
 	// resync
 
@@ -144,6 +161,7 @@ func (p *ExamplePlugin) testLocalClientWithScheduler() {
 		VppInterface(memif0).
 		ACL(acl0).
 		ACL(acl1).
+		ACL(acl3).
 		Send().ReceiveReply()
 	if err != nil {
 		fmt.Println(err)
@@ -156,11 +174,13 @@ func (p *ExamplePlugin) testLocalClientWithScheduler() {
 
 	acl1.Interfaces = nil
 	acl0.Interfaces.Egress = nil
+	acl3.Rules[0].IpRule.Ip.SourceNetwork = "0.0.0.0/0" // this is actually equivalent to uspecified field
 
 	txn2 := localclient.DataChangeRequest("example")
 	err = txn2.Put().
 		ACL(acl0).
 		ACL(acl1).
+		ACL(acl3).
 		Send().ReceiveReply()
 	if err != nil {
 		fmt.Println(err)

--- a/examples/kvscheduler/acls/main.go
+++ b/examples/kvscheduler/acls/main.go
@@ -174,7 +174,7 @@ func (p *ExamplePlugin) testLocalClientWithScheduler() {
 
 	acl1.Interfaces = nil
 	acl0.Interfaces.Egress = nil
-	acl3.Rules[0].IpRule.Ip.SourceNetwork = "0.0.0.0/0" // this is actually equivalent to uspecified field
+	acl3.Rules[0].IpRule.Ip.SourceNetwork = "0.0.0.0/0" // this is actually equivalent to unspecified field
 
 	txn2 := localclient.DataChangeRequest("example")
 	err = txn2.Put().

--- a/examples/kvscheduler/nat/main.go
+++ b/examples/kvscheduler/nat/main.go
@@ -228,6 +228,8 @@ func (plugin *ExamplePlugin) testLocalClientWithScheduler() {
 		extIfaceDNATExternalPort = 3333
 		extIfaceDNATLocalPort = 4444
 
+		emptyDNATLabel = "empty-dnat"
+
 		natPoolAddr1 = hostNetPrefix + "100"
 		natPoolAddr2 = hostNetPrefix + "200"
 	)
@@ -621,6 +623,11 @@ func (plugin *ExamplePlugin) testLocalClientWithScheduler() {
 		},
 	}
 
+	/* empty DNAT */
+	emptyDNAT := &vpp_nat.DNat44{
+		Label: emptyDNATLabel,
+	}
+
 	// resync
 
 	time.Sleep(time.Second * 2)
@@ -650,6 +657,7 @@ func (plugin *ExamplePlugin) testLocalClientWithScheduler() {
 		DNAT44(udpServiceDNAT).
 		DNAT44(idDNAT).
 		DNAT44(externalIfaceDNAT).
+		DNAT44(emptyDNAT).
 		Send().ReceiveReply()
 	if err != nil {
 		fmt.Println(err)

--- a/plugins/vppv2/aclplugin/descriptor/acl.go
+++ b/plugins/vppv2/aclplugin/descriptor/acl.go
@@ -126,18 +126,18 @@ func (d *ACLDescriptor) equivalentACLRules(rule1, rule2 *acl.Acl_Rule) bool {
 	if rule1.IpRule.Ip == nil || rule2.IpRule.Ip == nil {
 		return rule1.IpRule.Ip == rule2.IpRule.Ip
 	}
-	if !d.equivalentIpRuleNetworks(rule1.IpRule.Ip.SourceNetwork, rule2.IpRule.Ip.SourceNetwork) {
+	if !d.equivalentIPRuleNetworks(rule1.IpRule.Ip.SourceNetwork, rule2.IpRule.Ip.SourceNetwork) {
 		return false
 	}
-	if !d.equivalentIpRuleNetworks(rule1.IpRule.Ip.DestinationNetwork, rule2.IpRule.Ip.DestinationNetwork) {
+	if !d.equivalentIPRuleNetworks(rule1.IpRule.Ip.DestinationNetwork, rule2.IpRule.Ip.DestinationNetwork) {
 		return false
 	}
 	return true
 }
 
-// equivalentIpRuleNetworks compares two IP networks, taking into account the fact
+// equivalentIPRuleNetworks compares two IP networks, taking into account the fact
 // that empty string is equivalent to address with all zeroes.
-func (d *ACLDescriptor) equivalentIpRuleNetworks(net1, net2 string) bool {
+func (d *ACLDescriptor) equivalentIPRuleNetworks(net1, net2 string) bool {
 	var (
 		ip1, ip2 net.IP
 		ipNet1, ipNet2 *net.IPNet

--- a/plugins/vppv2/aclplugin/descriptor/acl.go
+++ b/plugins/vppv2/aclplugin/descriptor/acl.go
@@ -109,6 +109,8 @@ func (d *ACLDescriptor) EquivalentACLs(key string, oldACL, newACL *acl.Acl) bool
 	return true
 }
 
+// equivalentACLRules compares two ACL rules, handling the cases of unspecified
+// source/destination networks.
 func (d *ACLDescriptor) equivalentACLRules(rule1, rule2 *acl.Acl_Rule) bool {
 	if rule1.Action != rule2.Action || !proto.Equal(rule1.MacipRule, rule2.MacipRule) {
 		return false

--- a/plugins/vppv2/aclplugin/descriptor/acl.go
+++ b/plugins/vppv2/aclplugin/descriptor/acl.go
@@ -112,26 +112,28 @@ func (d *ACLDescriptor) EquivalentACLs(key string, oldACL, newACL *acl.Acl) bool
 // equivalentACLRules compares two ACL rules, handling the cases of unspecified
 // source/destination networks.
 func (d *ACLDescriptor) equivalentACLRules(rule1, rule2 *acl.Acl_Rule) bool {
-	if rule1.Action != rule2.Action || !proto.Equal(rule1.MacipRule, rule2.MacipRule) {
+	// Action
+	if rule1.Action != rule2.Action {
+		return false
+	}
+
+	// MAC IP Rule
+	if !proto.Equal(rule1.MacipRule, rule2.MacipRule) {
 		return false
 	}
 
 	// IP Rule
-	if rule1.IpRule == nil || rule2.IpRule == nil {
-		return rule1.IpRule == rule2.IpRule
-	}
-	if !proto.Equal(rule1.IpRule.Icmp, rule2.IpRule.Icmp) ||
-		!proto.Equal(rule1.IpRule.Tcp, rule2.IpRule.Tcp) ||
-		!proto.Equal(rule1.IpRule.Udp, rule2.IpRule.Udp) {
+	ipRule1 := rule1.GetIpRule()
+	ipRule2 := rule2.GetIpRule()
+	if !proto.Equal(ipRule1.GetIcmp(), ipRule2.GetIcmp()) ||
+		!proto.Equal(ipRule1.GetTcp(), ipRule2.GetTcp()) ||
+		!proto.Equal(ipRule1.GetUdp(), ipRule2.GetUdp()) {
 		return false
 	}
-	if rule1.IpRule.Ip == nil || rule2.IpRule.Ip == nil {
-		return rule1.IpRule.Ip == rule2.IpRule.Ip
-	}
-	if !d.equivalentIPRuleNetworks(rule1.IpRule.Ip.SourceNetwork, rule2.IpRule.Ip.SourceNetwork) {
+	if !d.equivalentIPRuleNetworks(ipRule1.GetIp().GetSourceNetwork(), ipRule2.GetIp().GetSourceNetwork()) {
 		return false
 	}
-	if !d.equivalentIPRuleNetworks(rule1.IpRule.Ip.DestinationNetwork, rule2.IpRule.Ip.DestinationNetwork) {
+	if !d.equivalentIPRuleNetworks(ipRule1.GetIp().GetDestinationNetwork(), ipRule2.GetIp().GetDestinationNetwork()) {
 		return false
 	}
 	return true

--- a/plugins/vppv2/aclplugin/descriptor/acl_to_interface.go
+++ b/plugins/vppv2/aclplugin/descriptor/acl_to_interface.go
@@ -54,7 +54,7 @@ func (d *ACLToInterfaceDescriptor) IsACLInterfaceKey(key string) bool {
 	return isACLToInterfaceKey
 }
 
-// Add enables DHCP client.
+// Add binds interface to ACL.
 func (d *ACLToInterfaceDescriptor) Add(key string, emptyVal proto.Message) (metadata scheduler.Metadata, err error) {
 	aclName, ifName, flow, _ := acl.ParseACLToInterfaceKey(key)
 
@@ -68,16 +68,19 @@ func (d *ACLToInterfaceDescriptor) Add(key string, emptyVal proto.Message) (meta
 	if aclMeta.L2 {
 		// MACIP ACL (L2)
 		if err := d.aclHandler.AddMACIPACLToInterface(aclMeta.Index, ifName); err != nil {
+			d.log.Error(err)
 			return nil, err
 		}
 	} else {
 		// ACL (L3/L4)
 		if flow == acl.IngressFlow {
 			if err := d.aclHandler.AddACLToInterfaceAsIngress(aclMeta.Index, ifName); err != nil {
+				d.log.Error(err)
 				return nil, err
 			}
 		} else if flow == acl.EgressFlow {
 			if err := d.aclHandler.AddACLToInterfaceAsEgress(aclMeta.Index, ifName); err != nil {
+				d.log.Error(err)
 				return nil, err
 			}
 		}
@@ -86,7 +89,7 @@ func (d *ACLToInterfaceDescriptor) Add(key string, emptyVal proto.Message) (meta
 	return nil, nil
 }
 
-// Delete disables DHCP client.
+// Delete unbinds interface from ACL.
 func (d *ACLToInterfaceDescriptor) Delete(key string, emptyVal proto.Message, metadata scheduler.Metadata) error {
 	aclName, ifName, flow, _ := acl.ParseACLToInterfaceKey(key)
 
@@ -100,16 +103,19 @@ func (d *ACLToInterfaceDescriptor) Delete(key string, emptyVal proto.Message, me
 	if aclMeta.L2 {
 		// MACIP ACL (L2)
 		if err := d.aclHandler.DeleteMACIPACLFromInterface(aclMeta.Index, ifName); err != nil {
+			d.log.Error(err)
 			return err
 		}
 	} else {
 		// ACL (L3/L4)
 		if flow == acl.IngressFlow {
 			if err := d.aclHandler.DeleteACLFromInterfaceAsIngress(aclMeta.Index, ifName); err != nil {
+				d.log.Error(err)
 				return err
 			}
 		} else if flow == acl.EgressFlow {
 			if err := d.aclHandler.DeleteACLFromInterfaceAsEgress(aclMeta.Index, ifName); err != nil {
+				d.log.Error(err)
 				return err
 			}
 		}

--- a/plugins/vppv2/aclplugin/vppcalls/interfaces_vppcalls.go
+++ b/plugins/vppv2/aclplugin/vppcalls/interfaces_vppcalls.go
@@ -76,9 +76,6 @@ func (h *ACLVppHandler) AddACLToInterfaceAsIngress(aclIndex uint32, ifName strin
 	if err != nil {
 		return fmt.Errorf("failed to add interface %d to ACL (L3/L4) %d as ingress: %v", ifIdx, aclIndex, err)
 	}
-	if reply.Retval != 0 {
-		return fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
-	}
 
 	return nil
 }
@@ -103,9 +100,6 @@ func (h *ACLVppHandler) AddACLToInterfaceAsEgress(aclIndex uint32, ifName string
 	if err != nil {
 		return fmt.Errorf("failed to add interface %d to ACL (L3/L4) %d as egress: %v", ifIdx, aclIndex, err)
 	}
-	if reply.Retval != 0 {
-		return fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
-	}
 
 	return nil
 }
@@ -128,9 +122,6 @@ func (h *ACLVppHandler) DeleteACLFromInterfaceAsIngress(aclIndex uint32, ifName 
 
 	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return fmt.Errorf("failed to delete interface %d from ACL (L3/L4) %d as ingress: %v", ifIdx, aclIndex, err)
-	}
-	if reply.Retval != 0 {
-		return fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
 	}
 
 	return nil
@@ -155,9 +146,6 @@ func (h *ACLVppHandler) DeleteACLFromInterfaceAsEgress(aclIndex uint32, ifName s
 	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return fmt.Errorf("failed to delete interface %d from ACL (L3/L4) %d as egress: %v", ifIdx, aclIndex, err)
 	}
-	if reply.Retval != 0 {
-		return fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
-	}
 
 	return nil
 }
@@ -180,9 +168,6 @@ func (h *ACLVppHandler) AddMACIPACLToInterface(aclIndex uint32, ifName string) e
 	err := h.callsChannel.SendRequest(req).ReceiveReply(reply)
 	if err != nil {
 		return fmt.Errorf("failed to add interface %d to MACIP ACL (L2) %d: %v", ifIdx, aclIndex, err)
-	}
-	if reply.Retval != 0 {
-		return fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
 	}
 
 	return nil
@@ -207,9 +192,6 @@ func (h *ACLVppHandler) DeleteMACIPACLFromInterface(aclIndex uint32, ifName stri
 	if err != nil {
 		return fmt.Errorf("failed to delete interface %d from MACIP ACL (L2) %d: %v", ifIdx, aclIndex, err)
 	}
-	if reply.Retval != 0 {
-		return fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
-	}
 
 	return nil
 }
@@ -228,9 +210,6 @@ func (h *ACLVppHandler) SetMACIPACLToInterfaces(aclIndex uint32, ifIndices []uin
 		if err != nil {
 			return fmt.Errorf("failed to set interface %d to L2 ACL %d: %v", ingressIfIdx, aclIndex, err)
 		}
-		if reply.Retval != 0 {
-			return fmt.Errorf("set interface %d to L2 ACL %d returned %d", ingressIfIdx, aclIndex, reply.Retval)
-		}
 	}
 
 	return nil
@@ -248,10 +227,6 @@ func (h *ACLVppHandler) RemoveMACIPACLFromInterfaces(removedACLIndex uint32, ifI
 
 		if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 			return fmt.Errorf("failed to remove L2 ACL %d from interface %d: %v", removedACLIndex, ifIdx, err)
-		}
-		if reply.Retval != 0 {
-			return fmt.Errorf("remove L2 ACL %d from interface %d returned error %d", removedACLIndex,
-				removedACLIndex, reply.Retval)
 		}
 	}
 	return nil

--- a/plugins/vppv2/aclplugin/vppcalls/interfaces_vppcalls.go
+++ b/plugins/vppv2/aclplugin/vppcalls/interfaces_vppcalls.go
@@ -76,6 +76,9 @@ func (h *ACLVppHandler) AddACLToInterfaceAsIngress(aclIndex uint32, ifName strin
 	if err != nil {
 		return fmt.Errorf("failed to add interface %d to ACL (L3/L4) %d as ingress: %v", ifIdx, aclIndex, err)
 	}
+	if reply.Retval != 0 {
+		return fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
+	}
 
 	return nil
 }
@@ -100,6 +103,9 @@ func (h *ACLVppHandler) AddACLToInterfaceAsEgress(aclIndex uint32, ifName string
 	if err != nil {
 		return fmt.Errorf("failed to add interface %d to ACL (L3/L4) %d as egress: %v", ifIdx, aclIndex, err)
 	}
+	if reply.Retval != 0 {
+		return fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
+	}
 
 	return nil
 }
@@ -122,6 +128,9 @@ func (h *ACLVppHandler) DeleteACLFromInterfaceAsIngress(aclIndex uint32, ifName 
 
 	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return fmt.Errorf("failed to delete interface %d from ACL (L3/L4) %d as ingress: %v", ifIdx, aclIndex, err)
+	}
+	if reply.Retval != 0 {
+		return fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
 	}
 
 	return nil
@@ -146,6 +155,9 @@ func (h *ACLVppHandler) DeleteACLFromInterfaceAsEgress(aclIndex uint32, ifName s
 	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return fmt.Errorf("failed to delete interface %d from ACL (L3/L4) %d as egress: %v", ifIdx, aclIndex, err)
 	}
+	if reply.Retval != 0 {
+		return fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
+	}
 
 	return nil
 }
@@ -169,6 +181,9 @@ func (h *ACLVppHandler) AddMACIPACLToInterface(aclIndex uint32, ifName string) e
 	if err != nil {
 		return fmt.Errorf("failed to add interface %d to MACIP ACL (L2) %d: %v", ifIdx, aclIndex, err)
 	}
+	if reply.Retval != 0 {
+		return fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
+	}
 
 	return nil
 }
@@ -191,6 +206,9 @@ func (h *ACLVppHandler) DeleteMACIPACLFromInterface(aclIndex uint32, ifName stri
 	err := h.callsChannel.SendRequest(req).ReceiveReply(reply)
 	if err != nil {
 		return fmt.Errorf("failed to delete interface %d from MACIP ACL (L2) %d: %v", ifIdx, aclIndex, err)
+	}
+	if reply.Retval != 0 {
+		return fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
 	}
 
 	return nil

--- a/plugins/vppv2/ifplugin/descriptor/interface_crud.go
+++ b/plugins/vppv2/ifplugin/descriptor/interface_crud.go
@@ -94,6 +94,7 @@ func (d *InterfaceDescriptor) Add(key string, intf *interfaces.Interface) (metad
 		ifIdx, found = d.ethernetIfs[intf.Name]
 		if !found {
 			err = errors.Errorf("failed to find physical interface %s", intf.Name)
+			d.log.Error(err)
 			return nil, err
 		}
 

--- a/plugins/vppv2/l3plugin/descriptor/static_route.go
+++ b/plugins/vppv2/l3plugin/descriptor/static_route.go
@@ -38,6 +38,9 @@ const (
 
 	// dependency labels
 	routeOutInterfaceDep = "interface-exists"
+
+	// static route weight by default
+	defaultWeight = 1
 )
 
 // RouteDescriptor teaches KVScheduler how to configure VPP routes.
@@ -89,7 +92,7 @@ func (d *RouteDescriptor) EquivalentRoutes(key string, oldRoute, newRoute *l3.St
 		oldRoute.GetVrfId() != newRoute.GetVrfId() ||
 		oldRoute.GetViaVrfId() != newRoute.GetViaVrfId() ||
 		oldRoute.GetOutgoingInterface() != newRoute.GetOutgoingInterface() ||
-		oldRoute.GetWeight() != newRoute.GetWeight() ||
+		getWeight(oldRoute) != getWeight(newRoute) ||
 		oldRoute.GetPreference() != newRoute.GetPreference() {
 		return false
 	}
@@ -232,6 +235,14 @@ func getGwAddr(route *l3.StaticRoute) string {
 		return net.IPv6zero.String()
 	}
 	return net.IPv4zero.String()
+}
+
+// getWeight returns static route weight, handling the cases when it is left undefined.
+func getWeight(route *l3.StaticRoute) uint32 {
+	if route.Weight == 0 {
+		return defaultWeight
+	}
+	return route.Weight
 }
 
 // equalNetworks compares two IP networks for equality.

--- a/plugins/vppv2/natplugin/vppcalls/dump_nat_vppcalls_test.go
+++ b/plugins/vppv2/natplugin/vppcalls/dump_nat_vppcalls_test.go
@@ -139,7 +139,7 @@ func TestDNATDump(t *testing.T) {
 			VrfID:             1,
 			TwiceNat:          1,
 			SelfTwiceNat:      0,
-			Tag:               []byte("DNAT 1|EP"),
+			Tag:               []byte("DNAT 1|POOL"),
 		},
 		&bin_api.Nat44StaticMappingDetails{
 			LocalIPAddress:    net.ParseIP("10.10.11.120").To4(),
@@ -252,7 +252,7 @@ func TestDNATDump(t *testing.T) {
 			IPAddress: net.ParseIP("10.10.11.200").To4(),
 			SwIfIndex: vppcalls.NoInterface,
 			VrfID:     1,
-			Tag:       []byte("DNAT 3|EP"),
+			Tag:       []byte("DNAT 3|POOL"),
 		},
 		&bin_api.Nat44IdentityMappingDetails{
 			AddrOnly:  1,

--- a/plugins/vppv2/natplugin/vppcalls/dump_nat_vppcalls_test.go
+++ b/plugins/vppv2/natplugin/vppcalls/dump_nat_vppcalls_test.go
@@ -139,7 +139,7 @@ func TestDNATDump(t *testing.T) {
 			VrfID:             1,
 			TwiceNat:          1,
 			SelfTwiceNat:      0,
-			Tag:               []byte("DNAT 1"),
+			Tag:               []byte("DNAT 1|EP"),
 		},
 		&bin_api.Nat44StaticMappingDetails{
 			LocalIPAddress:    net.ParseIP("10.10.11.120").To4(),
@@ -252,7 +252,7 @@ func TestDNATDump(t *testing.T) {
 			IPAddress: net.ParseIP("10.10.11.200").To4(),
 			SwIfIndex: vppcalls.NoInterface,
 			VrfID:     1,
-			Tag:       []byte("DNAT 3"),
+			Tag:       []byte("DNAT 3|EP"),
 		},
 		&bin_api.Nat44IdentityMappingDetails{
 			AddrOnly:  1,
@@ -301,6 +301,7 @@ func TestDNATDump(t *testing.T) {
 	Expect(dnat.StMappings[0].Protocol).To(Equal(nat.DNat44_TCP))
 	Expect(dnat.StMappings[0].ExternalInterface).To(BeEmpty())
 	Expect(dnat.StMappings[0].ExternalIp).To(Equal("10.36.20.20"))
+	Expect(dnat.StMappings[0].ExternalIpFromPool).To(BeTrue())
 	Expect(dnat.StMappings[0].ExternalPort).To(BeEquivalentTo(80))
 	Expect(dnat.StMappings[0].LocalIps).To(HaveLen(1))
 	Expect(dnat.StMappings[0].LocalIps[0].VrfId).To(BeEquivalentTo(1))
@@ -312,6 +313,7 @@ func TestDNATDump(t *testing.T) {
 	Expect(dnat.StMappings[1].Protocol).To(Equal(nat.DNat44_TCP))
 	Expect(dnat.StMappings[1].ExternalInterface).To(BeEquivalentTo("if0"))
 	Expect(dnat.StMappings[1].ExternalIp).To(BeEmpty())
+	Expect(dnat.StMappings[1].ExternalIpFromPool).To(BeFalse())
 	Expect(dnat.StMappings[1].ExternalPort).To(BeEquivalentTo(80))
 	Expect(dnat.StMappings[1].LocalIps).To(HaveLen(1))
 	Expect(dnat.StMappings[1].LocalIps[0].VrfId).To(BeEquivalentTo(1))
@@ -328,6 +330,7 @@ func TestDNATDump(t *testing.T) {
 	Expect(dnat.StMappings[0].Protocol).To(Equal(nat.DNat44_TCP))
 	Expect(dnat.StMappings[0].ExternalInterface).To(Equal("if1"))
 	Expect(dnat.StMappings[0].ExternalIp).To(BeEmpty())
+	Expect(dnat.StMappings[0].ExternalIpFromPool).To(BeFalse())
 	Expect(dnat.StMappings[0].ExternalPort).To(BeEquivalentTo(80))
 	Expect(dnat.StMappings[0].LocalIps).To(HaveLen(1))
 	Expect(dnat.StMappings[0].LocalIps[0].VrfId).To(BeEquivalentTo(1))
@@ -339,6 +342,7 @@ func TestDNATDump(t *testing.T) {
 	Expect(dnat.StMappings[1].Protocol).To(Equal(nat.DNat44_UDP))
 	Expect(dnat.StMappings[1].ExternalInterface).To(BeEmpty())
 	Expect(dnat.StMappings[1].ExternalIp).To(Equal("10.36.20.60"))
+	Expect(dnat.StMappings[1].ExternalIpFromPool).To(BeFalse())
 	Expect(dnat.StMappings[1].ExternalPort).To(BeEquivalentTo(53))
 	Expect(dnat.StMappings[1].LocalIps).To(HaveLen(2))
 	Expect(dnat.StMappings[1].LocalIps[0].VrfId).To(BeEquivalentTo(0))
@@ -359,12 +363,14 @@ func TestDNATDump(t *testing.T) {
 	Expect(dnat.IdMappings[0].Protocol).To(Equal(nat.DNat44_UDP))
 	Expect(dnat.IdMappings[0].Port).To(BeEquivalentTo(0))
 	Expect(dnat.IdMappings[0].IpAddress).To(Equal("10.10.11.200"))
+	Expect(dnat.IdMappings[0].IpAddressFromPool).To(BeTrue())
 	Expect(dnat.IdMappings[0].Interface).To(BeEmpty())
 	// 2nd mapping
 	Expect(dnat.IdMappings[1].VrfId).To(BeEquivalentTo(1))
 	Expect(dnat.IdMappings[1].Protocol).To(Equal(nat.DNat44_UDP))
 	Expect(dnat.IdMappings[1].Port).To(BeEquivalentTo(0))
 	Expect(dnat.IdMappings[1].IpAddress).To(BeEmpty())
+	Expect(dnat.IdMappings[1].IpAddressFromPool).To(BeFalse())
 	Expect(dnat.IdMappings[1].Interface).To(BeEquivalentTo("if1"))
 }
 

--- a/plugins/vppv2/natplugin/vppcalls/nat_vppcalls_test.go
+++ b/plugins/vppv2/natplugin/vppcalls/nat_vppcalls_test.go
@@ -451,8 +451,9 @@ func TestAddNat44StaticMappingAddrOnly(t *testing.T) {
 
 	// DataContext
 	mapping := &nat.DNat44_StaticMapping{
-		ExternalIp: externalIP.String(),
-		Protocol:   nat.DNat44_TCP,
+		ExternalIp:         externalIP.String(),
+		ExternalIpFromPool: true,
+		Protocol:           nat.DNat44_TCP,
 		LocalIps: []*nat.DNat44_StaticMapping_LocalIP{
 			{
 				LocalIp: localIP.String(),
@@ -467,7 +468,7 @@ func TestAddNat44StaticMappingAddrOnly(t *testing.T) {
 
 	msg, ok := ctx.MockChannel.Msg.(*binapi.Nat44AddDelStaticMapping)
 	Expect(ok).To(BeTrue())
-	Expect(msg.Tag).To(BeEquivalentTo("DNAT 1"))
+	Expect(msg.Tag).To(BeEquivalentTo("DNAT 1|EP"))
 	Expect(msg.IsAdd).To(BeEquivalentTo(1))
 	Expect(msg.AddrOnly).To(BeEquivalentTo(1))
 	Expect(msg.ExternalIPAddress).To(BeEquivalentTo(externalIP))
@@ -550,8 +551,9 @@ func TestDelNat44StaticMappingAddrOnly(t *testing.T) {
 	externalIP := net.ParseIP("10.0.0.2").To4()
 
 	mapping := &nat.DNat44_StaticMapping{
-		ExternalIp: externalIP.String(),
-		Protocol:   nat.DNat44_TCP,
+		ExternalIp:         externalIP.String(),
+		ExternalIpFromPool: true,
+		Protocol:           nat.DNat44_TCP,
 		LocalIps: []*nat.DNat44_StaticMapping_LocalIP{
 			{
 				LocalIp: localIP.String(),
@@ -566,7 +568,7 @@ func TestDelNat44StaticMappingAddrOnly(t *testing.T) {
 
 	msg, ok := ctx.MockChannel.Msg.(*binapi.Nat44AddDelStaticMapping)
 	Expect(ok).To(BeTrue())
-	Expect(msg.Tag).To(BeEquivalentTo("DNAT 1"))
+	Expect(msg.Tag).To(BeEquivalentTo("DNAT 1|EP"))
 	Expect(msg.IsAdd).To(BeEquivalentTo(0))
 	Expect(msg.AddrOnly).To(BeEquivalentTo(1))
 	Expect(msg.ExternalIPAddress).To(BeEquivalentTo(externalIP))
@@ -598,6 +600,53 @@ func TestAddNat44StaticMappingLb(t *testing.T) {
 	msg, ok := ctx.MockChannel.Msg.(*binapi.Nat44AddDelLbStaticMapping)
 	Expect(ok).To(BeTrue())
 	Expect(msg.Tag).To(BeEquivalentTo("DNAT 1"))
+	Expect(msg.TwiceNat).To(BeEquivalentTo(1))
+	Expect(msg.IsAdd).To(BeEquivalentTo(1))
+	Expect(msg.ExternalAddr).To(BeEquivalentTo(externalIP))
+	Expect(msg.ExternalPort).To(BeEquivalentTo(8080))
+	Expect(msg.Protocol).To(BeEquivalentTo(6))
+	Expect(msg.Out2inOnly).To(BeEquivalentTo(1))
+
+	// Local IPs
+	Expect(msg.Locals).To(HaveLen(2))
+	expectedCount := 0
+	for _, local := range msg.Locals {
+		if bytes.Compare(local.Addr, localIP1) == 0 && local.Port == 8080 && local.Probability == 35 {
+			expectedCount++
+		}
+		if bytes.Compare(local.Addr, localIP2) == 0 && local.Port == 8181 && local.Probability == 65 {
+			expectedCount++
+		}
+	}
+	Expect(expectedCount).To(BeEquivalentTo(2))
+}
+
+func TestAddNat44StaticMappingLbWithExtIPFromPool(t *testing.T) {
+	ctx, natHandler, _, _ := natTestSetup(t)
+	defer ctx.TeardownTestCtx()
+
+	externalIP := net.ParseIP("10.0.0.1").To4()
+	localIP1 := net.ParseIP("10.0.0.2").To4()
+	localIP2 := net.ParseIP("10.0.0.3").To4()
+
+	mapping := &nat.DNat44_StaticMapping{
+		ExternalIp:         externalIP.String(),
+		ExternalIpFromPool: true,
+		ExternalPort:       8080,
+		ExternalInterface:  "if0",
+		Protocol:           nat.DNat44_TCP,
+		TwiceNat:           nat.DNat44_StaticMapping_ENABLED,
+		LocalIps:           localIPs(localIP1, localIP2),
+	}
+
+	ctx.MockVpp.MockReply(&binapi.Nat44AddDelLbStaticMappingReply{})
+	err := natHandler.AddNat44StaticMapping(mapping, "DNAT 1")
+
+	Expect(err).ShouldNot(HaveOccurred())
+
+	msg, ok := ctx.MockChannel.Msg.(*binapi.Nat44AddDelLbStaticMapping)
+	Expect(ok).To(BeTrue())
+	Expect(msg.Tag).To(BeEquivalentTo("DNAT 1|EP"))
 	Expect(msg.TwiceNat).To(BeEquivalentTo(1))
 	Expect(msg.IsAdd).To(BeEquivalentTo(1))
 	Expect(msg.ExternalAddr).To(BeEquivalentTo(externalIP))
@@ -698,7 +747,7 @@ func TestAddNat44IdentityMapping(t *testing.T) {
 	Expect(msg.AddrOnly).To(BeEquivalentTo(0))
 }
 
-func TestAddNat44IdentityMappingAddrOnly(t *testing.T) {
+func TestAddNat44IdentityMappingWithInterface(t *testing.T) {
 	ctx, natHandler, swIfIndexes, _ := natTestSetup(t)
 	defer ctx.TeardownTestCtx()
 
@@ -733,10 +782,11 @@ func TestAddNat44IdentityMappingNoInterface(t *testing.T) {
 	address := net.ParseIP("10.0.0.1").To4()
 
 	mapping := &nat.DNat44_IdentityMapping{
-		VrfId:     1,
-		Protocol:  nat.DNat44_UDP,
-		IpAddress: address.String(),
-		Port:      8989,
+		VrfId:             1,
+		Protocol:          nat.DNat44_UDP,
+		IpAddress:         address.String(),
+		IpAddressFromPool: true,
+		Port:              8989,
 	}
 
 	ctx.MockVpp.MockReply(&binapi.Nat44AddDelIdentityMappingReply{})
@@ -746,7 +796,7 @@ func TestAddNat44IdentityMappingNoInterface(t *testing.T) {
 
 	msg, ok := ctx.MockChannel.Msg.(*binapi.Nat44AddDelIdentityMapping)
 	Expect(ok).To(BeTrue())
-	Expect(msg.Tag).To(BeEquivalentTo("DNAT 2"))
+	Expect(msg.Tag).To(BeEquivalentTo("DNAT 2|EP"))
 	Expect(msg.IPAddress).To(BeEquivalentTo(address))
 	Expect(msg.Port).To(BeEquivalentTo(8989))
 	Expect(msg.AddrOnly).To(BeEquivalentTo(0))

--- a/plugins/vppv2/natplugin/vppcalls/nat_vppcalls_test.go
+++ b/plugins/vppv2/natplugin/vppcalls/nat_vppcalls_test.go
@@ -468,7 +468,7 @@ func TestAddNat44StaticMappingAddrOnly(t *testing.T) {
 
 	msg, ok := ctx.MockChannel.Msg.(*binapi.Nat44AddDelStaticMapping)
 	Expect(ok).To(BeTrue())
-	Expect(msg.Tag).To(BeEquivalentTo("DNAT 1|EP"))
+	Expect(msg.Tag).To(BeEquivalentTo("DNAT 1|POOL"))
 	Expect(msg.IsAdd).To(BeEquivalentTo(1))
 	Expect(msg.AddrOnly).To(BeEquivalentTo(1))
 	Expect(msg.ExternalIPAddress).To(BeEquivalentTo(externalIP))
@@ -568,7 +568,7 @@ func TestDelNat44StaticMappingAddrOnly(t *testing.T) {
 
 	msg, ok := ctx.MockChannel.Msg.(*binapi.Nat44AddDelStaticMapping)
 	Expect(ok).To(BeTrue())
-	Expect(msg.Tag).To(BeEquivalentTo("DNAT 1|EP"))
+	Expect(msg.Tag).To(BeEquivalentTo("DNAT 1|POOL"))
 	Expect(msg.IsAdd).To(BeEquivalentTo(0))
 	Expect(msg.AddrOnly).To(BeEquivalentTo(1))
 	Expect(msg.ExternalIPAddress).To(BeEquivalentTo(externalIP))
@@ -646,7 +646,7 @@ func TestAddNat44StaticMappingLbWithExtIPFromPool(t *testing.T) {
 
 	msg, ok := ctx.MockChannel.Msg.(*binapi.Nat44AddDelLbStaticMapping)
 	Expect(ok).To(BeTrue())
-	Expect(msg.Tag).To(BeEquivalentTo("DNAT 1|EP"))
+	Expect(msg.Tag).To(BeEquivalentTo("DNAT 1|POOL"))
 	Expect(msg.TwiceNat).To(BeEquivalentTo(1))
 	Expect(msg.IsAdd).To(BeEquivalentTo(1))
 	Expect(msg.ExternalAddr).To(BeEquivalentTo(externalIP))
@@ -796,7 +796,7 @@ func TestAddNat44IdentityMappingNoInterface(t *testing.T) {
 
 	msg, ok := ctx.MockChannel.Msg.(*binapi.Nat44AddDelIdentityMapping)
 	Expect(ok).To(BeTrue())
-	Expect(msg.Tag).To(BeEquivalentTo("DNAT 2|EP"))
+	Expect(msg.Tag).To(BeEquivalentTo("DNAT 2|POOL"))
 	Expect(msg.IPAddress).To(BeEquivalentTo(address))
 	Expect(msg.Port).To(BeEquivalentTo(8989))
 	Expect(msg.AddrOnly).To(BeEquivalentTo(0))


### PR DESCRIPTION
With these fixes, the resync for Contiv is almost "empty" (when it should be), the only operation is modify on IPNeigh:

  * planned operations:
      1. MODIFY:
          - key: vpp/config/v2/ipneigh
          - prev-value: { mode:IPv4 scan_interval:1 max_proc_time:20 max_update:10 scan_int_delay:1 stale_threshold:4  } 
          - new-value: { mode:IPv4 scan_interval:1 stale_threshold:4  }

Default values need to be considered in the comparison function, Ondrej would you take care of it?