### PR TITLE
kvscheduler: separate transaction summary from logrus-based logging

### DIFF
--- a/plugins/kvscheduler/plugin_scheduler.go
+++ b/plugins/kvscheduler/plugin_scheduler.go
@@ -60,6 +60,10 @@ const (
 	// simulation (Retries are always first simulated)
 	defaultEnableTxnSimulation = false
 
+	// by default, a concise summary of every processed transactions is printed
+	// to stdout
+	defaultPrintTxnSummary = true
+
 	// name of the environment variable used to enable verification after every transaction
 	verifyModeEnv = "KVSCHED_VERIFY_MODE"
 
@@ -122,6 +126,7 @@ type Config struct {
 	TransactionHistoryAgeLimit    uint32 `json:"transaction-history-age-limit"`    // in minutes
 	PermanentlyRecordedInitPeriod uint32 `json:"permanently-recorded-init-period"` // in minutes
 	EnableTxnSimulation           bool   `json:"enable-txn-simulation"`
+	PrintTxnSummary               bool   `json:"print-txn-summary"`
 }
 
 // SchedulerTxn implements transaction for the KV scheduler.
@@ -145,6 +150,7 @@ func (s *Scheduler) Init() error {
 		TransactionHistoryAgeLimit:    defaultTransactionHistoryAgeLimit,
 		PermanentlyRecordedInitPeriod: defaultPermanentlyRecordedInitPeriod,
 		EnableTxnSimulation:           defaultEnableTxnSimulation,
+		PrintTxnSummary:               defaultPrintTxnSummary,
 	}
 
 	// load configuration

--- a/plugins/kvscheduler/refresh.go
+++ b/plugins/kvscheduler/refresh.go
@@ -202,7 +202,7 @@ func (s *Scheduler) refreshGraph(graphW graph.RWAccess,
 		s.refreshUnavailNode(graphW, node, refreshedKeys, 2)
 	}
 
-	if enableGraphDump && verbose && s.Log.GetLevel() >= logging.DebugLevel {
+	if enableGraphDump && verbose && s.config.PrintTxnSummary {
 		fmt.Println(dumpGraph(graphW))
 	}
 }

--- a/plugins/kvscheduler/txn_record.go
+++ b/plugins/kvscheduler/txn_record.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ligato/cn-infra/logging"
 	kvs "github.com/ligato/vpp-agent/plugins/kvscheduler/api"
 	"github.com/ligato/vpp-agent/plugins/kvscheduler/internal/graph"
 	"github.com/ligato/vpp-agent/plugins/kvscheduler/internal/utils"
@@ -134,8 +133,8 @@ func (s *Scheduler) preRecordTransaction(txn *transaction, planned kvs.RecordedT
 		})
 	}
 
-	// send to the log
-	if s.Log.GetLevel() >= logging.DebugLevel {
+	// if enabled, print txn summary
+	if s.config.PrintTxnSummary {
 		// build header for the log
 		txnInfo := txn.txnType.String()
 		if txn.txnType == kvs.NBTransaction && txn.nb.resyncType != kvs.NotResync {
@@ -170,7 +169,7 @@ func (s *Scheduler) recordTransaction(txn *transaction, txnRecord *kvs.RecordedT
 	txnRecord.Stop = stop
 	txnRecord.Executed = executed
 
-	if s.Log.GetLevel() >= logging.DebugLevel {
+	if s.config.PrintTxnSummary {
 		var buf strings.Builder
 		buf.WriteString("o----------------------------------------------------------------------------------------------------------------------o\n")
 		buf.WriteString(txnRecord.StringWithOpts(true, false, 2))


### PR DESCRIPTION
Everyone is now confused that by default transaction logs are not printed anymore. Since these logs are quite essential in that they are the only source of visibility into what is agent doing, I would keep them enabled by default. Furthermore, these logs are separate from logrus-based logging (stdout output vs. per-line logging), therefore I have added a separate config option that would allow to disable transaction  output if needed for performance (e.g. in Kiknos).
Please include this in the upcoming release. Transaction output is also quite referenced in the documentation.

Alternative solution could be to disable transaction output automatically when the bandwidth is high....

Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>