### PR TITLE
Fix crash in kvscheduler in case of descriptor with no dependencies

### DIFF
--- a/plugins/kvscheduler/internal/graph/node_read.go
+++ b/plugins/kvscheduler/internal/graph/node_read.go
@@ -136,7 +136,9 @@ func (s sourcesByRelation) getSourcesForRelation(relation string) *relationSourc
 
 // newNodeR creates a new instance of nodeR.
 func newNodeR() *nodeR {
-	return &nodeR{}
+	return &nodeR{
+		targetsDef: newTargetsDef(nil),
+	}
 }
 
 // GetKey returns the key associated with the node.


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <raszabo@cisco.com>

Fixes:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x12c204a]

goroutine 66 [running]:
github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler/internal/graph.(*targetsDef).getForKey(0x0, 0x0, 0x0, 0xc000703590, 0x48, 0x0, 0x0, 0x0)
	/home/rasto/go/src/github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler/internal/graph/node_read.go:96 +0x3a
github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler/internal/graph.(*node).checkPotentialTarget(0xc0004fb870, 0xc0004fb920)
	/home/rasto/go/src/github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler/internal/graph/node_write.go:208 +0x82
github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler/internal/graph.(*graphRW).SetNode(0xc0004e2820, 0xc000703590, 0x48, 0x0, 0x0)
	/home/rasto/go/src/github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler/internal/graph/graph_write.go:79 +0x1d3
github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler.(*Scheduler).applyValue(0x2d73e00, 0xc00077ec60, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/rasto/go/src/github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler/txn_exec.go:152 +0x171
github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler.(*Scheduler).executeTransaction(0x2d73e00, 0xc0008381e0, 0x1bcb3e0, 0xc0004e2820, 0x0, 0xc000448cc0, 0x6, 0x8)
	/home/rasto/go/src/github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler/txn_exec.go:77 +0x3cc
github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler.(*Scheduler).processTransaction(0x2d73e00, 0xc0008381e0)
	/home/rasto/go/src/github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler/txn_process.go:146 +0x2bd
github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler.(*Scheduler).consumeTransactions(0x2d73e00)
	/home/rasto/go/src/github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler/txn_process.go:95 +0x5d
created by github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler.(*Scheduler).Init
	/home/rasto/go/src/github.com/contiv/vpp/vendor/github.com/ligato/vpp-agent/plugins/kvscheduler/plugin_scheduler.go:185 +0x4ac
```