### PR TITLE
Fixes and improvements

### DIFF
--- a/pkg/idxvpp/idxvpp.go
+++ b/pkg/idxvpp/idxvpp.go
@@ -23,6 +23,8 @@ import (
 	"github.com/ligato/cn-infra/logging"
 )
 
+var DefaultNotifTimeout = time.Millisecond * 100
+
 // WithIndex is interface that items with integer handle must implement to get
 // indexed by NameToIndex.
 type WithIndex interface {
@@ -153,7 +155,7 @@ func (idx *nameToIndex) WatchItems(subscriber string, channel chan<- NameToIndex
 		}
 		select {
 		case channel <- msg:
-		case <-time.After(idxmap.DefaultNotifTimeout):
+		case <-time.After(DefaultNotifTimeout):
 			idx.log.Warn("Unable to deliver notification")
 		}
 	}

--- a/plugins/govppmux/govpp_channel_test.go
+++ b/plugins/govppmux/govpp_channel_test.go
@@ -1,0 +1,100 @@
+//  Copyright (c) 2019 Cisco and/or its affiliates.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at:
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package govppmux
+
+import (
+	"testing"
+	"time"
+
+	"git.fd.io/govpp.git/core"
+	"github.com/ligato/vpp-agent/tests/vppcallmock"
+	. "github.com/onsi/gomega"
+)
+
+func TestRequestRetry(t *testing.T) {
+	tests := []struct {
+		name        string
+		attempts    int
+		timeout     time.Duration
+		retErrs     []error
+		expErr      error
+		expAttempts int
+	}{
+		{name: "no retry fail",
+			attempts:    0,
+			timeout:     time.Millisecond,
+			retErrs:     []error{core.ErrNotConnected},
+			expErr:      core.ErrNotConnected,
+			expAttempts: 0,
+		},
+		{name: "1 retry ok",
+			attempts:    1,
+			timeout:     time.Millisecond,
+			retErrs:     []error{core.ErrNotConnected},
+			expErr:      nil,
+			expAttempts: 1,
+		},
+		{name: "3 retries fail",
+			attempts:    3,
+			timeout:     time.Millisecond,
+			retErrs:     []error{core.ErrNotConnected, core.ErrNotConnected, core.ErrNotConnected, core.ErrNotConnected},
+			expErr:      core.ErrNotConnected,
+			expAttempts: 3,
+		},
+		{name: "no retry attempt",
+			attempts:    3,
+			timeout:     time.Millisecond,
+			retErrs:     []error{core.ErrInvalidRequestCtx},
+			expErr:      core.ErrInvalidRequestCtx,
+			expAttempts: 0,
+		},
+
+		{name: "3 retries ok",
+			attempts:    3,
+			timeout:     time.Millisecond,
+			retErrs:     []error{core.ErrNotConnected, core.ErrNotConnected, core.ErrNotConnected},
+			expErr:      nil,
+			expAttempts: 3,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := vppcallmock.SetupTestCtx(t)
+			defer ctx.TeardownTestCtx()
+
+			retryCfg := retryConfig{test.attempts, test.timeout}
+			ch := newGovppChan(ctx.MockChannel, retryCfg, nil)
+
+			ctx.MockChannel.RetErrs = test.retErrs
+
+			ctx.MockVpp.MockReply(&core.ControlPingReply{})
+			for i := 0; i < test.attempts; i++ {
+				ctx.MockVpp.MockReply(&core.ControlPingReply{})
+			}
+
+			req := &core.ControlPing{}
+			reply := &core.ControlPingReply{}
+			reqCtx := ch.SendRequest(req)
+			err := reqCtx.ReceiveReply(reply)
+
+			if test.expErr == nil {
+				Expect(err).Should(Succeed())
+			} else {
+				Expect(err).Should(HaveOccurred())
+			}
+			Expect(ctx.MockChannel.Msgs).To(HaveLen(test.expAttempts + 1))
+		})
+	}
+}

--- a/plugins/govppmux/plugin_impl_govppmux.go
+++ b/plugins/govppmux/plugin_impl_govppmux.go
@@ -243,7 +243,7 @@ func (p *Plugin) NewAPIChannel() (govppapi.Channel, error) {
 		p.config.RetryRequestCount,
 		p.config.RetryRequestTimeout,
 	}
-	return &goVppChan{ch, retryCfg, p.tracer}, nil
+	return newGovppChan(ch, retryCfg, p.tracer), nil
 }
 
 // NewAPIChannelBuffered returns a new API channel for communication with VPP via govpp core.
@@ -261,7 +261,7 @@ func (p *Plugin) NewAPIChannelBuffered(reqChanBufSize, replyChanBufSize int) (go
 		p.config.RetryRequestCount,
 		p.config.RetryRequestTimeout,
 	}
-	return &goVppChan{ch, retryCfg, p.tracer}, nil
+	return newGovppChan(ch, retryCfg, p.tracer), nil
 }
 
 // GetTrace returns all trace entries measured so far

--- a/plugins/govppmux/vppcalls/vpp1901/vpe_vppcalls.go
+++ b/plugins/govppmux/vppcalls/vpp1901/vpe_vppcalls.go
@@ -16,7 +16,6 @@ package vpp1901
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 
 	govppapi "git.fd.io/govpp.git/api"
@@ -112,8 +111,6 @@ func (h *VpeHandler) RunCli(cmd string) (string, error) {
 
 	if err := h.ch.SendRequest(req).ReceiveReply(reply); err != nil {
 		return "", err
-	} else if reply.Retval != 0 {
-		return "", fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
 	}
 
 	return reply.Reply, nil

--- a/plugins/kvscheduler/api/kv_scheduler_api.go
+++ b/plugins/kvscheduler/api/kv_scheduler_api.go
@@ -18,10 +18,10 @@ package api
 
 import (
 	"context"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/ligato/cn-infra/idxmap"
-	"time"
 )
 
 // KeySelector is used to filter keys.

--- a/plugins/kvscheduler/txn_exec.go
+++ b/plugins/kvscheduler/txn_exec.go
@@ -337,8 +337,7 @@ func (s *Scheduler) applyDelete(node graph.NodeRW, txnOp *kvs.RecordedTxnOp, arg
 		}
 		if err != nil {
 			retriableErr = handler.isRetriableFailure(err)
-		}
-		if canNodeHaveMetadata(node) && descriptor.WithMetadata {
+		} else if canNodeHaveMetadata(node) && descriptor.WithMetadata {
 			node.SetMetadata(nil)
 		}
 	}

--- a/plugins/orchestrator/dispatcher.go
+++ b/plugins/orchestrator/dispatcher.go
@@ -103,7 +103,7 @@ func (p *dispatcher) PushData(ctx context.Context, kvPairs []KeyVal) (kvErrs []k
 			kvErrs = txErr.GetKVErrors()
 			var errInfo = ""
 			for i, kvErr := range kvErrs {
-				errInfo += fmt.Sprintf(" - %d. error (%s) %s - %+v\n", i+1, kvErr.TxnOperation, kvErr.Key, kvErr.Error)
+				errInfo += fmt.Sprintf(" - %3d. error (%s) %s - %v\n", i+1, kvErr.TxnOperation, kvErr.Key, kvErr.Error)
 			}
 			p.log.Errorf("Transaction #%d finished with %d errors", seqID, len(kvErrs))
 			fmt.Println(errInfo)

--- a/plugins/vpp/ifplugin/ifaceidx/ifaceidx.go
+++ b/plugins/vpp/ifplugin/ifaceidx/ifaceidx.go
@@ -155,10 +155,12 @@ func (ifmx *ifaceMetadataIndex) WatchInterfaces(subscriber string, channel chan<
 			NamedMappingEvent: dto.NamedMappingEvent,
 			Metadata:          typedMeta,
 		}
+		timeout := idxmap.DefaultNotifTimeout
 		select {
 		case channel <- msg:
-		case <-time.After(idxmap.DefaultNotifTimeout):
-			ifmx.log.Warn("Unable to deliver notification")
+			// OK
+		case <-time.After(timeout):
+			ifmx.log.Warnf("Unable to deliver interface watch notification after %v, channel is full", timeout)
 		}
 	}
 	if err := ifmx.Watch(subscriber, watcher); err != nil {

--- a/plugins/vpp/ifplugin/interface_state.go
+++ b/plugins/vpp/ifplugin/interface_state.go
@@ -106,7 +106,7 @@ func (c *InterfaceStateUpdater) Init(ctx context.Context, logger logging.PluginL
 
 	c.ifHandler = vppcalls.CompatibleInterfaceVppHandler(c.vppCh, logger.NewLogger("if-handler"))
 
-	c.ifMetaChan = make(chan ifaceidx.IfaceMetadataDto, 100)
+	c.ifMetaChan = make(chan ifaceidx.IfaceMetadataDto, 1000)
 	swIfIndexes.WatchInterfaces("ifplugin_ifstate", c.ifMetaChan)
 
 	c.ifEvents = make(chan *vppcalls.InterfaceEvent)

--- a/plugins/vpp/ifplugin/publish_state.go
+++ b/plugins/vpp/ifplugin/publish_state.go
@@ -112,7 +112,7 @@ func (p *IfPlugin) publishIfStateEvents() {
 			}
 
 			// Send interface state data to global agent status
-			if p.statusCheckReg {
+			if p.statusCheckReg && ifState.State.InternalName != "" {
 				p.StatusCheck.ReportStateChangeWithMeta(p.PluginName, statuscheck.OK, nil, &status.InterfaceStats_Interface{
 					InternalName: ifState.State.InternalName,
 					Index:        ifState.State.IfIndex,

--- a/plugins/vpp/ifplugin/vppcalls/vpp1810/ipsec_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp1810/ipsec_vppcalls.go
@@ -16,7 +16,6 @@ package vpp1810
 
 import (
 	"encoding/hex"
-	"fmt"
 	"net"
 
 	interfaces "github.com/ligato/vpp-agent/api/models/vpp/interfaces"
@@ -77,8 +76,6 @@ func (h *InterfaceVppHandler) tunnelIfAddDel(ifName string, ipSecLink *interface
 
 	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return 0, err
-	} else if reply.Retval != 0 {
-		return 0, fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
 	}
 
 	return reply.SwIfIndex, nil

--- a/plugins/vpp/ifplugin/vppcalls/vpp1810/tap_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp1810/tap_vppcalls.go
@@ -16,7 +16,6 @@ package vpp1810
 
 import (
 	"errors"
-	"fmt"
 
 	interfaces "github.com/ligato/vpp-agent/api/models/vpp/interfaces"
 	"github.com/ligato/vpp-agent/plugins/vpp/binapi/vpp1810/tap"
@@ -29,10 +28,6 @@ func (h *InterfaceVppHandler) AddTapInterface(ifName string, tapIf *interfaces.T
 		return 0, errors.New("host interface name was not provided for the TAP interface")
 	}
 
-	var (
-		retval  int32
-		msgName string
-	)
 	if tapIf.Version == 2 {
 		// Configure fast virtio-based TAP interface
 		req := &tapv2.TapCreateV2{
@@ -46,9 +41,7 @@ func (h *InterfaceVppHandler) AddTapInterface(ifName string, tapIf *interfaces.T
 
 		reply := &tapv2.TapCreateV2Reply{}
 		err = h.callsChannel.SendRequest(req).ReceiveReply(reply)
-		retval = reply.Retval
 		swIfIdx = reply.SwIfIndex
-		msgName = reply.GetMessageName()
 	} else {
 		// Configure the original TAP interface
 		req := &tap.TapConnect{
@@ -58,15 +51,10 @@ func (h *InterfaceVppHandler) AddTapInterface(ifName string, tapIf *interfaces.T
 
 		reply := &tap.TapConnectReply{}
 		err = h.callsChannel.SendRequest(req).ReceiveReply(reply)
-		retval = reply.Retval
 		swIfIdx = reply.SwIfIndex
-		msgName = reply.GetMessageName()
 	}
 	if err != nil {
 		return 0, err
-	}
-	if retval != 0 {
-		return 0, fmt.Errorf("%s returned %d", msgName, retval)
 	}
 
 	return swIfIdx, h.SetInterfaceTag(ifName, swIfIdx)
@@ -74,11 +62,8 @@ func (h *InterfaceVppHandler) AddTapInterface(ifName string, tapIf *interfaces.T
 
 // DeleteTapInterface implements interface handler.
 func (h *InterfaceVppHandler) DeleteTapInterface(ifName string, idx uint32, version uint32) error {
-	var (
-		err     error
-		retval  int32
-		msgName string
-	)
+	var err error
+
 	if version == 2 {
 		req := &tapv2.TapDeleteV2{
 			SwIfIndex: idx,
@@ -86,8 +71,6 @@ func (h *InterfaceVppHandler) DeleteTapInterface(ifName string, idx uint32, vers
 
 		reply := &tapv2.TapDeleteV2Reply{}
 		err = h.callsChannel.SendRequest(req).ReceiveReply(reply)
-		retval = reply.Retval
-		msgName = reply.GetMessageName()
 	} else {
 		req := &tap.TapDelete{
 			SwIfIndex: idx,
@@ -95,14 +78,9 @@ func (h *InterfaceVppHandler) DeleteTapInterface(ifName string, idx uint32, vers
 
 		reply := &tap.TapDeleteReply{}
 		err = h.callsChannel.SendRequest(req).ReceiveReply(reply)
-		retval = reply.Retval
-		msgName = reply.GetMessageName()
 	}
 	if err != nil {
 		return err
-	}
-	if retval != 0 {
-		return fmt.Errorf("%s returned %d", msgName, retval)
 	}
 
 	return h.RemoveInterfaceTag(ifName, idx)

--- a/plugins/vpp/ifplugin/vppcalls/vpp1810/vmxnet3_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp1810/vmxnet3_vppcalls.go
@@ -17,7 +17,8 @@ package vpp1810
 import (
 	"fmt"
 
-	"github.com/go-errors/errors"
+	"github.com/pkg/errors"
+
 	interfaces "github.com/ligato/vpp-agent/api/models/vpp/interfaces"
 	"github.com/ligato/vpp-agent/plugins/vpp/binapi/vpp1810/vmxnet3"
 )
@@ -43,8 +44,6 @@ func (h *InterfaceVppHandler) AddVmxNet3(ifName string, vmxNet3 *interfaces.VmxN
 	reply := &vmxnet3.Vmxnet3CreateReply{}
 	if err = h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return 0, errors.Errorf(err.Error())
-	} else if reply.Retval != 0 {
-		return 0, errors.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
 	}
 
 	return reply.SwIfIndex, h.SetInterfaceTag(ifName, reply.SwIfIndex)
@@ -58,8 +57,6 @@ func (h *InterfaceVppHandler) DeleteVmxNet3(ifName string, ifIdx uint32) error {
 	reply := &vmxnet3.Vmxnet3DeleteReply{}
 	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return errors.Errorf(err.Error())
-	} else if reply.Retval != 0 {
-		return errors.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
 	}
 
 	return h.RemoveInterfaceTag(ifName, ifIdx)

--- a/plugins/vpp/ifplugin/vppcalls/vpp1901/ipsec_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp1901/ipsec_vppcalls.go
@@ -16,7 +16,6 @@ package vpp1901
 
 import (
 	"encoding/hex"
-	"fmt"
 	"net"
 
 	interfaces "github.com/ligato/vpp-agent/api/models/vpp/interfaces"
@@ -77,8 +76,6 @@ func (h *InterfaceVppHandler) tunnelIfAddDel(ifName string, ipSecLink *interface
 
 	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return 0, err
-	} else if reply.Retval != 0 {
-		return 0, fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
 	}
 
 	return reply.SwIfIndex, nil

--- a/plugins/vpp/ifplugin/vppcalls/vpp1901/vmxnet3_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp1901/vmxnet3_vppcalls.go
@@ -17,7 +17,8 @@ package vpp1901
 import (
 	"fmt"
 
-	"github.com/go-errors/errors"
+	"github.com/pkg/errors"
+
 	interfaces "github.com/ligato/vpp-agent/api/models/vpp/interfaces"
 	"github.com/ligato/vpp-agent/plugins/vpp/binapi/vpp1901/vmxnet3"
 )
@@ -43,8 +44,6 @@ func (h *InterfaceVppHandler) AddVmxNet3(ifName string, vmxNet3 *interfaces.VmxN
 	reply := &vmxnet3.Vmxnet3CreateReply{}
 	if err = h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return 0, errors.Errorf(err.Error())
-	} else if reply.Retval != 0 {
-		return 0, errors.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
 	}
 
 	return reply.SwIfIndex, h.SetInterfaceTag(ifName, reply.SwIfIndex)
@@ -58,8 +57,6 @@ func (h *InterfaceVppHandler) DeleteVmxNet3(ifName string, ifIdx uint32) error {
 	reply := &vmxnet3.Vmxnet3DeleteReply{}
 	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return errors.Errorf(err.Error())
-	} else if reply.Retval != 0 {
-		return errors.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
 	}
 
 	return h.RemoveInterfaceTag(ifName, ifIdx)

--- a/plugins/vpp/ipsecplugin/descriptor/sa.go
+++ b/plugins/vpp/ipsecplugin/descriptor/sa.go
@@ -17,8 +17,9 @@ package descriptor
 import (
 	"strconv"
 
-	"github.com/go-errors/errors"
 	"github.com/ligato/cn-infra/logging"
+	"github.com/pkg/errors"
+
 	ipsec "github.com/ligato/vpp-agent/api/models/vpp/ipsec"
 	kvs "github.com/ligato/vpp-agent/plugins/kvscheduler/api"
 	"github.com/ligato/vpp-agent/plugins/vpp/ipsecplugin/descriptor/adapter"

--- a/plugins/vpp/ipsecplugin/descriptor/spd.go
+++ b/plugins/vpp/ipsecplugin/descriptor/spd.go
@@ -21,17 +21,15 @@ import (
 	"strings"
 
 	"github.com/ligato/cn-infra/idxmap"
-
-	"github.com/ligato/vpp-agent/pkg/idxvpp"
-
-	"github.com/go-errors/errors"
-	"github.com/ligato/vpp-agent/plugins/vpp/ipsecplugin/vppcalls"
-
 	"github.com/ligato/cn-infra/logging"
+	"github.com/pkg/errors"
+
 	ipsec "github.com/ligato/vpp-agent/api/models/vpp/ipsec"
+	"github.com/ligato/vpp-agent/pkg/idxvpp"
 	kvs "github.com/ligato/vpp-agent/plugins/kvscheduler/api"
 	vppIfDescriptor "github.com/ligato/vpp-agent/plugins/vpp/ifplugin/descriptor"
 	"github.com/ligato/vpp-agent/plugins/vpp/ipsecplugin/descriptor/adapter"
+	"github.com/ligato/vpp-agent/plugins/vpp/ipsecplugin/vppcalls"
 )
 
 const (

--- a/plugins/vpp/ipsecplugin/descriptor/spd_interface.go
+++ b/plugins/vpp/ipsecplugin/descriptor/spd_interface.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-errors/errors"
 	"github.com/gogo/protobuf/proto"
 	"github.com/ligato/cn-infra/logging"
+
 	interfaces "github.com/ligato/vpp-agent/api/models/vpp/interfaces"
 	ipsec "github.com/ligato/vpp-agent/api/models/vpp/ipsec"
 	kvs "github.com/ligato/vpp-agent/plugins/kvscheduler/api"

--- a/plugins/vpp/ipsecplugin/descriptor/spd_policy.go
+++ b/plugins/vpp/ipsecplugin/descriptor/spd_policy.go
@@ -17,9 +17,10 @@ package descriptor
 import (
 	"strconv"
 
-	"github.com/go-errors/errors"
 	"github.com/gogo/protobuf/proto"
 	"github.com/ligato/cn-infra/logging"
+	"github.com/pkg/errors"
+
 	ipsec "github.com/ligato/vpp-agent/api/models/vpp/ipsec"
 	kvs "github.com/ligato/vpp-agent/plugins/kvscheduler/api"
 	"github.com/ligato/vpp-agent/plugins/vpp/ipsecplugin/descriptor/adapter"

--- a/plugins/vpp/ipsecplugin/ipsecplugin.go
+++ b/plugins/vpp/ipsecplugin/ipsecplugin.go
@@ -21,9 +21,10 @@ package ipsecplugin
 
 import (
 	govppapi "git.fd.io/govpp.git/api"
-	"github.com/go-errors/errors"
 	"github.com/ligato/cn-infra/health/statuscheck"
 	"github.com/ligato/cn-infra/infra"
+	"github.com/pkg/errors"
+
 	"github.com/ligato/vpp-agent/plugins/govppmux"
 	kvs "github.com/ligato/vpp-agent/plugins/kvscheduler/api"
 	"github.com/ligato/vpp-agent/plugins/vpp/ifplugin"

--- a/plugins/vpp/ipsecplugin/vppcalls/vpp1810/dump_vppcalls.go
+++ b/plugins/vpp/ipsecplugin/vppcalls/vpp1810/dump_vppcalls.go
@@ -19,7 +19,7 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/go-errors/errors"
+	"github.com/pkg/errors"
 
 	ipsec "github.com/ligato/vpp-agent/api/models/vpp/ipsec"
 	ipsecapi "github.com/ligato/vpp-agent/plugins/vpp/binapi/vpp1810/ipsec"

--- a/plugins/vpp/ipsecplugin/vppcalls/vpp1810/ipsec_vppcalls.go
+++ b/plugins/vpp/ipsecplugin/vppcalls/vpp1810/ipsec_vppcalls.go
@@ -19,7 +19,7 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/go-errors/errors"
+	"github.com/pkg/errors"
 
 	"github.com/ligato/cn-infra/utils/addrs"
 	ipsec "github.com/ligato/vpp-agent/api/models/vpp/ipsec"

--- a/plugins/vpp/ipsecplugin/vppcalls/vpp1901/dump_vppcalls.go
+++ b/plugins/vpp/ipsecplugin/vppcalls/vpp1901/dump_vppcalls.go
@@ -19,11 +19,11 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/go-errors/errors"
-	"github.com/ligato/vpp-agent/plugins/vpp/ipsecplugin/vppcalls"
+	"github.com/pkg/errors"
 
 	ipsec "github.com/ligato/vpp-agent/api/models/vpp/ipsec"
 	ipsecapi "github.com/ligato/vpp-agent/plugins/vpp/binapi/vpp1901/ipsec"
+	"github.com/ligato/vpp-agent/plugins/vpp/ipsecplugin/vppcalls"
 )
 
 // DumpIPSecSA implements IPSec handler.

--- a/plugins/vpp/ipsecplugin/vppcalls/vpp1901/ipsec_vppcalls.go
+++ b/plugins/vpp/ipsecplugin/vppcalls/vpp1901/ipsec_vppcalls.go
@@ -19,9 +19,9 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/go-errors/errors"
-
 	"github.com/ligato/cn-infra/utils/addrs"
+	"github.com/pkg/errors"
+
 	ipsec "github.com/ligato/vpp-agent/api/models/vpp/ipsec"
 	api "github.com/ligato/vpp-agent/plugins/vpp/binapi/vpp1901/ipsec"
 )

--- a/plugins/vpp/puntplugin/puntplugin.go
+++ b/plugins/vpp/puntplugin/puntplugin.go
@@ -21,13 +21,13 @@ import (
 	"strings"
 
 	govppapi "git.fd.io/govpp.git/api"
-	"github.com/go-errors/errors"
 	"github.com/ligato/cn-infra/datasync"
 	"github.com/ligato/cn-infra/health/statuscheck"
 	"github.com/ligato/cn-infra/infra"
+	"github.com/pkg/errors"
+
 	"github.com/ligato/vpp-agent/api/models/vpp/punt"
 	"github.com/ligato/vpp-agent/pkg/models"
-
 	"github.com/ligato/vpp-agent/plugins/govppmux"
 	kvs "github.com/ligato/vpp-agent/plugins/kvscheduler/api"
 	"github.com/ligato/vpp-agent/plugins/vpp/ifplugin"

--- a/plugins/vpp/puntplugin/vppcalls/vpp1810/punt_vppcalls.go
+++ b/plugins/vpp/puntplugin/vppcalls/vpp1810/punt_vppcalls.go
@@ -18,7 +18,8 @@ import (
 	"net"
 	"strings"
 
-	"github.com/go-errors/errors"
+	"github.com/pkg/errors"
+
 	punt "github.com/ligato/vpp-agent/api/models/vpp/punt"
 	ipba "github.com/ligato/vpp-agent/plugins/vpp/binapi/vpp1810/ip"
 	puntba "github.com/ligato/vpp-agent/plugins/vpp/binapi/vpp1810/punt"

--- a/plugins/vpp/puntplugin/vppcalls/vpp1901/punt_vppcalls.go
+++ b/plugins/vpp/puntplugin/vppcalls/vpp1901/punt_vppcalls.go
@@ -17,7 +17,7 @@ package vpp1901
 import (
 	"strings"
 
-	"github.com/go-errors/errors"
+	"github.com/pkg/errors"
 
 	punt "github.com/ligato/vpp-agent/api/models/vpp/punt"
 	ba_ip "github.com/ligato/vpp-agent/plugins/vpp/binapi/vpp1901/ip"

--- a/plugins/vpp/stnplugin/vppcalls/vpp1810/stn_vppcalls.go
+++ b/plugins/vpp/stnplugin/vppcalls/vpp1810/stn_vppcalls.go
@@ -15,7 +15,6 @@
 package vpp1810
 
 import (
-	"fmt"
 	"net"
 	"strings"
 
@@ -76,8 +75,6 @@ func (h *StnVppHandler) addDelStnRule(stnRule *stn.Rule, isAdd bool) error {
 
 	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return err
-	} else if reply.Retval != 0 {
-		return fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
 	}
 
 	return nil

--- a/plugins/vpp/stnplugin/vppcalls/vpp1901/stn_vppcalls.go
+++ b/plugins/vpp/stnplugin/vppcalls/vpp1901/stn_vppcalls.go
@@ -15,7 +15,6 @@
 package vpp1901
 
 import (
-	"fmt"
 	"net"
 	"strings"
 
@@ -76,8 +75,6 @@ func (h *StnVppHandler) addDelStnRule(stnRule *stn.Rule, isAdd bool) error {
 
 	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return err
-	} else if reply.Retval != 0 {
-		return fmt.Errorf("%s returned %d", reply.GetMessageName(), reply.Retval)
 	}
 
 	return nil


### PR DESCRIPTION
- fix dump for IPSec tunnel interfaces (integ/crypto keys were not used)
- do not show kvscheduler graph dump by default (use `KVSCHEDULER_GRAPHDUMP=y` to enable it)
- avoid publishing delete to index mapping when operation results in error
- cleanup retry code in govppmux and add unit test for it
- removed obsolete Retval checks
