### PR TITLE
Models & Orchestrator input checks

### DIFF
--- a/api/models/vpp/l3/keys.go
+++ b/api/models/vpp/l3/keys.go
@@ -44,13 +44,13 @@ var (
 		Module:  ModuleName,
 		Type:    "proxyarp-global",
 		Version: "v2",
-	}, models.WithNameTemplate("settings"))
+	})
 
 	ModelIPScanNeighbor = models.Register(&IPScanNeighbor{}, models.Spec{
 		Module:  ModuleName,
 		Type:    "ipscanneigh-global",
 		Version: "v2",
-	}, models.WithNameTemplate("settings"))
+	})
 )
 
 // ProxyARPKey is key for global proxy arp

--- a/api/models/vpp/nat/keys.go
+++ b/api/models/vpp/nat/keys.go
@@ -28,7 +28,7 @@ var (
 		Module:  ModuleName,
 		Type:    "nat44-global",
 		Version: "v2",
-	}, models.WithNameTemplate("settings"))
+	})
 	ModelDNat44 = models.Register(&DNat44{}, models.Spec{
 		Module:  ModuleName,
 		Type:    "dnat44",

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -65,7 +65,7 @@ func GetKey(x proto.Message) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	name, err := model.nameFunc(x)
+	name, err := model.name(x)
 	if err != nil {
 		return "", err
 	}
@@ -79,7 +79,7 @@ func GetName(x proto.Message) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	name, err := model.nameFunc(x)
+	name, err := model.name(x)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/models/spec.go
+++ b/pkg/models/spec.go
@@ -118,6 +118,11 @@ func Register(pb proto.Message, spec Spec, opts ...ModelOption) *registeredModel
 		protoName: proto.MessageName(pb),
 	}
 
+	// Check proto message name
+	if model.protoName == "" {
+		panic(fmt.Sprintf("empty proto message name for type: %T\n\n\tPlease ensure your .proto file contains: 'option (gogoproto.messagename_all) = true'", pb))
+	}
+
 	// Check duplicate registration
 	if _, ok := registeredModels[model.protoName]; ok {
 		panic(fmt.Sprintf("proto message %q already registered", model.protoName))

--- a/plugins/orchestrator/orchestrator.go
+++ b/plugins/orchestrator/orchestrator.go
@@ -184,11 +184,6 @@ func (p *Plugin) watchEvents() {
 				}
 			}
 
-			if len(kvPairs) == 0 {
-				p.log.Warn("no valid kv pairs received in resync event")
-				continue
-			}
-
 			p.log.Debugf("Resync with %d items", len(kvPairs))
 
 			ctx := e.GetContext()

--- a/plugins/orchestrator/orchestrator.go
+++ b/plugins/orchestrator/orchestrator.go
@@ -131,12 +131,17 @@ func (p *Plugin) watchEvents() {
 						p.log.Errorf("unmarshal value for key %s failed: %v", kv.Key, err)
 						continue
 					}
+					if k := models.Key(kv.Val); k != kv.Key {
+						p.log.Errorf("value for key %s does not match generated model key: %v", kv.Key, k)
+						continue
+					}
 				}
 				kvPairs = append(kvPairs, kv)
 			}
 
 			if len(kvPairs) == 0 {
 				p.log.Warn("no valid kv pairs received in change event")
+				e.Done(nil)
 				continue
 			}
 
@@ -165,6 +170,10 @@ func (p *Plugin) watchEvents() {
 					val, err := models.UnmarshalLazyValue(key, x)
 					if err != nil {
 						p.log.Errorf("unmarshal value for key %s failed: %v", key, err)
+						continue
+					}
+					if k := models.Key(val); k != key {
+						p.log.Errorf("value for key %s does not match generated model key: %v", key, k)
 						continue
 					}
 					kvPairs = append(kvPairs, KeyVal{


### PR DESCRIPTION
- Support no-name keys used for global objects
- Model keys changed for globals (`/settings` suffix is stripped): 
  - **proxyarp**
  - **ipscanneigh** 
  - **nat44**
- Check if registered proto message is empty and recommend fix (proto option)
- Improve error log messages when unmarshalling fails during datasync event processing
- Validate model keys (compares KV key with generated model key from value)