### PR TITLE
POC: logically grouped configuration items.

### DIFF
--- a/plugins/kvscheduler/api/kv_scheduler_api.go
+++ b/plugins/kvscheduler/api/kv_scheduler_api.go
@@ -262,7 +262,7 @@ type KVScheduler interface {
 type Txn interface {
 	// SetValue changes (non-derived) value.
 	// If <value> is nil, the value will get deleted.
-	SetValue(key string, value proto.Message) Txn
+	SetValue(key string, value proto.Message, groupings []string) Txn
 
 	// Commit orders scheduler to execute enqueued operations.
 	// Operations with unmet dependencies will get postponed and possibly

--- a/plugins/kvscheduler/txn_exec.go
+++ b/plugins/kvscheduler/txn_exec.go
@@ -106,6 +106,7 @@ func (s *Scheduler) executeTransaction(txn *transaction, dryRun bool) (executed 
 						value:    kvPair.Value,
 						origin:   kvs.FromNB,
 						isRevert: true,
+						// TODO: groupings
 					},
 					baseKey: kvPair.Key,
 					dryRun:  dryRun,
@@ -178,6 +179,7 @@ func (s *Scheduler) applyValue(args *applyValueArgs) (executed kvs.RecordedTxnOp
 		txnSeqNum: args.txn.seqNum,
 		txnOp:     txnOp.Operation,
 		value:     args.kv.value,
+		groupings: args.kv.groupings,
 		revert:    args.kv.isRevert,
 	}
 	if args.txn.txnType == kvs.NBTransaction {
@@ -285,10 +287,11 @@ func (s *Scheduler) applyDelete(node graph.NodeRW, txnOp *kvs.RecordedTxnOp, arg
 		var derivedVals []kvForTxn
 		for _, derivedNode := range getDerivedNodes(node) {
 			derivedVals = append(derivedVals, kvForTxn{
-				key:      derivedNode.GetKey(),
-				value:    nil, // delete
-				origin:   args.kv.origin,
-				isRevert: args.kv.isRevert,
+				key:       derivedNode.GetKey(),
+				value:     nil, // delete
+				origin:    args.kv.origin,
+				groupings: args.kv.groupings,
+				isRevert:  args.kv.isRevert,
 			})
 		}
 		derExecs, inheritedErr := s.applyDerived(derivedVals, args, false)
@@ -443,10 +446,11 @@ func (s *Scheduler) applyAdd(node graph.NodeRW, txnOp *kvs.RecordedTxnOp, args *
 		var derivedVals []kvForTxn
 		for _, derivedVal := range derives {
 			derivedVals = append(derivedVals, kvForTxn{
-				key:      derivedVal.Key,
-				value:    derivedVal.Value,
-				origin:   args.kv.origin,
-				isRevert: args.kv.isRevert,
+				key:       derivedVal.Key,
+				value:     derivedVal.Value,
+				origin:    args.kv.origin,
+				groupings: args.kv.groupings,
+				isRevert:  args.kv.isRevert,
 			})
 		}
 		derExecs, inheritedErr := s.applyDerived(derivedVals, args, true)
@@ -596,10 +600,11 @@ func (s *Scheduler) applyModify(node graph.NodeRW, txnOp *kvs.RecordedTxnOp, arg
 		var derivedVals []kvForTxn
 		for _, derivedVal := range derives {
 			derivedVals = append(derivedVals, kvForTxn{
-				key:      derivedVal.Key,
-				value:    derivedVal.Value,
-				origin:   args.kv.origin,
-				isRevert: args.kv.isRevert,
+				key:       derivedVal.Key,
+				value:     derivedVal.Value,
+				origin:    args.kv.origin,
+				groupings: args.kv.groupings,
+				isRevert:  args.kv.isRevert,
 			})
 		}
 		derExecs, inheritedErr := s.applyDerived(derivedVals, args, true)
@@ -636,10 +641,11 @@ func (s *Scheduler) applyNewRelations(node graph.NodeRW, handler *descriptorHand
 	prevDerived.Subtract(getDerivedKeys(node))
 	for _, obsolete := range prevDerived.Iterate() {
 		obsoleteDerVals = append(obsoleteDerVals, kvForTxn{
-			key:      obsolete,
-			value:    nil, // delete
-			origin:   args.kv.origin,
-			isRevert: args.kv.isRevert,
+			key:       obsolete,
+			value:     nil, // delete
+			origin:    args.kv.origin,
+			groupings: args.kv.groupings,
+			isRevert:  args.kv.isRevert,
 		})
 	}
 	executed, err = s.applyDerived(obsoleteDerVals, args, false)
@@ -687,21 +693,24 @@ func (s *Scheduler) runUpdates(node graph.Node, args *applyValueArgs) (executed 
 		if getNodeOrigin(depNode) != kvs.FromNB {
 			continue
 		}
+		var groupings []string
 		value := depNode.GetValue()
 		lastUpdate := getNodeLastUpdate(depNode)
 		if lastUpdate != nil {
 			// anything but state=FOUND
 			value = lastUpdate.value
+			groupings = lastUpdate.groupings
 		}
 		ops, _, _ := s.applyValue(
 			&applyValueArgs{
 				graphW: args.graphW,
 				txn:    args.txn,
 				kv: kvForTxn{
-					key:      depNode.GetKey(),
-					value:    value,
-					origin:   getNodeOrigin(depNode),
-					isRevert: args.kv.isRevert,
+					key:       depNode.GetKey(),
+					value:     value,
+					origin:    getNodeOrigin(depNode),
+					groupings: groupings,
+					isRevert:  args.kv.isRevert,
 				},
 				baseKey:   getNodeBaseKey(depNode),
 				isRetry:   args.isRetry,

--- a/plugins/kvscheduler/txn_process.go
+++ b/plugins/kvscheduler/txn_process.go
@@ -39,11 +39,12 @@ type transaction struct {
 
 // kvForTxn represents a new value for a given key to be applied in a transaction.
 type kvForTxn struct {
-	key      string
-	value    proto.Message
-	metadata kvs.Metadata
-	origin   kvs.ValueOrigin
-	isRevert bool
+	key       string
+	value     proto.Message
+	metadata  kvs.Metadata
+	origin    kvs.ValueOrigin
+	groupings []string
+	isRevert  bool
 }
 
 // nbTxn encapsulates data for NB transaction.
@@ -192,10 +193,11 @@ func (s *Scheduler) preProcessNBTransaction(txn *transaction) (skip bool) {
 			lastUpdate := getNodeLastUpdate(node)
 			txn.values = append(txn.values,
 				kvForTxn{
-					key:      node.GetKey(),
-					value:    lastUpdate.value,
-					origin:   kvs.FromNB,
-					isRevert: lastUpdate.revert,
+					key:       node.GetKey(),
+					value:     lastUpdate.value,
+					groupings: lastUpdate.groupings,
+					origin:    kvs.FromNB,
+					isRevert:  lastUpdate.revert,
 				})
 		}
 	}
@@ -264,10 +266,11 @@ func (s *Scheduler) preProcessRetryTxn(txn *transaction) (skip bool) {
 		}
 		txn.values = append(txn.values,
 			kvForTxn{
-				key:      key,
-				value:    lastUpdate.value,
-				origin:   kvs.FromNB,
-				isRevert: lastUpdate.revert,
+				key:       key,
+				value:     lastUpdate.value,
+				groupings: lastUpdate.groupings,
+				origin:    kvs.FromNB,
+				isRevert:  lastUpdate.revert,
 			})
 	}
 	skip = len(txn.values) == 0

--- a/plugins/kvscheduler/value_flags.go
+++ b/plugins/kvscheduler/value_flags.go
@@ -55,6 +55,7 @@ type LastUpdateFlag struct {
 	txnSeqNum uint64
 	txnOp     kvs.TxnOperation
 	value     proto.Message
+	groupings []string
 
 	// updated only when the value content is being modified
 	revert bool

--- a/plugins/orchestrator/dispatcher.go
+++ b/plugins/orchestrator/dispatcher.go
@@ -267,10 +267,10 @@ func (p *Plugin) PushData(ctx context.Context, kvPairs []KeyValuePair) (kvErrs [
 		p.Log.Debugf(" - PUT: %q ", kv.Key)
 
 		if kv.Value == nil {
-			txn.SetValue(kv.Key, nil)
+			txn.SetValue(kv.Key, nil, nil)
 			p.store.Delete(kv.Key)
 		} else {
-			txn.SetValue(kv.Key, kv.Value)
+			txn.SetValue(kv.Key, kv.Value, nil)
 			p.store.Update(kv.Key, kv.Value)
 		}
 	}


### PR DESCRIPTION
This is just a POC code to spark a further discussion on assigning user-defined scheduler-opaque logical meta information to key-value pairs. Here I have just played with what I called `groupings` - a slice of potentially nested groups a value belongs to. I have used slice instead of map because it gives me an order that can be used to represent nesting.

For a complex project like Contiv, we can use groupings to define logical clusters for a more readable graph visualization. For example, configuration items grouped by pods: https://pasteboard.co/HYQMOTT.png. The grouped items in the example use groupings: `["Pods", <pod-name>]` (i.e. every pod is a separate cluster nested inside "Pods", which is nested inside the main cluster).

My suggestion is to consider extending value definition to:
```
Config proto.Message
State proto.Message (state data + what is currently known as metadata)
Meta []string (or map if we can easily define nesting)
```

Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>