### PR TITLE
fixed af-packet mac address update

### DIFF
--- a/plugins/vpp/ifplugin/descriptor/interface.go
+++ b/plugins/vpp/ifplugin/descriptor/interface.go
@@ -412,6 +412,11 @@ func (d *InterfaceDescriptor) UpdateWithRecreate(key string, oldIntf, newIntf *i
 		return true
 	}
 
+	// case for af-packet mac update (cannot be updated directly)
+	if oldIntf.GetType() == interfaces.Interface_AF_PACKET && oldIntf.PhysAddress != newIntf.PhysAddress {
+		return true
+	}
+
 	return false
 }
 

--- a/plugins/vpp/ifplugin/descriptor/interface_crud.go
+++ b/plugins/vpp/ifplugin/descriptor/interface_crud.go
@@ -177,6 +177,7 @@ func (d *InterfaceDescriptor) Create(key string, intf *interfaces.Interface) (me
 
 	// MAC address. Note: physical interfaces cannot have the MAC address changed
 	if intf.GetPhysAddress() != "" &&
+		intf.GetType() != interfaces.Interface_AF_PACKET &&
 		intf.GetType() != interfaces.Interface_DPDK {
 		if err = d.ifHandler.SetInterfaceMac(ifIdx, intf.GetPhysAddress()); err != nil {
 			err = errors.Errorf("failed to set MAC address %s to interface %s: %v",
@@ -357,6 +358,7 @@ func (d *InterfaceDescriptor) Update(key string, oldIntf, newIntf *interfaces.In
 	// configure new MAC address if set (and only if it was changed and only for supported interface type)
 	if newIntf.PhysAddress != "" &&
 		newIntf.PhysAddress != oldIntf.PhysAddress &&
+		oldIntf.Type != interfaces.Interface_AF_PACKET &&
 		oldIntf.Type != interfaces.Interface_DPDK {
 		if err := d.ifHandler.SetInterfaceMac(ifIdx, newIntf.PhysAddress); err != nil {
 			err = errors.Errorf("setting interface %s MAC address %s failed: %v",


### PR DESCRIPTION
The af-packet mac address cannot be set properly using the 'sw_interface_set_mac_address' since this change causes that the mac address of the adjacent veth interface to change as well. The mac address is set directly in create/delete api for af-packets, so the interface should be re-created at update if the mac was changed.

Signed-off-by: Vladimir Lavor <vlavor@cisco.com>