### PR TITLE
Fix interface counters for TX packets

### DIFF
--- a/plugins/vpp/ifplugin/interface_state_test.go
+++ b/plugins/vpp/ifplugin/interface_state_test.go
@@ -236,7 +236,7 @@ func TestInterfaceStateUpdaterVnetIntCombinedNotif(t *testing.T) {
 
 	// Test notifications
 	notifChan <- &stats.VnetInterfaceCombinedCounters{
-		VnetCounterType: 1, // TX
+		VnetCounterType: 4, // TX
 		FirstSwIfIndex:  0,
 		Count:           2,
 		Data: []stats.VlibCounter{


### PR DESCRIPTION
The interfaces stats for TX (out) packets/bytes was missing because of the wrong index for TX counters.