### PR TITLE
Changes in configuration of GoVPP

### DIFF
--- a/docker/dev/exec_agent.sh
+++ b/docker/dev/exec_agent.sh
@@ -1,1 +1,10 @@
-../prod/exec_agent.sh
+#!/usr/bin/env bash
+
+set -e
+
+if [ -n "$OMIT_AGENT" ]; then
+    echo "Start of vpp-agent disabled (unset OMIT_AGENT to enable it)"
+else
+    echo "Starting vpp-agent.."
+    exec vpp-agent --config-dir=/opt/vpp-agent/dev
+fi

--- a/docker/dev/govpp.conf
+++ b/docker/dev/govpp.conf
@@ -1,4 +1,0 @@
-health-check-probe-interval: 1000000000
-health-check-reply-timeout: 100000000
-health-check-threshold: 1
-reply-timeout: 1000000000

--- a/docker/dev/supervisord_kill.py
+++ b/docker/dev/supervisord_kill.py
@@ -1,1 +1,66 @@
-../prod/supervisord_kill.py
+#!/usr/bin/env python
+
+import sys
+import os
+import signal
+
+
+def write_stdout(msg):
+    # only eventlistener protocol messages may be sent to stdout
+    sys.stdout.write(msg)
+    sys.stdout.flush()
+
+
+def write_stderr(msg):
+    sys.stderr.write(msg)
+    sys.stderr.flush()
+
+
+def main():
+    while 1:
+        # transition from ACKNOWLEDGED to READY
+        write_stdout('READY\n')
+
+        # read header line and print it to stderr
+        line = sys.stdin.readline()
+        write_stderr('EVENT: ' + line)
+
+        # read event payload and print it to stderr
+        headers = dict([x.split(':') for x in line.split()])
+        data = sys.stdin.read(int(headers['len']))
+        write_stderr('DATA: ' + data + '\n')
+
+        # ignore non vpp events, skipping
+        parsed_data = dict([x.split(':') for x in data.split()])
+        if parsed_data["processname"] not in ["vpp", "agent"]:
+            write_stderr('Ignoring event from ' + parsed_data["processname"] + '\n')
+            write_stdout('RESULT 2\nOK')
+            continue
+
+        # ignore exits with expected exit codes
+        if parsed_data["expected"] == "1":
+            write_stderr('Exit state from ' + parsed_data["processname"] + ' was expected\n')
+            write_stdout('RESULT 2\nOK')
+            continue
+
+        # do not kill supervisor if retained and exit
+        if 'RETAIN_SUPERVISOR' in os.environ and os.environ['RETAIN_SUPERVISOR'] != '':
+            write_stderr('Supervisord is configured to retain after unexpected exits (unset RETAIN_SUPERVISOR to disable it)\n')
+            write_stdout('RESULT 2\nOK')
+            continue
+
+        try:
+            with open('/run/supervisord.pid', 'r') as pidfile:
+                pid = int(pidfile.readline())
+            write_stderr('Killing supervisord with pid: ' + str(pid) + '\n')
+            os.kill(pid, signal.SIGQUIT)
+        except Exception as e:
+            write_stderr('Could not kill supervisor: ' + str(e) + '\n')
+
+        # transition from READY to ACKNOWLEDGED
+        write_stdout('RESULT 2\nOK')
+        return
+
+
+if __name__ == '__main__':
+    main()

--- a/docker/prod/govpp.conf
+++ b/docker/prod/govpp.conf
@@ -1,4 +1,0 @@
-health-check-probe-interval: 1000000000
-health-check-reply-timeout: 100000000
-health-check-threshold: 1
-reply-timeout: 1000000000

--- a/plugins/govppmux/plugin_impl_govppmux.go
+++ b/plugins/govppmux/plugin_impl_govppmux.go
@@ -84,81 +84,94 @@ type Config struct {
 func defaultConfig() *Config {
 	return &Config{
 		HealthCheckProbeInterval: time.Second,
-		HealthCheckReplyTimeout:  100 * time.Millisecond,
+		HealthCheckReplyTimeout:  250 * time.Millisecond,
 		HealthCheckThreshold:     1,
 		ReplyTimeout:             time.Second,
 		RetryRequestTimeout:      500 * time.Millisecond,
 	}
 }
 
+func (p *Plugin) loadConfig() (*Config, error) {
+	cfg := defaultConfig()
+
+	found, err := p.Cfg.LoadValue(cfg)
+	if err != nil {
+		return nil, err
+	} else if found {
+		p.Log.Debugf("config loaded from file %q", p.Cfg.GetConfigName())
+	} else {
+		p.Log.Debugf("config file %q not found, using default config", p.Cfg.GetConfigName())
+	}
+
+	return cfg, nil
+}
+
 // Init is the entry point called by Agent Core. A single binary-API connection to VPP is established.
-func (plugin *Plugin) Init() error {
+func (p *Plugin) Init() error {
 	var err error
 
-	govppLogger := plugin.Deps.Log.NewLogger("GoVpp")
+	govppLogger := p.Deps.Log.NewLogger("govpp")
 	if govppLogger, ok := govppLogger.(*logrus.Logger); ok {
 		govppLogger.SetLevel(logging.InfoLevel)
 		govpp.SetLogger(govppLogger.StandardLogger())
 	}
 
-	plugin.PluginName = plugin.Deps.PluginName
-
-	plugin.config = defaultConfig()
-	found, err := plugin.Cfg.LoadValue(plugin.config)
-	if err != nil {
+	if p.config, err = p.loadConfig(); err != nil {
 		return err
 	}
-	if found {
-		govpp.HealthCheckProbeInterval = plugin.config.HealthCheckProbeInterval
-		govpp.HealthCheckReplyTimeout = plugin.config.HealthCheckReplyTimeout
-		govpp.HealthCheckThreshold = plugin.config.HealthCheckThreshold
-		if plugin.config.TraceEnabled {
-			plugin.tracer = measure.NewTracer("govpp-mux")
-			plugin.Log.Info("VPP API trace enabled")
-		}
+
+	p.Log.Debugf("config: %+v", p.config)
+	govpp.HealthCheckProbeInterval = p.config.HealthCheckProbeInterval
+	govpp.HealthCheckReplyTimeout = p.config.HealthCheckReplyTimeout
+	govpp.HealthCheckThreshold = p.config.HealthCheckThreshold
+	govpp.DefaultReplyTimeout = p.config.ReplyTimeout
+	if p.config.TraceEnabled {
+		p.tracer = measure.NewTracer("govpp-mux")
+		p.Log.Info("VPP API trace enabled")
 	}
 
-	if plugin.vppAdapter == nil {
-		plugin.vppAdapter = NewVppAdapter(plugin.config.ShmPrefix)
+	if p.vppAdapter == nil {
+		p.vppAdapter = NewVppAdapter(p.config.ShmPrefix)
 	} else {
-		plugin.Log.Info("Reusing existing vppAdapter") //this is used for testing purposes
+		// this is used for testing purposes
+		p.Log.Info("Reusing existing vppAdapter")
 	}
 
 	startTime := time.Now()
-	plugin.vppConn, plugin.vppConChan, err = govpp.AsyncConnect(plugin.vppAdapter)
+	p.vppConn, p.vppConChan, err = govpp.AsyncConnect(p.vppAdapter)
 	if err != nil {
 		return err
 	}
 
 	// TODO: Async connect & automatic reconnect support is not yet implemented in the agent,
 	// so synchronously wait until connected to VPP.
-	status := <-plugin.vppConChan
+	status := <-p.vppConChan
 	if status.State != govpp.Connected {
 		return errors.New("unable to connect to VPP")
 	}
 	vppConnectTime := time.Since(startTime)
-	plugin.Log.Info("Connecting to VPP took ", vppConnectTime)
-	plugin.retrieveVersion()
+	p.Log.Info("Connecting to VPP took ", vppConnectTime)
+	p.retrieveVersion()
 
 	// Register providing status reports (push mode)
-	plugin.StatusCheck.Register(plugin.PluginName, nil)
-	plugin.StatusCheck.ReportStateChange(plugin.PluginName, statuscheck.OK, nil)
+	p.StatusCheck.Register(p.PluginName, nil)
+	p.StatusCheck.ReportStateChange(p.PluginName, statuscheck.OK, nil)
 
 	var ctx context.Context
-	ctx, plugin.cancel = context.WithCancel(context.Background())
-	go plugin.handleVPPConnectionEvents(ctx)
+	ctx, p.cancel = context.WithCancel(context.Background())
+	go p.handleVPPConnectionEvents(ctx)
 
 	return nil
 }
 
 // Close cleans up the resources allocated by the govppmux plugin.
-func (plugin *Plugin) Close() error {
-	plugin.cancel()
-	plugin.wg.Wait()
+func (p *Plugin) Close() error {
+	p.cancel()
+	p.wg.Wait()
 
 	defer func() {
-		if plugin.vppConn != nil {
-			plugin.vppConn.Disconnect()
+		if p.vppConn != nil {
+			p.vppConn.Disconnect()
 		}
 	}()
 
@@ -171,19 +184,16 @@ func (plugin *Plugin) Close() error {
 // Example of binary API call from some plugin using GOVPP:
 //      ch, _ := govpp_mux.NewAPIChannel()
 //      ch.SendRequest(req).ReceiveReply
-func (plugin *Plugin) NewAPIChannel() (govppapi.Channel, error) {
-	ch, err := plugin.vppConn.NewAPIChannel()
+func (p *Plugin) NewAPIChannel() (govppapi.Channel, error) {
+	ch, err := p.vppConn.NewAPIChannel()
 	if err != nil {
 		return nil, err
 	}
-	if plugin.config.ReplyTimeout > 0 {
-		ch.SetReplyTimeout(plugin.config.ReplyTimeout)
-	}
 	retryCfg := retryConfig{
-		plugin.config.RetryRequestCount,
-		plugin.config.RetryRequestTimeout,
+		p.config.RetryRequestCount,
+		p.config.RetryRequestTimeout,
 	}
-	return &goVppChan{ch, retryCfg, plugin.tracer}, nil
+	return &goVppChan{ch, retryCfg, p.tracer}, nil
 }
 
 // NewAPIChannelBuffered returns a new API channel for communication with VPP via govpp core.
@@ -192,53 +202,50 @@ func (plugin *Plugin) NewAPIChannel() (govppapi.Channel, error) {
 // Example of binary API call from some plugin using GOVPP:
 //      ch, _ := govpp_mux.NewAPIChannelBuffered(100, 100)
 //      ch.SendRequest(req).ReceiveReply
-func (plugin *Plugin) NewAPIChannelBuffered(reqChanBufSize, replyChanBufSize int) (govppapi.Channel, error) {
-	ch, err := plugin.vppConn.NewAPIChannelBuffered(reqChanBufSize, replyChanBufSize)
+func (p *Plugin) NewAPIChannelBuffered(reqChanBufSize, replyChanBufSize int) (govppapi.Channel, error) {
+	ch, err := p.vppConn.NewAPIChannelBuffered(reqChanBufSize, replyChanBufSize)
 	if err != nil {
 		return nil, err
 	}
-	if plugin.config.ReplyTimeout > 0 {
-		ch.SetReplyTimeout(plugin.config.ReplyTimeout)
-	}
 	retryCfg := retryConfig{
-		plugin.config.RetryRequestCount,
-		plugin.config.RetryRequestTimeout,
+		p.config.RetryRequestCount,
+		p.config.RetryRequestTimeout,
 	}
-	return &goVppChan{ch, retryCfg, plugin.tracer}, nil
+	return &goVppChan{ch, retryCfg, p.tracer}, nil
 }
 
 // GetTrace returns all trace entries measured so far
-func (plugin *Plugin) GetTrace() *apitrace.Trace {
-	if !plugin.config.TraceEnabled {
-		plugin.Log.Warnf("VPP API trace is disabled")
+func (p *Plugin) GetTrace() *apitrace.Trace {
+	if !p.config.TraceEnabled {
+		p.Log.Warnf("VPP API trace is disabled")
 		return nil
 	}
-	return plugin.tracer.Get()
+	return p.tracer.Get()
 }
 
 // handleVPPConnectionEvents handles VPP connection events.
-func (plugin *Plugin) handleVPPConnectionEvents(ctx context.Context) {
-	plugin.wg.Add(1)
-	defer plugin.wg.Done()
+func (p *Plugin) handleVPPConnectionEvents(ctx context.Context) {
+	p.wg.Add(1)
+	defer p.wg.Done()
 
 	for {
 		select {
-		case status := <-plugin.vppConChan:
+		case status := <-p.vppConChan:
 			if status.State == govpp.Connected {
-				plugin.retrieveVersion()
-				if plugin.config.ReconnectResync && plugin.lastConnErr != nil {
-					plugin.Log.Info("Starting resync after VPP reconnect")
-					if plugin.Resync != nil {
-						plugin.Resync.DoResync()
-						plugin.lastConnErr = nil
+				p.retrieveVersion()
+				if p.config.ReconnectResync && p.lastConnErr != nil {
+					p.Log.Info("Starting resync after VPP reconnect")
+					if p.Resync != nil {
+						p.Resync.DoResync()
+						p.lastConnErr = nil
 					} else {
-						plugin.Log.Warn("Expected resync after VPP reconnect could not start because of missing Resync plugin")
+						p.Log.Warn("Expected resync after VPP reconnect could not start because of missing Resync plugin")
 					}
 				}
-				plugin.StatusCheck.ReportStateChange(plugin.PluginName, statuscheck.OK, nil)
+				p.StatusCheck.ReportStateChange(p.PluginName, statuscheck.OK, nil)
 			} else {
-				plugin.lastConnErr = errors.New("VPP disconnected")
-				plugin.StatusCheck.ReportStateChange(plugin.PluginName, statuscheck.Error, plugin.lastConnErr)
+				p.lastConnErr = errors.New("VPP disconnected")
+				p.StatusCheck.ReportStateChange(p.PluginName, statuscheck.Error, p.lastConnErr)
 			}
 
 		case <-ctx.Done():
@@ -247,28 +254,28 @@ func (plugin *Plugin) handleVPPConnectionEvents(ctx context.Context) {
 	}
 }
 
-func (plugin *Plugin) retrieveVersion() {
-	vppAPIChan, err := plugin.vppConn.NewAPIChannel()
+func (p *Plugin) retrieveVersion() {
+	vppAPIChan, err := p.vppConn.NewAPIChannel()
 	if err != nil {
-		plugin.Log.Error("getting new api channel failed:", err)
+		p.Log.Error("getting new api channel failed:", err)
 		return
 	}
 	defer vppAPIChan.Close()
 
 	info, err := vppcalls.GetVersionInfo(vppAPIChan)
 	if err != nil {
-		plugin.Log.Warn("getting version info failed:", err)
+		p.Log.Warn("getting version info failed:", err)
 		return
 	}
 
-	plugin.Log.Debugf("version info: %+v", info)
-	plugin.Log.Infof("VPP version: %q (%v)", info.Version, info.BuildDate)
+	p.Log.Debugf("version info: %+v", info)
+	p.Log.Infof("VPP version: %q (%v)", info.Version, info.BuildDate)
 
 	// Get VPP ACL plugin version
 	var aclVersion string
 	if aclVersion, err = vppcalls.GetACLPluginVersion(vppAPIChan); err != nil {
-		plugin.Log.Warn("getting acl version info failed:", err)
+		p.Log.Warn("getting acl version info failed:", err)
 		return
 	}
-	plugin.Log.Infof("VPP ACL plugin version: %q", aclVersion)
+	p.Log.Infof("VPP ACL plugin version: %q", aclVersion)
 }


### PR DESCRIPTION
- correctly configure GoVPP with defaults even when config file is missing
- configure `DefaultReplyTimeout` in GoVPP instead of   setting it for each request separately
- remove `govpp.conf` from docker images, forcing to use defaults (which were same as in config file)
- change default for health check reply timeout to **250ms**, because it seems that **100ms** is just too short period