### PR TITLE
do not set interface back to zero vrf only if the interface is unnumbered

### DIFF
--- a/plugins/vpp/ifplugin/descriptor/interface.go
+++ b/plugins/vpp/ifplugin/descriptor/interface.go
@@ -643,12 +643,6 @@ func getIPAddressVersions(ipAddrs []*net.IPNet) (isIPv4, isIPv6 bool) {
 
 // setInterfaceVrf sets the interface to VRF according to versions of IP addresses configured on the interface.
 func setInterfaceVrf(ifHandler vppcalls.InterfaceVppAPI, ifName string, ifIdx uint32, vrf uint32, ipAddresses []*net.IPNet) error {
-	if vrf == 0 {
-		// explicit set to VRF 0 seems to be causing issues on VPP
-		// NOTE: because of this return, this function cannot be used to switch VRF from non-zero to zero
-		// (can be only used to put a newly created interface to a VRF)
-		return nil
-	}
 	isIPv4, isIPv6 := getIPAddressVersions(ipAddresses)
 	if isIPv4 {
 		if err := ifHandler.SetInterfaceVrf(ifIdx, vrf); err != nil {

--- a/plugins/vpp/ifplugin/descriptor/unnumbered.go
+++ b/plugins/vpp/ifplugin/descriptor/unnumbered.go
@@ -105,10 +105,17 @@ func (d *UnnumberedIfDescriptor) Create(key string, unIntf *interfaces.Interface
 	}
 
 	// VRF (optional), should be done before setting as unnumbered
-	err = setInterfaceVrf(d.ifHandler, ifName, ifMeta.SwIfIndex, ifMeta.Vrf, ipAddresses)
-	if err != nil {
-		d.log.Error(err)
-		return nil, err
+	if ifMeta.Vrf == 0 {
+		// explicit set to VRF 0 seems to be causing issues on VPP
+		// NOTE: because of this return, this function cannot be used to switch VRF from non-zero to zero
+		// (can be only used to put a newly created interface to a VRF)
+		d.log.Debugf("Set VRF to 0 for unnumbered interface is not allowed")
+	} else {
+		err = setInterfaceVrf(d.ifHandler, ifName, ifMeta.SwIfIndex, ifMeta.Vrf, ipAddresses)
+		if err != nil {
+			d.log.Error(err)
+			return nil, err
+		}
 	}
 
 	err = d.ifHandler.SetUnnumberedIP(ifMeta.SwIfIndex, ifWithIPMeta.SwIfIndex)


### PR DESCRIPTION
Signed-off-by: Vladimir Lavor <vlavor@cisco.com>