### PR TITLE
kvscheduler bugfix: revert only if failed value is from the current txn

### DIFF
--- a/plugins/kvscheduler/graphviz.go
+++ b/plugins/kvscheduler/graphviz.go
@@ -183,12 +183,15 @@ func (s *Scheduler) renderDotOutput(graphNodes []*graph.RecordedNode, txn *kvs.R
 			c = c.Clusters[descriptorName]
 		}
 
-		valueState := kvs.ValueState_MISSING // missing dependencies
+		var valueState kvs.ValueState
 		stateFlag := graphNode.GetFlag(ValueStateFlagName)
 		if stateFlag != nil {
 			valueState = stateFlag.(*ValueStateFlag).valueState
 		}
 		switch valueState {
+		case kvs.ValueState_NONEXISTENT:
+			attrs["fontcolor"] = "White"
+			attrs["fillcolor"] = "Black"
 		case kvs.ValueState_MISSING:
 			attrs["fillcolor"] = "Dimgray"
 			attrs["style"] = "dashed,filled"

--- a/plugins/kvscheduler/internal/graph/graph_read.go
+++ b/plugins/kvscheduler/internal/graph/graph_read.go
@@ -117,11 +117,12 @@ func (graph *graphR) GetFlagStats(flagName string, selector KeySelector) FlagSta
 		if selector != nil && !selector(key) {
 			continue
 		}
-		for _, record := range timeline {
+		for /*idx*/_, record := range timeline {
 			if record.TargetUpdateOnly {
 				continue
 			}
 			if flag := record.Flags.GetFlag(flagName); flag != nil {
+				//fmt.Printf("Found flag %s in %dth record of %s\n", flagName, idx, record.Key)
 				flagValue := flag.GetValue()
 				stats.TotalCount++
 				if _, hasValue := stats.PerValueCount[flagValue]; !hasValue {

--- a/plugins/kvscheduler/internal/test/values.go
+++ b/plugins/kvscheduler/internal/test/values.go
@@ -19,40 +19,9 @@ package test
 import (
 	"github.com/gogo/protobuf/proto"
 
-	"github.com/ligato/cn-infra/datasync"
 	. "github.com/ligato/vpp-agent/plugins/kvscheduler/api"
 	. "github.com/ligato/vpp-agent/plugins/kvscheduler/internal/test/model"
 )
-
-// LazyArrayValue implements datasync.LazyValue for ArrayValue.
-type LazyArrayValue struct {
-	items []string
-}
-
-// LazyStringValue implements datasync.LazyValue for StringValue.
-type LazyStringValue struct {
-	value string
-}
-
-// GetValue unmarshalls ArrayValue into the given proto.Message.
-func (lav *LazyArrayValue) GetValue(value proto.Message) error {
-	av := NewArrayValue(lav.items...)
-	tmp, err := proto.Marshal(av)
-	if err != nil {
-		return err
-	}
-	return proto.Unmarshal(tmp, value)
-}
-
-// GetValue unmarshalls StringValue into the given proto.Message.
-func (lsv *LazyStringValue) GetValue(value proto.Message) error {
-	sv := NewStringValue(lsv.value)
-	tmp, err := proto.Marshal(sv)
-	if err != nil {
-		return err
-	}
-	return proto.Unmarshal(tmp, value)
-}
 
 // NewStringValue creates a new instance of StringValue.
 func NewStringValue(str string) proto.Message {
@@ -62,18 +31,6 @@ func NewStringValue(str string) proto.Message {
 // NewArrayValue creates a new instance of ArrayValue.
 func NewArrayValue(items ...string) proto.Message {
 	return &ArrayValue{Items: items}
-}
-
-// NewLazyStringValue creates a new instance of lazy (marshalled) StringValue.
-func NewLazyStringValue(str string) datasync.LazyValue {
-	return &LazyStringValue{value: str}
-}
-
-// NewLazyArrayValue creates a new instance of lazy (marshalled) ArrayValue.
-func NewLazyArrayValue(items ...string) datasync.LazyValue {
-	return &LazyArrayValue{
-		items: items,
-	}
 }
 
 // StringValueComparator is (a custom) KVDescriptor.ValueComparator for string values.

--- a/plugins/kvscheduler/plugin_scheduler.go
+++ b/plugins/kvscheduler/plugin_scheduler.go
@@ -324,9 +324,10 @@ func (s *Scheduler) DumpValuesByDescriptor(descriptor string, view kvs.View) (va
 				continue
 			}
 			kvPairs = append(kvPairs, kvs.KVWithMetadata{
-				Key:    node.GetKey(),
-				Value:  lastUpdate.value,
-				Origin: kvs.FromNB,
+				Key:      node.GetKey(),
+				Value:    lastUpdate.value,
+				Origin:   kvs.FromNB,
+				Metadata: node.GetMetadata(),
 			})
 		}
 		return kvPairs, nil


### PR DESCRIPTION
Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>