### PR TITLE
Add benchmarks for kvscheduler

### DIFF
--- a/examples/kvscheduler/mock_plugins/ifplugin/mockcalls/mockcalls.go
+++ b/examples/kvscheduler/mock_plugins/ifplugin/mockcalls/mockcalls.go
@@ -16,6 +16,7 @@ package mockcalls
 
 import (
 	"fmt"
+
 	"github.com/ligato/vpp-agent/examples/kvscheduler/mock_plugins/ifplugin/model"
 )
 
@@ -31,7 +32,7 @@ func (h *MockIfaceHandler) CreateLoopbackInterface(ifaceName string) (sbIfaceHan
 		Name: ifaceName,
 		Type: mock_interfaces.Interface_LOOPBACK,
 	}
-	h.log.Infof("Created Loopback interface: %s", ifaceName)
+	h.log.Debugf("Created Loopback interface: %s", ifaceName)
 	return sbIfaceHandle, nil
 }
 
@@ -42,7 +43,7 @@ func (h *MockIfaceHandler) DeleteLoopbackInterface(sbIfaceHandle uint32) error {
 		return err
 	}
 	delete(h.mockIfaces, sbIfaceHandle)
-	h.log.Infof("Deleted Loopback interface: %s", iface.Name)
+	h.log.Debugf("Deleted Loopback interface: %s", iface.Name)
 	return nil
 }
 
@@ -58,10 +59,9 @@ func (h *MockIfaceHandler) CreateTapInterface(ifaceName string) (sbIfaceHandle u
 		Name: ifaceName,
 		Type: mock_interfaces.Interface_TAP,
 	}
-	h.log.Infof("Created TAP interface: %s", ifaceName)
+	h.log.Debugf("Created TAP interface: %s", ifaceName)
 	return sbIfaceHandle, nil
 }
-
 
 // CreateTapInterface deletes TAP interface in the mock SB.
 func (h *MockIfaceHandler) DeleteTapInterface(sbIfaceHandle uint32) error {
@@ -70,7 +70,7 @@ func (h *MockIfaceHandler) DeleteTapInterface(sbIfaceHandle uint32) error {
 		return err
 	}
 	delete(h.mockIfaces, sbIfaceHandle)
-	h.log.Infof("Deleted TAP interface: %s", iface.Name)
+	h.log.Debugf("Deleted TAP interface: %s", iface.Name)
 	return nil
 }
 
@@ -81,7 +81,7 @@ func (h *MockIfaceHandler) InterfaceAdminDown(sbIfaceHandle uint32) error {
 		return err
 	}
 	iface.Enabled = false
-	h.log.Infof("Set interface '%s' DOWN", iface.Name)
+	h.log.Debugf("Set interface '%s' DOWN", iface.Name)
 	return nil
 }
 
@@ -92,7 +92,7 @@ func (h *MockIfaceHandler) InterfaceAdminUp(sbIfaceHandle uint32) error {
 		return err
 	}
 	iface.Enabled = true
-	h.log.Infof("Set interface '%s' UP", iface.Name)
+	h.log.Debugf("Set interface '%s' UP", iface.Name)
 	return nil
 }
 
@@ -103,13 +103,13 @@ func (h *MockIfaceHandler) SetInterfaceMac(sbIfaceHandle uint32, macAddress stri
 		return err
 	}
 	iface.PhysAddress = macAddress
-	h.log.Infof("Set interface '%s' MAC address: %s", iface.Name, macAddress)
+	h.log.Debugf("Set interface '%s' MAC address: %s", iface.Name, macAddress)
 	return nil
 }
 
 // DumpInterfaces returns interfaces "configured" in the mock SB.
 func (h *MockIfaceHandler) DumpInterfaces() (mockIfaces, error) {
-	h.log.Infof("Dumped mock interfaces: %+v", h.mockIfaces)
+	h.log.Debugf("Dumped mock interfaces: %+v", h.mockIfaces)
 	return h.mockIfaces, nil
 }
 

--- a/examples/kvscheduler/mock_plugins/l2plugin/mockcalls/bd_mockcalls.go
+++ b/examples/kvscheduler/mock_plugins/l2plugin/mockcalls/bd_mockcalls.go
@@ -16,6 +16,7 @@ package mockcalls
 
 import (
 	"fmt"
+
 	l2 "github.com/ligato/vpp-agent/examples/kvscheduler/mock_plugins/l2plugin/model"
 )
 
@@ -26,7 +27,7 @@ func (h *MockBDHandler) CreateBridgeDomain(bdName string) (sbBDHandle uint32, er
 	h.mockBDs[sbBDHandle] = &l2.BridgeDomain{
 		Name: bdName,
 	}
-	h.log.Infof("Created bridge domain: %s", bdName)
+	h.log.Debugf("Created bridge domain: %s", bdName)
 	return sbBDHandle, nil
 }
 
@@ -37,7 +38,7 @@ func (h *MockBDHandler) DeleteBridgeDomain(sbBDHandle uint32) error {
 		return err
 	}
 	delete(h.mockBDs, sbBDHandle)
-	h.log.Infof("Deleted bridge domain: %s", bd.Name)
+	h.log.Debugf("Deleted bridge domain: %s", bd.Name)
 	return nil
 }
 
@@ -57,7 +58,7 @@ func (h *MockBDHandler) AddInterfaceToBridgeDomain(sbBDHandle uint32, ifaceName 
 		Name: ifaceName,
 		BridgedVirtualInterface: isBVI,
 	})
-	h.log.Infof("Added interface '%s' into the bridge domain '%s'",
+	h.log.Debugf("Added interface '%s' into the bridge domain '%s'",
 		ifaceName, bd.Name)
 	return nil
 }
@@ -79,14 +80,14 @@ func (h *MockBDHandler) DeleteInterfaceFromBridgeDomain(sbBDHandle uint32, iface
 			ifaceName, bd.Name)
 	}
 	bd.Interfaces = append(bd.Interfaces[:idx], bd.Interfaces[idx+1:]...)
-	h.log.Infof("Removed interface '%s' from the bridge domain '%s'",
+	h.log.Debugf("Removed interface '%s' from the bridge domain '%s'",
 		ifaceName, bd.Name)
 	return nil
 }
 
 // DumpBridgeDomains dumps bridge domains "configured" in the mock SB.
 func (h *MockBDHandler) DumpBridgeDomains() (mockBDs, error) {
-	h.log.Infof("Dumped mock bridge domains: %+v", h.mockBDs)
+	h.log.Debugf("Dumped mock bridge domains: %+v", h.mockBDs)
 	return h.mockBDs, nil
 }
 

--- a/plugins/kvscheduler/bench_test.go
+++ b/plugins/kvscheduler/bench_test.go
@@ -1,0 +1,153 @@
+//  Copyright (c) 2019 Cisco and/or its affiliates.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at:
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package kvscheduler_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/ligato/cn-infra/logging"
+	_ "github.com/ligato/cn-infra/logging/logrus" // for setting default registry
+
+	mock_ifplugin "github.com/ligato/vpp-agent/examples/kvscheduler/mock_plugins/ifplugin"
+	"github.com/ligato/vpp-agent/examples/kvscheduler/mock_plugins/ifplugin/model"
+	mock_l2plugin "github.com/ligato/vpp-agent/examples/kvscheduler/mock_plugins/l2plugin"
+	"github.com/ligato/vpp-agent/examples/kvscheduler/mock_plugins/l2plugin/model"
+	"github.com/ligato/vpp-agent/pkg/models"
+	. "github.com/ligato/vpp-agent/plugins/kvscheduler"
+	. "github.com/ligato/vpp-agent/plugins/kvscheduler/api"
+)
+
+/*
+------------------------
+ KVScheduler benchmarks
+------------------------
+- starts scheduler together with mocked ifplugin and l2plugin
+- configures 1/10/100/1000 number of interfaces with bridge domain
+
+How to run:
+  - build test binary	`go test -c`
+  - run all benchmarks:	`./kvscheduler.test -test.run=XXX -test.bench=.`
+  - with CPU profile:	`./kvscheduler.test -test.run=XXX -test.bench=. -test.cpuprofile=cpu.out`
+    - analyze profile: `go tool pprof cpu.out`
+  - with mem profile:	`./kvscheduler.test -test.run=XXX -test.bench=. -memprofile mem.out`
+    - analyze profile: `go tool pprof -alloc_space mem.out`
+  - with trace profile:	`./kvscheduler.test -test.run=XXX -test.bench=. -trace trace.out`
+    - analyze profile: `go tool trace -http=:6060 trace.out`
+*/
+
+func BenchmarkScale1(b *testing.B)    { benchmarkScale(1, b) }
+func BenchmarkScale10(b *testing.B)   { benchmarkScale(10, b) }
+func BenchmarkScale100(b *testing.B)  { benchmarkScale(100, b) }
+func BenchmarkScale1000(b *testing.B) { benchmarkScale(1000, b) }
+
+func benchmarkScale(i int, b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		runScale(i)
+	}
+}
+
+func runScale(n int) {
+	// error handler
+	checkErr := func(err error) {
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	// prepare run context
+	runCtx := newRunCtx()
+	err := runCtx.Init()
+	checkErr(err)
+	defer func() {
+		err = runCtx.Close()
+		checkErr(err)
+	}()
+
+	// run non-resync transaction against empty SB
+	txn := runCtx.scheduler.StartNBTransaction()
+
+	// create single bridge domain
+	valBd := &mock_l2.BridgeDomain{
+		Name: fmt.Sprintf("bd-%d", 1),
+	}
+	// create n interfaces for bridge domain
+	for i := 0; i < n; i++ {
+		valIface := &mock_interfaces.Interface{
+			Name: fmt.Sprintf("iface-%d", i),
+			Type: mock_interfaces.Interface_LOOPBACK,
+		}
+		valBd.Interfaces = append(valBd.Interfaces, &mock_l2.BridgeDomain_Interface{
+			Name: valIface.Name,
+		})
+		txn.SetValue(models.Key(valIface), valIface)
+	}
+	txn.SetValue(models.Key(valBd), valBd)
+
+	testCtx := WithSimulation(context.Background())
+	_, err = txn.Commit(WithDescription(testCtx, "benchmarking scale"))
+	checkErr(err)
+}
+
+type runCtx struct {
+	scheduler *Scheduler
+	IfPlugin  *mock_ifplugin.IfPlugin
+	L2Plugin  *mock_l2plugin.L2Plugin
+}
+
+func newRunCtx() *runCtx {
+	c := &runCtx{}
+	c.scheduler = NewPlugin(UseDeps(func(deps *Deps) {
+		deps.HTTPHandlers = nil
+	}))
+	c.IfPlugin = mock_ifplugin.NewPlugin(mock_ifplugin.UseDeps(
+		func(deps *mock_ifplugin.Deps) {
+			deps.KVScheduler = c.scheduler
+		}))
+	c.L2Plugin = mock_l2plugin.NewPlugin(mock_l2plugin.UseDeps(
+		func(deps *mock_l2plugin.Deps) {
+			deps.KVScheduler = c.scheduler
+		}))
+	return c
+}
+
+func (c *runCtx) Init() error {
+	if err := c.scheduler.Init(); err != nil {
+		return err
+	}
+	if err := c.IfPlugin.Init(); err != nil {
+		return err
+	}
+	if err := c.L2Plugin.Init(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *runCtx) Close() error {
+	if err := c.L2Plugin.Close(); err != nil {
+		return err
+	}
+	if err := c.IfPlugin.Close(); err != nil {
+		return err
+	}
+	if err := c.scheduler.Close(); err != nil {
+		return err
+	}
+	logging.DefaultRegistry.ClearRegistry()
+	return nil
+}

--- a/plugins/kvscheduler/plugin_scheduler.go
+++ b/plugins/kvscheduler/plugin_scheduler.go
@@ -153,7 +153,7 @@ func (s *Scheduler) Init() error {
 		s.Log.Error(err)
 		return err
 	}
-	s.Log.Infof("KVScheduler configuration: %+v", *s.config)
+	s.Log.Debugf("KVScheduler configuration: %+v", *s.config)
 
 	// prepare context for all go routines
 	s.ctx, s.cancel = context.WithCancel(context.Background())
@@ -236,7 +236,7 @@ func (s *Scheduler) RegisterKVDescriptor(descriptor *kvs.KVDescriptor) error {
 		} else {
 			metadataMap = mem.NewNamedMapping(s.Log, descriptor.Name, nil)
 		}
-		graphW := s.graph.Write(true,false)
+		graphW := s.graph.Write(true, false)
 		graphW.RegisterMetadataMap(descriptor.Name, metadataMap)
 		graphW.Release()
 	}

--- a/plugins/kvscheduler/rest.go
+++ b/plugins/kvscheduler/rest.go
@@ -143,7 +143,7 @@ func kvsWithMetaForREST(in []kvs.KVWithMetadata) (out []kvs.KVWithMetadata) {
 // registerHandlers registers all supported REST APIs.
 func (s *Scheduler) registerHandlers(http rest.HTTPHandlers) {
 	if http == nil {
-		s.Log.Warn("No http handler provided, skipping registration of KVScheduler REST handlers")
+		s.Log.Debug("No http handler provided, skipping registration of KVScheduler REST handlers")
 		return
 	}
 	http.RegisterHTTPHandler(txnHistoryURL, s.txnHistoryGetHandler, "GET")


### PR DESCRIPTION
KVScheduler benchmarks
------------------------

- starts scheduler together with mocked ifplugin and l2plugin
- configures 1/10/100/1000 number of interfaces with bridge domain

How to run:
  - build test binary	`go test -c`
  - run all benchmarks:	`./kvscheduler.test -test.run=XXX -test.bench=.`
  - with CPU profile:	`./kvscheduler.test -test.run=XXX -test.bench=. -test.cpuprofile=cpu.out`
    - analyze profile: `go tool pprof cpu.out`
  - with mem profile:	`./kvscheduler.test -test.run=XXX -test.bench=. -memprofile mem.out`
    - analyze profile: `go tool pprof -alloc_space mem.out`
  - with trace profile:	`./kvscheduler.test -test.run=XXX -test.bench=. -trace trace.out`
    - analyze profile: `go tool trace -http=:6060 trace.out`