### PR TITLE
Handle unused (non-default) plugin (without panic).

### DIFF
--- a/plugins/configurator/dump.go
+++ b/plugins/configurator/dump.go
@@ -1,6 +1,7 @@
 package configurator
 
 import (
+	"github.com/go-errors/errors"
 	"github.com/ligato/cn-infra/logging"
 	"golang.org/x/net/context"
 
@@ -62,6 +63,9 @@ func (svc *dumpService) Dump(context.Context, *rpc.DumpRequest) (*rpc.DumpRespon
 // only error is send back in response
 func (svc *dumpService) DumpAcls() ([]*vpp_acl.ACL, error) {
 	var acls []*vpp_acl.ACL
+	if svc.aclHandler == nil {
+		return nil, errors.New("aclHandler is not available")
+	}
 	ipACLs, err := svc.aclHandler.DumpACL()
 	if err != nil {
 		return nil, err
@@ -99,6 +103,9 @@ func (svc *dumpService) DumpInterfaces() ([]*vpp_interfaces.Interface, error) {
 // only error is send back in response
 func (svc *dumpService) DumpIPSecSPDs() ([]*vpp_ipsec.SecurityPolicyDatabase, error) {
 	var spds []*vpp_ipsec.SecurityPolicyDatabase
+	if svc.ipsecHandler == nil {
+		return nil, errors.New("ipsecHandler is not available")
+	}
 	spdDetails, err := svc.ipsecHandler.DumpIPSecSPD()
 	if err != nil {
 		return nil, err
@@ -114,6 +121,9 @@ func (svc *dumpService) DumpIPSecSPDs() ([]*vpp_ipsec.SecurityPolicyDatabase, er
 // only error is send back in response
 func (svc *dumpService) DumpIPSecSAs() ([]*vpp_ipsec.SecurityAssociation, error) {
 	var sas []*vpp_ipsec.SecurityAssociation
+	if svc.ipsecHandler == nil {
+		return nil, errors.New("ipsecHandler is not available")
+	}
 	saDetails, err := svc.ipsecHandler.DumpIPSecSA()
 	if err != nil {
 		return nil, err
@@ -217,6 +227,9 @@ func (svc *dumpService) DumpARPs() ([]*vpp_l3.ARPEntry, error) {
 
 // DumpPunt reads VPP Punt socket registrations and returns them as an *PuntResponse.
 func (svc *dumpService) DumpPunt() (punts []*vpp_punt.ToHost, err error) {
+	if svc.puntHandler == nil {
+		return nil, errors.New("puntHandler is not available")
+	}
 	dump, err := svc.puntHandler.DumpRegisteredPuntSockets()
 	if err != nil {
 		return nil, err

--- a/plugins/restapi/handlers.go
+++ b/plugins/restapi/handlers.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/go-errors/errors"
 	"github.com/unrolled/render"
 
 	interfaces "github.com/ligato/vpp-agent/api/models/vpp/interfaces"
@@ -30,12 +31,19 @@ import (
 
 // Registers access list REST handlers
 func (p *Plugin) registerAccessListHandlers() {
+	unavailHandler := errors.New("aclHandler is not available")
 	// GET IP ACLs
 	p.registerHTTPHandler(resturl.ACLIP, GET, func() (interface{}, error) {
+		if p.aclHandler == nil {
+			return nil, unavailHandler
+		}
 		return p.aclHandler.DumpACL()
 	})
 	// GET MACIP ACLs
 	p.registerHTTPHandler(resturl.ACLMACIP, GET, func() (interface{}, error) {
+		if p.aclHandler == nil {
+			return nil, unavailHandler
+		}
 		return p.aclHandler.DumpMACIPACL()
 	})
 }
@@ -74,16 +82,23 @@ func (p *Plugin) registerInterfaceHandlers() {
 
 // Registers NAT REST handlers
 func (p *Plugin) registerNatHandlers() {
+	unavailHandler := errors.New("natHandler is not available")
 	// GET NAT configuration
 	/*p.registerHTTPHandler(resturl.NatURL, GET, func() (interface{}, error) {
 		return p.natHandler.Nat44Dump()
 	})*/
 	// GET NAT global config
 	p.registerHTTPHandler(resturl.NatGlobal, GET, func() (interface{}, error) {
+		if p.natHandler == nil {
+			return nil, unavailHandler
+		}
 		return p.natHandler.Nat44GlobalConfigDump()
 	})
 	// GET DNAT config
 	p.registerHTTPHandler(resturl.NatDNat, GET, func() (interface{}, error) {
+		if p.natHandler == nil {
+			return nil, unavailHandler
+		}
 		return p.natHandler.DNat44Dump()
 	})
 }

--- a/plugins/vpp/aclplugin/aclplugin.go
+++ b/plugins/vpp/aclplugin/aclplugin.go
@@ -73,6 +73,9 @@ func (p *ACLPlugin) Init() error {
 
 	// init handlers
 	p.aclHandler = vppcalls.CompatibleACLVppHandler(p.vppCh, p.dumpVppCh, p.IfPlugin.GetInterfaceIndex(), p.Log)
+	if p.aclHandler == nil {
+		return errors.New("aclHandler is not available")
+	}
 
 	// init & register descriptors
 	p.aclDescriptor = descriptor.NewACLDescriptor(p.aclHandler, p.IfPlugin, p.Log)

--- a/plugins/vpp/aclplugin/vppcalls/acl_vppcalls.go
+++ b/plugins/vpp/aclplugin/vppcalls/acl_vppcalls.go
@@ -116,6 +116,10 @@ type HandlerVersion struct {
 }
 
 func CompatibleACLVppHandler(ch, dch govppapi.Channel, idx ifaceidx.IfaceMetadataIndex, log logging.Logger) ACLVppAPI {
+	if len(Versions) == 0 {
+		// aclplugin is not loaded
+		return nil
+	}
 	for ver, h := range Versions {
 		log.Debugf("checking compatibility with %s", ver)
 		if err := ch.CheckCompatiblity(h.Msgs...); err != nil {

--- a/plugins/vpp/ipsecplugin/ipsecplugin.go
+++ b/plugins/vpp/ipsecplugin/ipsecplugin.go
@@ -71,6 +71,9 @@ func (p *IPSecPlugin) Init() (err error) {
 
 	// init IPSec handler
 	p.ipSecHandler = vppcalls.CompatibleIPSecVppHandler(p.vppCh, p.IfPlugin.GetInterfaceIndex(), p.Log)
+	if p.ipSecHandler == nil {
+		return errors.New("ipsecHandler is not available")
+	}
 
 	// init and register security policy database descriptor
 	p.spdDescriptor = descriptor.NewIPSecSPDDescriptor(p.ipSecHandler, p.Log)

--- a/plugins/vpp/ipsecplugin/vppcalls/ipsec_vppcalls.go
+++ b/plugins/vpp/ipsecplugin/vppcalls/ipsec_vppcalls.go
@@ -98,6 +98,10 @@ type HandlerVersion struct {
 func CompatibleIPSecVppHandler(
 	ch govppapi.Channel, idx ifaceidx.IfaceMetadataIndex, log logging.Logger,
 ) IPSecVppAPI {
+	if len(Versions) == 0 {
+		// ipsecplugin is not loaded
+		return nil
+	}
 	for ver, h := range Versions {
 		log.Debugf("checking compatibility with %s", ver)
 		if err := ch.CheckCompatiblity(h.Msgs...); err != nil {

--- a/plugins/vpp/natplugin/natplugin.go
+++ b/plugins/vpp/natplugin/natplugin.go
@@ -72,6 +72,9 @@ func (p *NATPlugin) Init() error {
 
 	// init NAT handler
 	p.natHandler = vppcalls.CompatibleNatVppHandler(p.vppCh, p.IfPlugin.GetInterfaceIndex(), p.IfPlugin.GetDHCPIndex(), p.Log)
+	if p.natHandler == nil {
+		return errors.New("natHandler is not available")
+	}
 
 	// init and register descriptors
 	p.nat44GlobalDescriptor = descriptor.NewNAT44GlobalDescriptor(p.natHandler, p.Log)

--- a/plugins/vpp/natplugin/vppcalls/nat_vppcalls.go
+++ b/plugins/vpp/natplugin/vppcalls/nat_vppcalls.go
@@ -69,6 +69,10 @@ type HandlerVersion struct {
 func CompatibleNatVppHandler(
 	ch govppapi.Channel, ifIdx ifaceidx.IfaceMetadataIndex, dhcpIdx idxmap.NamedMapping, log logging.Logger,
 ) NatVppAPI {
+	if len(Versions) == 0 {
+		// natplugin is not loaded
+		return nil
+	}
 	for ver, h := range Versions {
 		log.Debugf("checking compatibility with %s", ver)
 		if err := ch.CheckCompatiblity(h.Msgs...); err != nil {

--- a/plugins/vpp/puntplugin/vppcalls/punt_vppcalls.go
+++ b/plugins/vpp/puntplugin/vppcalls/punt_vppcalls.go
@@ -62,6 +62,10 @@ type HandlerVersion struct {
 func CompatiblePuntVppHandler(
 	ch govppapi.Channel, idx ifaceidx.IfaceMetadataIndex, log logging.Logger,
 ) PuntVppAPI {
+	if len(Versions) == 0 {
+		// puntplugin is not loaded
+		return nil
+	}
 	for ver, h := range Versions {
 		log.Debugf("checking compatibility with %s", ver)
 		if err := ch.CheckCompatiblity(h.Msgs...); err != nil {


### PR DESCRIPTION
This is a quick solution to avoid panic when some VPP plugin we support is not loaded. It requires that our counterpart plugin is not loaded as well. This PR makes sure that both configurator and restapi plugin can handle a missing (non-default) plugin.

A dynamic and more robust solution will most likely require to introduce new value state - `UNSUPPORTED`.

Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>