### PR TITLE
Fix ready-test for newer etcd versions

### DIFF
--- a/tests/robot/libraries/docker.robot
+++ b/tests/robot/libraries/docker.robot
@@ -187,7 +187,7 @@ Check ETCD Running
 Start ETCD Server
     Open SSH Connection    etcd    ${DOCKER_HOST_IP}    ${DOCKER_HOST_USER}    ${DOCKER_HOST_PSWD}
     Execute On Machine    etcd    ${ETCD_SERVER_CREATE}
-    ${out}=  Write To Machine Until String    etcd    ${DOCKER_COMMAND} start -i etcd    etcdmain: ready to serve client requests
+    ${out}=  Write To Machine Until String    etcd    ${DOCKER_COMMAND} start -i etcd    ready to serve client requests
 #    ${hostname}=    Execute On Machine    docker    ${DOCKER_COMMAND} exec etcd bash -c 'echo $HOSTNAME'
 #   etcd nema bash, preto dame hostname natvrdo
     ${hostname}=    Set Variable    etcd


### PR DESCRIPTION
The version quay.io/coreos/etcd:v3.3.11-arm64 outputs the string 'embed: ready to serve client requests'.