### PR TITLE
Fixed wrong dependency for SRv6 end functions referencing VRF tables (DT6,DT4,T)

### DIFF
--- a/api/models/vpp/l3/keys_test.go
+++ b/api/models/vpp/l3/keys_test.go
@@ -14,6 +14,12 @@
 
 package vpp_l3
 
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
 /*func TestRouteKey(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -85,7 +91,9 @@ package vpp_l3
 		})
 	}
 }
+*/
 
+// TestParseRouteKey test different cases for ParseRouteKey(...)
 func TestParseRouteKey(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -98,7 +106,7 @@ func TestParseRouteKey(t *testing.T) {
 	}{
 		{
 			name:                "route-ipv4",
-			routeKey:            "vpp/config/v2/route/vrf/0/dst/10.10.0.0/16/gw/0.0.0.0",
+			routeKey:            "config/vpp/v2/route/vrf/0/dst/10.10.0.0/16/gw/0.0.0.0",
 			expectedIsRouteKey:  true,
 			expectedVrfIndex:    "0",
 			expectedDstNetAddr:  "10.10.0.0",
@@ -107,7 +115,7 @@ func TestParseRouteKey(t *testing.T) {
 		},
 		{
 			name:                "route-ipv6",
-			routeKey:            "vpp/config/v2/route/vrf/0/dst/2001:db8::/32/gw/::",
+			routeKey:            "config/vpp/v2/route/vrf/0/dst/2001:db8::/32/gw/::",
 			expectedIsRouteKey:  true,
 			expectedVrfIndex:    "0",
 			expectedDstNetAddr:  "2001:db8::",
@@ -116,42 +124,26 @@ func TestParseRouteKey(t *testing.T) {
 		},
 		{
 			name:               "invalid-key",
-			routeKey:           "vpp/config/v2/route/vrf/0/dst/2001:db8::/32/",
+			routeKey:           "config/vpp/v2/route/vrf/0/dst/2001:db8::/32/",
 			expectedIsRouteKey: false,
 		},
 		{
 			name:               "invalid-key-missing-dst",
-			routeKey:           "vpp/config/v2/route/vrf/0/10.10.0.0/16/gw/0.0.0.0",
+			routeKey:           "config/vpp/v2/route/vrf/0/10.10.0.0/16/gw/0.0.0.0",
 			expectedIsRouteKey: false,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			name, isRouteKey := models.Model(&Route{}).ParseKey(test.routeKey)
-			nameParts := strings.Split(name, "/")
-			if len(nameParts) != 7 {
-				t.Fatalf("invalid name: %q", name)
-			}
-			vrfIndex, dstNetAddr, nextHopAddr := nameParts[1], nameParts[3], nameParts[6]
-			dstNetMask, err := strconv.Atoi(nameParts[4])
-			if err != nil {
-				t.Fatalf("invalid mask: %v", dstNetMask)
-			}
-			if isRouteKey != test.expectedIsRouteKey {
-				t.Errorf("expected isRouteKey: %v\tgot: %v", test.expectedIsRouteKey, isRouteKey)
-			}
-			if vrfIndex != test.expectedVrfIndex {
-				t.Errorf("expected vrfIndex: %q\tgot: %q", test.expectedVrfIndex, vrfIndex)
-			}
-			if dstNetAddr != test.expectedDstNetAddr {
-				t.Errorf("expected dstNetAddr: %q\tgot: %q", test.expectedDstNetAddr, dstNetAddr)
-			}
-			if dstNetMask != test.expectedDstNetMask {
-				t.Errorf("expected dstNetMask: %v\tgot: %v", test.expectedDstNetMask, dstNetMask)
-			}
-			if nextHopAddr != test.expectedNextHopAddr {
-				t.Errorf("expected nextHopAddr: %q\tgot: %q", test.expectedNextHopAddr, nextHopAddr)
+			RegisterTestingT(t)
+			vrfIndex, dstNetAddr, dstNetMask, nextHopAddr, isRouteKey := ParseRouteKey(test.routeKey)
+			Expect(isRouteKey).To(BeEquivalentTo(test.expectedIsRouteKey), "Route/Non-route key should be properly detected")
+			if isRouteKey {
+				Expect(vrfIndex).To(BeEquivalentTo(test.expectedVrfIndex), "VRF should be properly extracted by parsing route key")
+				Expect(dstNetAddr).To(BeEquivalentTo(test.expectedDstNetAddr), "Destination network address should be properly extracted by parsing route key")
+				Expect(dstNetMask).To(BeEquivalentTo(test.expectedDstNetMask), "Destination network mask should be properly extracted by parsing route key")
+				Expect(nextHopAddr).To(BeEquivalentTo(test.expectedNextHopAddr), "Next hop address should be properly extracted by parsing route key")
 			}
 		})
 	}
-}*/
+}

--- a/plugins/vpp/srplugin/descriptor/localsid.go
+++ b/plugins/vpp/srplugin/descriptor/localsid.go
@@ -200,6 +200,7 @@ func (d *LocalSIDDescriptor) Dependencies(key string, localSID *srv6.LocalSID) (
 				Label: localsidVRFDep,
 				AnyOf: scheduler.AnyOfDependency{
 					KeyPrefixes: []string{vpp_l3.RouteVrfPrefix(ef.EndFunction_T.VrfId)}, // waiting for VRF table creation (route creation creates also VRF table if it doesn't exist)
+					KeySelector: d.isIPv6RouteKey,                                        // T refers to IPv6 VRF table
 				},
 			})
 		}
@@ -229,6 +230,7 @@ func (d *LocalSIDDescriptor) Dependencies(key string, localSID *srv6.LocalSID) (
 				Label: localsidVRFDep,
 				AnyOf: scheduler.AnyOfDependency{
 					KeyPrefixes: []string{vpp_l3.RouteVrfPrefix(ef.EndFunction_DT4.VrfId)}, // waiting for VRF table creation (route creation creates also VRF table if it doesn't exist)
+					KeySelector: d.isIPv4RouteKey,                                          // we want ipv4 VRF because DT4
 				},
 			})
 		}
@@ -238,15 +240,7 @@ func (d *LocalSIDDescriptor) Dependencies(key string, localSID *srv6.LocalSID) (
 				Label: localsidVRFDep,
 				AnyOf: scheduler.AnyOfDependency{
 					KeyPrefixes: []string{vpp_l3.RouteVrfPrefix(ef.EndFunction_DT6.VrfId)}, // waiting for VRF table creation (route creation creates also VRF table if it doesn't exist)
-					KeySelector: func(key string) bool {
-						_, dstNetAddr, dstNetMask, _, _ := vpp_l3.ParseRouteKey(key)
-						dstNet := fmt.Sprintf("%s/%d", dstNetAddr, dstNetMask)
-						_, isIPv6, err := addrs.ParseIPWithPrefix(dstNet)
-						if err != nil {
-							return false // it fails also in route creation (vpp_calls) and it is before needed vrf creation
-						}
-						return isIPv6
-					},
+					KeySelector: d.isIPv6RouteKey,                                          // we want ipv6 VRF because DT6
 				},
 			})
 		}
@@ -262,6 +256,24 @@ func (d *LocalSIDDescriptor) Dependencies(key string, localSID *srv6.LocalSID) (
 	}
 
 	return dependencies
+}
+
+func (d *LocalSIDDescriptor) isIPv4RouteKey(key string) bool {
+	isIPv6, err := isRouteDstIpv6(key)
+	if err != nil {
+		d.log.Debug("Can't determine whether key %v is for ipv4 route or not due to: %v", key, err)
+		return false // it fails also in route creation (vpp_calls) and it is before needed vrf creation
+	}
+	return !isIPv6
+}
+
+func (d *LocalSIDDescriptor) isIPv6RouteKey(key string) bool {
+	isIPv6, err := isRouteDstIpv6(key)
+	if err != nil {
+		d.log.Debug("Can't determine whether key %v is for ipv6 route or not due to: %v", key, err)
+		return false // it fails also in route creation (vpp_calls) and it is before needed vrf creation
+	}
+	return isIPv6
 }
 
 // ParseIPv6 parses string <str> to IPv6 address (including IPv4 address converted to IPv6 address)
@@ -288,6 +300,16 @@ func ParseIPv4(str string) (net.IP, error) {
 		return nil, errors.Errorf(" %q is not ipv4 address", str)
 	}
 	return ipv4, nil
+}
+
+func isRouteDstIpv6(key string) (bool, error) {
+	_, dstNetAddr, dstNetMask, _, isRouteKey := vpp_l3.ParseRouteKey(key)
+	if !isRouteKey {
+		return false, errors.Errorf("Key %v is not route key", key)
+	}
+	dstNet := fmt.Sprintf("%s/%d", dstNetAddr, dstNetMask)
+	_, isIPv6, err := addrs.ParseIPWithPrefix(dstNet)
+	return isIPv6, err
 }
 
 func equivalentSIDs(sid1, sid2 string) bool {


### PR DESCRIPTION
I know from previous pull requests that Parse key methods are not really wanted, but i couldn't get the info otherwise. If there is a better way, i can change the implementation.