### PR TITLE
kvgraph: optimize iterSources to have logarithmic complexity

### DIFF
--- a/plugins/kvscheduler/internal/graph/edge_lookup_test.go
+++ b/plugins/kvscheduler/internal/graph/edge_lookup_test.go
@@ -15,8 +15,8 @@
 package graph
 
 import (
-	"testing"
 	. "github.com/onsi/gomega"
+	"testing"
 )
 
 type mockIter struct {
@@ -186,7 +186,7 @@ func TestLookupOverNodeKeysWithOverlay(t *testing.T) {
 	Expect(mi.visitedNodes).To(HaveKey("prefix1/node2"))
 	Expect(mi.visitedNodes).To(HaveKey("prefix2/node3"))
 	mi.reset()
-	
+
 	// check in the underlay before saving
 	el.iterTargets("prefix1/node1", false, mi.visitNode)
 	Expect(mi.visitedNodes).To(HaveLen(1))
@@ -207,7 +207,7 @@ func TestLookupOverNodeKeysWithOverlay(t *testing.T) {
 	Expect(mi.visitedNodes).To(HaveKey("prefix1/node1"))
 	Expect(mi.visitedNodes).To(HaveKey("prefix2/node3"))
 	mi.reset()
-	
+
 	// save and re-check in the underlay
 	elOver.saveOverlay()
 	el.iterTargets("prefix1/node1", false, mi.visitNode)
@@ -233,7 +233,7 @@ func TestLookupOverNodeKeysWithOverlay(t *testing.T) {
 	Expect(mi.visitedNodes).To(HaveKey("prefix1/node2"))
 	Expect(mi.visitedNodes).To(HaveKey("prefix2/node3"))
 	mi.reset()
-	
+
 	// delete two in overlay
 	elOver.delNodeKey("prefix1/node2")
 	elOver.delNodeKey("prefix2/node3")
@@ -253,7 +253,7 @@ func TestLookupOverNodeKeysWithOverlay(t *testing.T) {
 	Expect(mi.visitedNodes).To(HaveLen(1))
 	Expect(mi.visitedNodes).To(HaveKey("prefix1/node1"))
 	mi.reset()
-	
+
 	// check in underlay before save:
 	el.iterTargets("prefix1/node1", false, mi.visitNode)
 	Expect(mi.visitedNodes).To(HaveLen(1))
@@ -278,7 +278,7 @@ func TestLookupOverNodeKeysWithOverlay(t *testing.T) {
 	Expect(mi.visitedNodes).To(HaveKey("prefix1/node2"))
 	Expect(mi.visitedNodes).To(HaveKey("prefix2/node3"))
 	mi.reset()
-	
+
 	// save and re-check underlay
 	elOver.saveOverlay()
 	el.iterTargets("prefix1/node1", false, mi.visitNode)
@@ -338,13 +338,14 @@ func TestLookupOverEdges(t *testing.T) {
 	el.iterSources("some-key", mi.visitEdge)
 	Expect(mi.visitedEdges).To(BeEmpty())
 
-	el.addEdge(edge{  // "prefix1/node2" -> "prefix1/node1"
+	el.addEdge(edge{ // "prefix1/node2" -> "prefix1/node1"
 		targetKey:  "prefix1/node1",
 		isPrefix:   false,
 		sourceNode: "prefix1/node2",
 		relation:   "depends-on",
 		label:      "node1 exists",
 	})
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 	el.addEdge(edge{ // "prefix1/node2" -> "prefix2/node3"
 		targetKey:  "prefix2/node3",
 		isPrefix:   false,
@@ -352,6 +353,7 @@ func TestLookupOverEdges(t *testing.T) {
 		relation:   "depends-on",
 		label:      "node3 exists",
 	})
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 
 	el.addEdge(edge{ // "prefix2/node3" -> "prefix1/*"
 		targetKey:  "prefix1/",
@@ -360,6 +362,7 @@ func TestLookupOverEdges(t *testing.T) {
 		relation:   "depends-on",
 		label:      "prefix1 non-empty",
 	})
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 	el.addEdge(edge{ // "prefix2/node3" -> "prefix2/node3"
 		targetKey:  "prefix2/node3",
 		isPrefix:   false,
@@ -367,6 +370,7 @@ func TestLookupOverEdges(t *testing.T) {
 		relation:   "myself",
 		label:      "edge to itself",
 	})
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 
 	el.addEdge(edge{
 		targetKey:  "", // "prefix1/node1" -> *
@@ -375,6 +379,7 @@ func TestLookupOverEdges(t *testing.T) {
 		relation:   "all",
 		label:      "all",
 	})
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 
 	Expect(el.edges).To(HaveLen(5))
 
@@ -406,6 +411,7 @@ func TestLookupOverEdges(t *testing.T) {
 		relation:   "depends-on",
 		label:      "node3 exists",
 	})
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 	el.delEdge(edge{
 		targetKey:  "", // "prefix1/node1" -> *
 		isPrefix:   true,
@@ -413,6 +419,7 @@ func TestLookupOverEdges(t *testing.T) {
 		relation:   "all",
 		label:      "all",
 	})
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 	Expect(el.edges).To(HaveLen(5)) // not gc-ed yet
 
 	el.iterSources("prefix1/node1", mi.visitEdge)
@@ -439,6 +446,7 @@ func TestLookupOverEdges(t *testing.T) {
 		relation:   "depends-on",
 		label:      "prefix1 non-empty",
 	})
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 	Expect(el.edges).To(HaveLen(2)) // gc-ed
 
 	el.iterSources("prefix1/node1", mi.visitEdge)
@@ -456,13 +464,14 @@ func TestLookupOverEdges(t *testing.T) {
 	mi.reset()
 
 	// delete the remaining edges
-	el.delEdge(edge{  // "prefix1/node2" -> "prefix1/node1"
+	el.delEdge(edge{ // "prefix1/node2" -> "prefix1/node1"
 		targetKey:  "prefix1/node1",
 		isPrefix:   false,
 		sourceNode: "prefix1/node2",
 		relation:   "depends-on",
 		label:      "node1 exists",
 	})
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 	el.delEdge(edge{ // "prefix2/node3" -> "prefix2/node3"
 		targetKey:  "prefix2/node3",
 		isPrefix:   false,
@@ -470,6 +479,7 @@ func TestLookupOverEdges(t *testing.T) {
 		relation:   "myself",
 		label:      "edge to itself",
 	})
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 	Expect(el.edges).To(BeEmpty()) // gc-ed
 
 	el.iterSources("prefix1/node1", mi.visitEdge)
@@ -490,13 +500,14 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 	el := newEdgeLookup()
 	Expect(el).ToNot(BeNil())
 
-	el.addEdge(edge{  // "prefix1/node2" -> "prefix1/node1"
+	el.addEdge(edge{ // "prefix1/node2" -> "prefix1/node1"
 		targetKey:  "prefix1/node1",
 		isPrefix:   false,
 		sourceNode: "prefix1/node2",
 		relation:   "depends-on",
 		label:      "node1 exists",
 	})
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 	el.addEdge(edge{ // "prefix1/node2" -> "prefix2/node3"
 		targetKey:  "prefix2/node3",
 		isPrefix:   false,
@@ -504,7 +515,7 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 		relation:   "depends-on",
 		label:      "node3 exists",
 	})
-
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 	el.addEdge(edge{ // "prefix2/node3" -> "prefix1/*"
 		targetKey:  "prefix1/",
 		isPrefix:   true,
@@ -512,12 +523,14 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 		relation:   "depends-on",
 		label:      "prefix1 non-empty",
 	})
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 
 	elOver := el.makeOverlay()
 	Expect(elOver).ToNot(BeNil())
 	Expect(elOver.underlay).To(Equal(el))
 	Expect(el.overlay).To(Equal(elOver))
-	
+	Expect(elOver.verifyDirDepthBounds()).To(BeNil())
+
 	elOver.addEdge(edge{ // "prefix2/node3" -> "prefix2/node3"
 		targetKey:  "prefix2/node3",
 		isPrefix:   false,
@@ -525,6 +538,7 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 		relation:   "myself",
 		label:      "edge to itself",
 	})
+	Expect(elOver.verifyDirDepthBounds()).To(BeNil())
 
 	elOver.addEdge(edge{
 		targetKey:  "", // "prefix1/node1" -> *
@@ -533,10 +547,11 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 		relation:   "all",
 		label:      "all",
 	})
+	Expect(elOver.verifyDirDepthBounds()).To(BeNil())
 
 	Expect(el.edges).To(HaveLen(3))
 	Expect(elOver.edges).To(HaveLen(5))
-	
+
 	// check overlay
 	elOver.iterSources("prefix1/node1", mi.visitEdge)
 	Expect(mi.visitedEdges).To(HaveLen(3))
@@ -555,7 +570,7 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 	Expect(mi.visitedEdges).To(HaveKey(visitedEdge{"prefix2/node3", "myself", "edge to itself"}))
 	Expect(mi.visitedEdges).To(HaveKey(visitedEdge{"prefix1/node1", "all", "all"}))
 	mi.reset()
-	
+
 	// check underlay
 	el.iterSources("prefix1/node1", mi.visitEdge)
 	Expect(mi.visitedEdges).To(HaveLen(2))
@@ -570,9 +585,10 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 	Expect(mi.visitedEdges).To(HaveLen(1))
 	Expect(mi.visitedEdges).To(HaveKey(visitedEdge{"prefix1/node2", "depends-on", "node3 exists"}))
 	mi.reset()
-	
+
 	// save and re-check underlay
 	elOver.saveOverlay()
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 	el.iterSources("prefix1/node1", mi.visitEdge)
 	Expect(mi.visitedEdges).To(HaveLen(3))
 	Expect(mi.visitedEdges).To(HaveKey(visitedEdge{"prefix1/node2", "depends-on", "node1 exists"}))
@@ -589,8 +605,8 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 	Expect(mi.visitedEdges).To(HaveKey(visitedEdge{"prefix1/node2", "depends-on", "node3 exists"}))
 	Expect(mi.visitedEdges).To(HaveKey(visitedEdge{"prefix2/node3", "myself", "edge to itself"}))
 	Expect(mi.visitedEdges).To(HaveKey(visitedEdge{"prefix1/node1", "all", "all"}))
-	mi.reset()	
-	
+	mi.reset()
+
 	// delete 2 edges in overlay
 	elOver.delEdge(edge{ // "prefix1/node2" -> "prefix2/node3"
 		targetKey:  "prefix2/node3",
@@ -599,6 +615,7 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 		relation:   "depends-on",
 		label:      "node3 exists",
 	})
+	Expect(elOver.verifyDirDepthBounds()).To(BeNil())
 	elOver.delEdge(edge{
 		targetKey:  "", // "prefix1/node1" -> *
 		isPrefix:   true,
@@ -606,6 +623,7 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 		relation:   "all",
 		label:      "all",
 	})
+	Expect(elOver.verifyDirDepthBounds()).To(BeNil())
 	Expect(elOver.edges).To(HaveLen(5)) // not gc-ed yet
 
 	// check overlay
@@ -622,7 +640,7 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 	Expect(mi.visitedEdges).To(HaveLen(1))
 	Expect(mi.visitedEdges).To(HaveKey(visitedEdge{"prefix2/node3", "myself", "edge to itself"}))
 	mi.reset()
-	
+
 	// underlay before save
 	el.iterSources("prefix1/node1", mi.visitEdge)
 	Expect(mi.visitedEdges).To(HaveLen(3))
@@ -641,9 +659,10 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 	Expect(mi.visitedEdges).To(HaveKey(visitedEdge{"prefix2/node3", "myself", "edge to itself"}))
 	Expect(mi.visitedEdges).To(HaveKey(visitedEdge{"prefix1/node1", "all", "all"}))
 	mi.reset()
-	
+
 	// save and re-check underlay
 	elOver.saveOverlay()
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 	el.iterSources("prefix1/node1", mi.visitEdge)
 	Expect(mi.visitedEdges).To(HaveLen(2))
 	Expect(mi.visitedEdges).To(HaveKey(visitedEdge{"prefix1/node2", "depends-on", "node1 exists"}))
@@ -657,7 +676,7 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 	Expect(mi.visitedEdges).To(HaveLen(1))
 	Expect(mi.visitedEdges).To(HaveKey(visitedEdge{"prefix2/node3", "myself", "edge to itself"}))
 	mi.reset()
-	
+
 	// delete another edge, but do not save
 	elOver.delEdge(edge{ // "prefix2/node3" -> "prefix1/*"
 		targetKey:  "prefix1/",
@@ -666,6 +685,7 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 		relation:   "depends-on",
 		label:      "prefix1 non-empty",
 	})
+	Expect(elOver.verifyDirDepthBounds()).To(BeNil())
 	Expect(elOver.edges).To(HaveLen(2)) // gc-ed
 	Expect(el.edges).To(HaveLen(5))
 
@@ -686,6 +706,7 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 	Expect(el.makeOverlay()).To(Equal(elOver))
 	elOver = el.makeOverlay()
 	elOver.saveOverlay()
+	Expect(el.verifyDirDepthBounds()).To(BeNil())
 
 	// check underlay
 	el.iterSources("prefix1/node1", mi.visitEdge)
@@ -702,5 +723,3 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 	Expect(mi.visitedEdges).To(HaveKey(visitedEdge{"prefix2/node3", "myself", "edge to itself"}))
 	mi.reset()
 }
-
-


### PR DESCRIPTION
Graph benchmark shows that it is better now for higher number of graph nodes/edges.
For example, before:
```
nchmarkScaleWithoutRecInPlace/1-2           	   50000	     27.311 ns/op
BenchmarkScaleWithoutRecInPlace/10-2          	   10000	    236.857 ns/op
BenchmarkScaleWithoutRecInPlace/100-2         	     300	   4.276.406 ns/op
BenchmarkScaleWithoutRecInPlace/1000-2        	      20	  76.376.488 ns/op
BenchmarkScaleWithoutRecInPlace/10000-2       	       1	3.530.690.159 ns/op
```
Now:
```
BenchmarkScaleWithoutRecInPlace/1-2           	   50000	     27.593 ns/op
BenchmarkScaleWithoutRecInPlace/10-2          	   10000	    246.341 ns/op
BenchmarkScaleWithoutRecInPlace/100-2         	     300	   4.484.061 ns/op
BenchmarkScaleWithoutRecInPlace/1000-2        	      20	  56.016.241 ns/op
BenchmarkScaleWithoutRecInPlace/10000-2       	       2	 936.665.104 ns/op
```
There are some extra calculations now that add some O(1) complexity, worsening the small-scale scenarios, but overall improving scalability.

iterSources is no longer in top10.
Before:
```
(pprof) top
Showing nodes accounting for 43.31s, 56.16% of 77.12s total
Dropped 256 nodes (cum <= 0.39s)
Showing top 10 nodes out of 126
      flat  flat%   sum%        cum   cum%
    10.11s 13.11% 13.11%     24.15s 31.31%  github.com/ligato/vpp-agent/plugins/kvscheduler/internal/graph.(*edgeLookup).iterSources
     6.42s  8.32% 21.43%      6.42s  8.32%  memeqbody
     5.92s  7.68% 29.11%     11.31s 14.67%  runtime.scanobject
     4.49s  5.82% 34.93%     13.19s 17.10%  runtime.mallocgc
     3.88s  5.03% 39.96%      4.49s  5.82%  runtime.heapBitsSetType
     3.57s  4.63% 44.59%      4.56s  5.91%  runtime.findObject
     3.15s  4.08% 48.68%     10.67s 13.84%  strings.HasPrefix (inline)
     2.39s  3.10% 51.78%      2.39s  3.10%  cmpbody
     1.93s  2.50% 54.28%      1.93s  2.50%  runtime.memequal
     1.45s  1.88% 56.16%      1.45s  1.88%  runtime.duffcopy
```
Now:
```
(pprof) top
Showing nodes accounting for 32.78s, 47.21% of 69.44s total
Dropped 268 nodes (cum <= 0.35s)
Showing top 10 nodes out of 135
      flat  flat%   sum%        cum   cum%
     6.49s  9.35%  9.35%     12.51s 18.02%  runtime.scanobject
     4.76s  6.85% 16.20%     14.08s 20.28%  runtime.mallocgc
     4.72s  6.80% 23.00%      5.95s  8.57%  runtime.findObject
     4.16s  5.99% 28.99%      4.16s  5.99%  runtime.memmove
     3.90s  5.62% 34.61%      4.67s  6.73%  runtime.heapBitsSetType
     2.89s  4.16% 38.77%      2.89s  4.16%  cmpbody
     1.81s  2.61% 41.37%      1.81s  2.61%  runtime.duffcopy
     1.64s  2.36% 43.74%      9.35s 13.46%  sort.Search
     1.21s  1.74% 45.48%      3.81s  5.49%  runtime.wbBufFlush1
     1.20s  1.73% 47.21%      3.39s  4.88%  github.com/ligato/vpp-agent/plugins/kvscheduler/internal/graph.edge.compare
```

The graph is now asymptotically as optimized as it is probably possible. Next optimizations should target limiting the memory usage and perhaps adding some paralelizm into the kvscheduler - best option (= gain / amount-of-work) is to execute descriptor Create/Delete/Update ops in parallel (asynchronously), but leave graph walk sequential.

Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>