### PR TITLE
kvgraph: further performance improvements

### DIFF
--- a/plugins/kvscheduler/internal/graph/bench_test.go
+++ b/plugins/kvscheduler/internal/graph/bench_test.go
@@ -53,7 +53,7 @@ type scaleCtx struct {
 }
 
 func init() {
-	benchEl = newEdgeLookup()
+	benchEl = newEdgeLookup(nil)
 }
 
 func BenchmarkScaleWithoutRec(b *testing.B) {

--- a/plugins/kvscheduler/internal/graph/edge_lookup.go
+++ b/plugins/kvscheduler/internal/graph/edge_lookup.go
@@ -32,14 +32,16 @@ const (
 // edgeLookup is a helper tool used internally by kvgraph for **efficient** lookups
 // over the set of graph edges, defined using keys or key prefixes.
 type edgeLookup struct {
-	nodeKeys     []nodeKey       // for O(log(n)) lookups against key prefixes
-	nodeKeysMap  map[string]bool // for O(1) lookups against full keys
-	removedNodes int
+	nodeKeyData   []nodeKey
+	nodeKeyOffset []int           // for O(log(n)) lookups against key prefixes
+	nodeKeyMap    map[string]bool // for O(1) lookups against full keys
+	removedNodes  int
 
-	edges        []edge
+	edgeData     []edge // unordered
+	edgeOffset   []int  // ordered first by directory depth, then lexicographically by edge data
 	removedEdges int
 	// edges are first sorted (split) by the number of target key components (directories)
-	// -> dirDepthBounds[dirCount] = index of the first edge in <edges> whose
+	// -> dirDepthBounds[dirCount] = index of the first edge in <edgeOffset> whose
 	//    targetKey consists of <dirCount> directories (incl. the last suffix)
 	dirDepthBounds []int
 
@@ -52,6 +54,8 @@ type edgeLookup struct {
 type nodeKey struct {
 	key     string
 	removed bool
+
+	decOffset int // used internally in gcNodeKeys()
 }
 
 type edge struct {
@@ -64,23 +68,29 @@ type edge struct {
 	label      string
 
 	removed bool
+
+	decOffset int // used internally in gcEdges()
 }
 
 func newEdgeLookup(mt MethodTracker) *edgeLookup {
 	return &edgeLookup{
-		nodeKeys:       make([]nodeKey, 0, initNodeKeysCap),
-		nodeKeysMap:    make(map[string]bool),
-		edges:          make([]edge, 0, initEdgesCap),
+		nodeKeyData:    make([]nodeKey, 0, initNodeKeysCap),
+		nodeKeyOffset:  make([]int, 0, initNodeKeysCap),
+		nodeKeyMap:     make(map[string]bool),
+		edgeData:       make([]edge, 0, initEdgesCap),
+		edgeOffset:     make([]int, 0, initEdgesCap),
 		dirDepthBounds: make([]int, 0, initDirDepthBoundsCap),
 		methodTracker:  mt,
 	}
 }
 
 func (el *edgeLookup) reset() {
-	el.nodeKeysMap = make(map[string]bool)
-	el.nodeKeys = el.nodeKeys[:0]
+	el.nodeKeyMap = make(map[string]bool)
+	el.nodeKeyData = el.nodeKeyData[:0]
+	el.nodeKeyOffset = el.nodeKeyOffset[:0]
 	el.removedNodes = 0
-	el.edges = el.edges[:0]
+	el.edgeData = el.edgeData[:0]
+	el.edgeOffset = el.edgeOffset[:0]
 	el.dirDepthBounds = el.dirDepthBounds[:0]
 	el.removedEdges = 0
 }
@@ -89,20 +99,24 @@ func (el *edgeLookup) makeOverlay() *edgeLookup {
 	if el.overlay == nil {
 		// create overlay for the first time
 		el.overlay = &edgeLookup{
-			nodeKeys:       make([]nodeKey, 0, max(len(el.nodeKeys), initNodeKeysCap)),
-			edges:          make([]edge, 0, max(len(el.edges), initEdgesCap)),
+			nodeKeyData:    make([]nodeKey, 0, max(len(el.nodeKeyData), initNodeKeysCap)),
+			nodeKeyOffset:  make([]int, 0, max(len(el.nodeKeyOffset), initNodeKeysCap)),
+			edgeData:       make([]edge, 0, max(len(el.edgeData), initEdgesCap)),
+			edgeOffset:     make([]int, 0, max(len(el.edgeOffset), initEdgesCap)),
 			dirDepthBounds: make([]int, 0, max(len(el.dirDepthBounds), initDirDepthBoundsCap)),
 			underlay:       el,
 		}
 	}
 	// re-use previously allocated memory
-	el.overlay.resizeNodeKeys(len(el.nodeKeys))
-	el.overlay.resizeEdges(len(el.edges))
+	el.overlay.resizeNodeKeys(len(el.nodeKeyOffset))
+	el.overlay.resizeEdges(len(el.edgeOffset))
 	el.overlay.resizeDirDepthBounds(len(el.dirDepthBounds))
-	copy(el.overlay.nodeKeys, el.nodeKeys)
-	copy(el.overlay.edges, el.edges)
+	copy(el.overlay.nodeKeyData, el.nodeKeyData)
+	copy(el.overlay.nodeKeyOffset, el.nodeKeyOffset)
+	copy(el.overlay.edgeData, el.edgeData)
+	copy(el.overlay.edgeOffset, el.edgeOffset)
 	copy(el.overlay.dirDepthBounds, el.dirDepthBounds)
-	el.overlay.nodeKeysMap = make(map[string]bool)
+	el.overlay.nodeKeyMap = make(map[string]bool)
 	el.overlay.removedEdges = el.removedEdges
 	el.overlay.removedNodes = el.removedNodes
 	return el.overlay
@@ -114,19 +128,21 @@ func (el *edgeLookup) saveOverlay() {
 	}
 	el.underlay.removedNodes = el.removedNodes
 	el.underlay.removedEdges = el.removedEdges
-	for key, add := range el.nodeKeysMap {
+	for key, add := range el.nodeKeyMap {
 		if add {
-			el.underlay.nodeKeysMap[key] = true
+			el.underlay.nodeKeyMap[key] = true
 		} else {
-			delete(el.underlay.nodeKeysMap, key)
+			delete(el.underlay.nodeKeyMap, key)
 		}
 	}
-	el.nodeKeysMap = make(map[string]bool) // clear
-	el.underlay.resizeNodeKeys(len(el.nodeKeys))
-	el.underlay.resizeEdges(len(el.edges))
+	el.nodeKeyMap = make(map[string]bool) // clear
+	el.underlay.resizeNodeKeys(len(el.nodeKeyOffset))
+	el.underlay.resizeEdges(len(el.edgeOffset))
 	el.underlay.resizeDirDepthBounds(len(el.dirDepthBounds))
-	copy(el.underlay.nodeKeys, el.nodeKeys)
-	copy(el.underlay.edges, el.edges)
+	copy(el.underlay.nodeKeyData, el.nodeKeyData)
+	copy(el.underlay.nodeKeyOffset, el.nodeKeyOffset)
+	copy(el.underlay.edgeData, el.edgeData)
+	copy(el.underlay.edgeOffset, el.edgeOffset)
 	copy(el.underlay.dirDepthBounds, el.dirDepthBounds)
 }
 
@@ -136,21 +152,31 @@ func (el *edgeLookup) addNodeKey(key string) {
 		defer el.methodTracker("edgeLookup.addNodeKey")()
 	}
 
-	el.nodeKeysMap[key] = true
+	el.nodeKeyMap[key] = true
+
+	// find the corresponding index in nodeKeyOffset
 	idx := el.nodeKeyIdx(key)
-	if idx < len(el.nodeKeys) && el.nodeKeys[idx].key == key {
-		if el.nodeKeys[idx].removed {
-			el.nodeKeys[idx].removed = false
-			el.removedNodes--
+	if idx < len(el.nodeKeyOffset) {
+		offset := el.nodeKeyOffset[idx]
+		if el.nodeKeyData[offset].key == key {
+			if el.nodeKeyData[offset].removed {
+				el.nodeKeyData[offset].removed = false
+				el.removedNodes--
+			}
+			return
 		}
-		return
 	}
-	el.nodeKeys = append(el.nodeKeys, nodeKey{})
-	if idx < len(el.nodeKeys)-1 {
-		copy(el.nodeKeys[idx+1:], el.nodeKeys[idx:])
+
+	// add to both nodeKeyOffset and nodeKeyData
+	el.nodeKeyData = append(el.nodeKeyData, nodeKey{})
+	offset := len(el.nodeKeyData) - 1
+	el.nodeKeyData[offset].key = key
+	el.nodeKeyData[offset].removed = false
+	el.nodeKeyOffset = append(el.nodeKeyOffset, -1)
+	if idx < len(el.nodeKeyOffset)-1 {
+		copy(el.nodeKeyOffset[idx+1:], el.nodeKeyOffset[idx:])
 	}
-	el.nodeKeys[idx].key = key
-	el.nodeKeys[idx].removed = false
+	el.nodeKeyOffset[idx] = offset
 }
 
 // O(log(n)) amortized
@@ -161,26 +187,29 @@ func (el *edgeLookup) delNodeKey(key string) {
 
 	if el.underlay != nil {
 		// this is overlay, remember operation
-		el.nodeKeysMap[key] = false
+		el.nodeKeyMap[key] = false
 	} else {
 		// do not store false, otherwise memory usage will grow
-		delete(el.nodeKeysMap, key)
+		delete(el.nodeKeyMap, key)
 	}
 	idx := el.nodeKeyIdx(key)
-	if idx < len(el.nodeKeys) && el.nodeKeys[idx].key == key && !el.nodeKeys[idx].removed {
-		el.nodeKeys[idx].removed = true
-		el.removedNodes++
-		if el.removedNodes > len(el.nodeKeys)/2 {
-			el.gcNodeKeys()
+	if idx < len(el.nodeKeyOffset) {
+		offset := el.nodeKeyOffset[idx]
+		if el.nodeKeyData[offset].key == key && !el.nodeKeyData[offset].removed {
+			el.nodeKeyData[offset].removed = true
+			el.removedNodes++
+			if el.removedNodes > len(el.nodeKeyData)/2 {
+				el.gcNodeKeys()
+			}
 		}
 	}
 }
 
 // O(log(n))
 func (el *edgeLookup) nodeKeyIdx(key string) int {
-	return sort.Search(len(el.nodeKeys),
+	return sort.Search(len(el.nodeKeyOffset),
 		func(i int) bool {
-			return key <= el.nodeKeys[i].key
+			return key <= el.nodeKeyData[el.nodeKeyOffset[i]].key
 		})
 }
 
@@ -190,30 +219,38 @@ func (el *edgeLookup) addEdge(e edge) {
 		defer el.methodTracker("edgeLookup.addEdge")()
 	}
 
+	// find the corresponding index in edgeOffset
 	e.targetKey = trimTrailingDirSep(e.targetKey)
 	dirDepth := getDirDepth(e.targetKey)
 	idx := el.edgeIdx(e, dirDepth)
-	if idx < len(el.edges) {
-		equal, _ := e.compare(el.edges[idx])
+	if idx < len(el.edgeOffset) {
+		offset := el.edgeOffset[idx]
+		equal, _ := e.compare(el.edgeData[offset])
 		if equal {
-			if el.edges[idx].removed {
-				el.edges[idx].removed = false
+			if el.edgeData[offset].removed {
+				el.edgeData[offset].removed = false
 				el.removedEdges--
 			}
 			return
 		}
 	}
-	el.edges = append(el.edges, edge{})
-	if idx < len(el.edges)-1 {
-		copy(el.edges[idx+1:], el.edges[idx:])
+
+	// add to both edgeOffset and edgeData
+	el.edgeData = append(el.edgeData, e)
+	offset := len(el.edgeData) - 1
+	el.edgeData[offset].removed = false
+	el.edgeOffset = append(el.edgeOffset, -1)
+	if idx < len(el.edgeOffset)-1 {
+		copy(el.edgeOffset[idx+1:], el.edgeOffset[idx:])
 	}
-	el.edges[idx] = e
-	el.edges[idx].removed = false
+	el.edgeOffset[idx] = offset
+
+	// update directory boundaries
 	for i := dirDepth + 1; i < len(el.dirDepthBounds); i++ {
 		el.dirDepthBounds[i]++
 	}
 	for i := len(el.dirDepthBounds); i <= dirDepth; i++ {
-		el.dirDepthBounds = append(el.dirDepthBounds, len(el.edges)-1)
+		el.dirDepthBounds = append(el.dirDepthBounds, len(el.edgeOffset)-1)
 	}
 }
 
@@ -226,12 +263,13 @@ func (el *edgeLookup) delEdge(e edge) {
 	e.targetKey = trimTrailingDirSep(e.targetKey)
 	dirDepth := getDirDepth(e.targetKey)
 	idx := el.edgeIdx(e, dirDepth)
-	if idx <= len(el.edges) {
-		equal, _ := e.compare(el.edges[idx])
-		if equal && !el.edges[idx].removed {
-			el.edges[idx].removed = true
+	if idx < len(el.edgeOffset) {
+		offset := el.edgeOffset[idx]
+		equal, _ := e.compare(el.edgeData[offset])
+		if equal && !el.edgeData[offset].removed {
+			el.edgeData[offset].removed = true
 			el.removedEdges++
-			if el.removedEdges > len(el.edges)/2 {
+			if el.removedEdges > len(el.edgeData)/2 {
 				el.gcEdges()
 			}
 		}
@@ -246,7 +284,8 @@ func (el *edgeLookup) edgeIdx(e edge, dirDepth int) int {
 	}
 	return begin + sort.Search(end-begin,
 		func(i int) bool {
-			_, order := e.compare(el.edges[begin+i])
+			e2 := el.edgeData[el.edgeOffset[begin+i]]
+			_, order := e.compare(e2)
 			return order <= 0
 		})
 }
@@ -255,12 +294,12 @@ func (el *edgeLookup) getDirDepthBounds(dirDepth int) (begin, end int) {
 	if dirDepth < len(el.dirDepthBounds) {
 		begin = el.dirDepthBounds[dirDepth]
 	} else {
-		begin = len(el.edges)
+		begin = len(el.edgeOffset)
 	}
 	if dirDepth < len(el.dirDepthBounds)-1 {
 		end = el.dirDepthBounds[dirDepth+1]
 	} else {
-		end = len(el.edges)
+		end = len(el.edgeOffset)
 	}
 	return
 }
@@ -274,21 +313,21 @@ func (el *edgeLookup) iterTargets(key string, isPrefix bool, cb func(targetNode 
 
 	if key == "" && isPrefix {
 		// iterate all
-		for i := range el.nodeKeys {
-			if el.nodeKeys[i].removed {
+		for i := range el.nodeKeyData {
+			if el.nodeKeyData[i].removed {
 				continue
 			}
-			cb(el.nodeKeys[i].key)
+			cb(el.nodeKeyData[i].key)
 		}
 		return
 	}
 	if !isPrefix {
-		added, known := el.nodeKeysMap[key]
+		added, known := el.nodeKeyMap[key]
 		if (known && !added) || (!known && el.underlay == nil) {
 			return
 		}
 		if !known && el.underlay != nil {
-			_, added = el.underlay.nodeKeysMap[key]
+			_, added = el.underlay.nodeKeyMap[key]
 			if !added {
 				return
 			}
@@ -298,14 +337,15 @@ func (el *edgeLookup) iterTargets(key string, isPrefix bool, cb func(targetNode 
 	}
 	// prefix:
 	idx := el.nodeKeyIdx(key)
-	for i := idx; i < len(el.nodeKeys); i++ {
-		if el.nodeKeys[i].removed {
+	for i := idx; i < len(el.nodeKeyOffset); i++ {
+		offset := el.nodeKeyOffset[i]
+		if el.nodeKeyData[offset].removed {
 			continue
 		}
-		if !strings.HasPrefix(el.nodeKeys[i].key, key) {
+		if !strings.HasPrefix(el.nodeKeyData[offset].key, key) {
 			break
 		}
-		cb(el.nodeKeys[i].key)
+		cb(el.nodeKeyData[offset].key)
 	}
 }
 
@@ -323,16 +363,17 @@ func (el *edgeLookup) iterSources(targetKey string, cb func(sourceNode, relation
 			idx := el.edgeIdx(edge{targetKey: targetKey[:i]}, dirDepth)
 			_, end := el.getDirDepthBounds(dirDepth)
 			for j := idx; j < end; j++ {
-				if el.edges[j].targetKey != targetKey[:i] {
+				offset := el.edgeOffset[j]
+				if el.edgeData[offset].targetKey != targetKey[:i] {
 					break
 				}
-				if prefix && !el.edges[j].isPrefix {
+				if prefix && !el.edgeData[offset].isPrefix {
 					continue
 				}
-				if el.edges[j].removed {
+				if el.edgeData[offset].removed {
 					continue
 				}
-				cb(el.edges[j].sourceNode, el.edges[j].relation, el.edges[j].label)
+				cb(el.edgeData[offset].sourceNode, el.edgeData[offset].relation, el.edgeData[offset].label)
 			}
 			dirDepth++
 		}
@@ -341,63 +382,126 @@ func (el *edgeLookup) iterSources(targetKey string, cb func(sourceNode, relation
 
 // O(n)
 func (el *edgeLookup) gcNodeKeys() {
+	// for each offset determine how much it will decrease
+	var decOffset int
+	for i := 0; i < len(el.nodeKeyData); i++ {
+		if el.nodeKeyData[i].removed {
+			decOffset++
+		} else {
+			el.nodeKeyData[i].decOffset = decOffset
+		}
+	}
+
+	// GC node-key offsets
 	var next int
-	for i := range el.nodeKeys {
-		if !el.nodeKeys[i].removed {
+	for i := range el.nodeKeyOffset {
+		offset := el.nodeKeyOffset[i]
+		if !el.nodeKeyData[offset].removed {
 			if next < i {
-				el.nodeKeys[next] = el.nodeKeys[i]
+				el.nodeKeyOffset[next] = el.nodeKeyOffset[i]
+			}
+			el.nodeKeyOffset[next] -= el.nodeKeyData[offset].decOffset
+			next++
+		}
+	}
+	el.nodeKeyOffset = el.nodeKeyOffset[:next]
+
+	// GC node-key data
+	next = 0
+	for i := 0; i < len(el.nodeKeyData); i++ {
+		if !el.nodeKeyData[i].removed {
+			if next < i {
+				el.nodeKeyData[next] = el.nodeKeyData[i]
 			}
 			next++
 		}
 	}
-	el.nodeKeys = el.nodeKeys[:next]
+	el.nodeKeyData = el.nodeKeyData[:next]
+
 	el.removedNodes = 0
+	if len(el.nodeKeyOffset) != len(el.nodeKeyData) {
+		panic("len(el.nodeKeyOffset) != len(el.nodeKeyData)")
+	}
 }
 
 // O(m)
 func (el *edgeLookup) gcEdges() {
+	// for each offset determine how much it will decrease
+	var decOffset int
+	for i := 0; i < len(el.edgeData); i++ {
+		if el.edgeData[i].removed {
+			decOffset++
+		} else {
+			el.edgeData[i].decOffset = decOffset
+		}
+	}
+
+	// GC edge offsets
 	var next int
 	for dIdx, curBound := range el.dirDepthBounds {
 		newBound := next
-		nextBound := len(el.edges)
+		nextBound := len(el.edgeOffset)
 		if dIdx < len(el.dirDepthBounds)-1 {
 			nextBound = el.dirDepthBounds[dIdx+1]
 		}
 		for i := curBound; i < nextBound; i++ {
-			if !el.edges[i].removed {
+			offset := el.edgeOffset[i]
+			if !el.edgeData[offset].removed {
 				if next < i {
-					el.edges[next] = el.edges[i]
+					el.edgeOffset[next] = el.edgeOffset[i]
 				}
+				// update offset to reflect the post-GC situation
+				el.edgeOffset[next] -= el.edgeData[offset].decOffset
 				next++
 			}
 		}
 		el.dirDepthBounds[dIdx] = newBound
 	}
+	el.edgeOffset = el.edgeOffset[:next]
 
-	el.edges = el.edges[:next]
-	el.removedEdges = 0
+	// GC edge data
+	next = 0
+	for i := 0; i < len(el.edgeData); i++ {
+		if !el.edgeData[i].removed {
+			if next < i {
+				el.edgeData[next] = el.edgeData[i]
+			}
+			next++
+		}
+	}
+	el.edgeData = el.edgeData[:next]
 
+	// GC directory boundaries
 	dIdx := len(el.dirDepthBounds) - 1
 	for ; dIdx >= 0; dIdx-- {
-		if el.dirDepthBounds[dIdx] < len(el.edges) {
+		if el.dirDepthBounds[dIdx] < len(el.edgeOffset) {
 			break
 		}
 	}
 	el.dirDepthBounds = el.dirDepthBounds[:dIdx+1]
+
+	el.removedEdges = 0
+	if len(el.edgeOffset) != len(el.edgeData) {
+		panic("len(el.edgeOffset) != len(el.edgeData)")
+	}
 }
 
 func (el *edgeLookup) resizeNodeKeys(size int) {
-	if cap(el.nodeKeys) < size {
-		el.nodeKeys = make([]nodeKey, size)
+	if cap(el.nodeKeyData) < size {
+		el.nodeKeyData = make([]nodeKey, size)
+		el.nodeKeyOffset = make([]int, size)
 	}
-	el.nodeKeys = el.nodeKeys[0:size]
+	el.nodeKeyData = el.nodeKeyData[0:size]
+	el.nodeKeyOffset = el.nodeKeyOffset[0:size]
 }
 
 func (el *edgeLookup) resizeEdges(size int) {
-	if cap(el.edges) < size {
-		el.edges = make([]edge, size)
+	if cap(el.edgeData) < size {
+		el.edgeData = make([]edge, size)
+		el.edgeOffset = make([]int, size)
 	}
-	el.edges = el.edges[0:size]
+	el.edgeData = el.edgeData[0:size]
+	el.edgeOffset = el.edgeOffset[0:size]
 }
 
 func (el *edgeLookup) resizeDirDepthBounds(size int) {
@@ -409,10 +513,54 @@ func (el *edgeLookup) resizeDirDepthBounds(size int) {
 
 // for UTs
 func (el *edgeLookup) verifyDirDepthBounds() error {
+	if len(el.edgeData) != len(el.edgeOffset) {
+		return fmt.Errorf("len(edgeData) != len(edgeOffset) (%d != %d)",
+			len(el.edgeData), len(el.edgeOffset))
+	}
+	if cap(el.edgeData) != cap(el.edgeOffset) {
+		return fmt.Errorf("cap(edgeData) != cap(edgeOffset) (%d != %d)",
+			cap(el.edgeData), cap(el.edgeOffset))
+	}
+	for i := 0; i < len(el.edgeOffset); i++ {
+		found := false
+		for j := 0; j < len(el.edgeOffset); j++ {
+			if el.edgeOffset[j] == i {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("missing entry for edge offset %d (offsets=%+v)",
+				i, el.edgeOffset)
+		}
+	}
+
+	if len(el.nodeKeyData) != len(el.nodeKeyOffset) {
+		return fmt.Errorf("len(nodeKeyData) != len(nodeKeyOffset) (%d != %d)",
+			len(el.nodeKeyData), len(el.nodeKeyOffset))
+	}
+	if cap(el.nodeKeyData) != cap(el.nodeKeyOffset) {
+		return fmt.Errorf("cap(nodeKeyData) != cap(nodeKeyOffset) (%d != %d)",
+			cap(el.nodeKeyData), cap(el.nodeKeyOffset))
+	}
+	for i := 0; i < len(el.nodeKeyOffset); i++ {
+		found := false
+		for j := 0; j < len(el.nodeKeyOffset); j++ {
+			if el.nodeKeyOffset[j] == i {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("missing entry for node-key offset %d (offsets=%+v)",
+				i, el.nodeKeyOffset)
+		}
+	}
+
 	expBounds := []int{}
 	dirDepth := -1
-	for i := range el.edges {
-		tk := el.edges[i].targetKey
+	for i := range el.edgeOffset {
+		tk := el.edgeData[el.edgeOffset[i]].targetKey
 		if len(tk) > 0 && tk[len(tk)-1] == dirSeparator[0] {
 			return fmt.Errorf("edge with targetKey ending with dir separator: %s", tk)
 		}
@@ -432,8 +580,9 @@ func (el *edgeLookup) verifyDirDepthBounds() error {
 	}
 	// bad performance of this is OK, the method is used only in unit tests
 	if !reflect.DeepEqual(el.dirDepthBounds, expBounds) {
-		return fmt.Errorf("unexpected dir-depth bounds: expected=%v, actual=%v (edges=%+v)",
-			expBounds, el.dirDepthBounds, el.edges)
+		return fmt.Errorf("unexpected dir-depth bounds: expected=%v, actual=%v "+
+			"(offsets=%+v, data=%+v)",
+			expBounds, el.dirDepthBounds, el.edgeOffset, el.edgeData)
 	}
 	return nil
 }

--- a/plugins/kvscheduler/internal/graph/edge_lookup_test.go
+++ b/plugins/kvscheduler/internal/graph/edge_lookup_test.go
@@ -116,9 +116,11 @@ func TestLookupOverNodeKeys(t *testing.T) {
 
 	// remove the rest
 	el.delNodeKey("prefix1/node1")
-	Expect(el.nodeKeys).To(HaveLen(1)) // gc-ed
+	Expect(el.nodeKeyData).To(HaveLen(1)) // gc-ed
+	Expect(el.nodeKeyOffset).To(HaveLen(1)) // gc-ed
 	el.delNodeKey("prefix2/node3")
-	Expect(el.nodeKeys).To(HaveLen(0)) // gc-ed
+	Expect(el.nodeKeyData).To(HaveLen(0)) // gc-ed
+	Expect(el.nodeKeyOffset).To(HaveLen(0)) // gc-ed
 
 	// empty prefix (select all)
 	el.iterTargets("", true, mi.visitNode)
@@ -295,14 +297,18 @@ func TestLookupOverNodeKeysWithOverlay(t *testing.T) {
 	Expect(mi.visitedNodes).To(HaveLen(1))
 	Expect(mi.visitedNodes).To(HaveKey("prefix1/node1"))
 	mi.reset()
-	Expect(elOver.nodeKeys).To(HaveLen(1))
-	Expect(el.nodeKeys).To(HaveLen(1))
+	Expect(elOver.nodeKeyData).To(HaveLen(1))
+	Expect(elOver.nodeKeyOffset).To(HaveLen(1))
+	Expect(el.nodeKeyData).To(HaveLen(1))
+	Expect(el.nodeKeyOffset).To(HaveLen(1))
 
 	// remove the last key in overlay, but do not save
 	Expect(el.makeOverlay()).To(Equal(elOver))
 	elOver.delNodeKey("prefix1/node1")
-	Expect(elOver.nodeKeys).To(HaveLen(0))
-	Expect(el.nodeKeys).To(HaveLen(1))
+	Expect(elOver.nodeKeyData).To(HaveLen(0))
+	Expect(elOver.nodeKeyOffset).To(HaveLen(0))
+	Expect(el.nodeKeyData).To(HaveLen(1))
+	Expect(el.nodeKeyOffset).To(HaveLen(1))
 	elOver.iterTargets("", true, mi.visitNode)
 	Expect(mi.visitedNodes).To(BeEmpty())
 
@@ -323,8 +329,10 @@ func TestLookupOverNodeKeysWithOverlay(t *testing.T) {
 	Expect(mi.visitedNodes).To(HaveLen(1))
 	Expect(mi.visitedNodes).To(HaveKey("prefix1/node1"))
 	mi.reset()
-	Expect(elOver.nodeKeys).To(HaveLen(1))
-	Expect(el.nodeKeys).To(HaveLen(1))
+	Expect(elOver.nodeKeyData).To(HaveLen(1))
+	Expect(elOver.nodeKeyOffset).To(HaveLen(1))
+	Expect(el.nodeKeyData).To(HaveLen(1))
+	Expect(el.nodeKeyOffset).To(HaveLen(1))
 }
 
 func TestLookupOverEdges(t *testing.T) {
@@ -381,7 +389,8 @@ func TestLookupOverEdges(t *testing.T) {
 	})
 	Expect(el.verifyDirDepthBounds()).To(BeNil())
 
-	Expect(el.edges).To(HaveLen(5))
+	Expect(el.edgeData).To(HaveLen(5))
+	Expect(el.edgeOffset).To(HaveLen(5))
 
 	el.iterSources("prefix1/node1", mi.visitEdge)
 	Expect(mi.visitedEdges).To(HaveLen(3))
@@ -420,7 +429,8 @@ func TestLookupOverEdges(t *testing.T) {
 		label:      "all",
 	})
 	Expect(el.verifyDirDepthBounds()).To(BeNil())
-	Expect(el.edges).To(HaveLen(5)) // not gc-ed yet
+	Expect(el.edgeData).To(HaveLen(5)) // not gc-ed yet
+	Expect(el.edgeOffset).To(HaveLen(5)) // not gc-ed yet
 
 	el.iterSources("prefix1/node1", mi.visitEdge)
 	Expect(mi.visitedEdges).To(HaveLen(2))
@@ -447,7 +457,8 @@ func TestLookupOverEdges(t *testing.T) {
 		label:      "prefix1 non-empty",
 	})
 	Expect(el.verifyDirDepthBounds()).To(BeNil())
-	Expect(el.edges).To(HaveLen(2)) // gc-ed
+	Expect(el.edgeData).To(HaveLen(2)) // gc-ed
+	Expect(el.edgeOffset).To(HaveLen(2)) // gc-ed
 
 	el.iterSources("prefix1/node1", mi.visitEdge)
 	Expect(mi.visitedEdges).To(HaveLen(1))
@@ -480,7 +491,8 @@ func TestLookupOverEdges(t *testing.T) {
 		label:      "edge to itself",
 	})
 	Expect(el.verifyDirDepthBounds()).To(BeNil())
-	Expect(el.edges).To(BeEmpty()) // gc-ed
+	Expect(el.edgeData).To(BeEmpty()) // gc-ed
+	Expect(el.edgeOffset).To(BeEmpty()) // gc-ed
 
 	el.iterSources("prefix1/node1", mi.visitEdge)
 	Expect(mi.visitedEdges).To(BeEmpty())
@@ -549,8 +561,8 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 	})
 	Expect(elOver.verifyDirDepthBounds()).To(BeNil())
 
-	Expect(el.edges).To(HaveLen(3))
-	Expect(elOver.edges).To(HaveLen(5))
+	Expect(el.edgeData).To(HaveLen(3))
+	Expect(elOver.edgeOffset).To(HaveLen(5))
 
 	// check overlay
 	elOver.iterSources("prefix1/node1", mi.visitEdge)
@@ -624,7 +636,8 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 		label:      "all",
 	})
 	Expect(elOver.verifyDirDepthBounds()).To(BeNil())
-	Expect(elOver.edges).To(HaveLen(5)) // not gc-ed yet
+	Expect(elOver.edgeData).To(HaveLen(5)) // not gc-ed yet
+	Expect(elOver.edgeOffset).To(HaveLen(5)) // not gc-ed yet
 
 	// check overlay
 	elOver.iterSources("prefix1/node1", mi.visitEdge)
@@ -686,8 +699,10 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 		label:      "prefix1 non-empty",
 	})
 	Expect(elOver.verifyDirDepthBounds()).To(BeNil())
-	Expect(elOver.edges).To(HaveLen(2)) // gc-ed
-	Expect(el.edges).To(HaveLen(5))
+	Expect(elOver.edgeData).To(HaveLen(2)) // gc-ed
+	Expect(elOver.edgeOffset).To(HaveLen(2)) // gc-ed
+	Expect(el.edgeOffset).To(HaveLen(5))
+	Expect(el.edgeData).To(HaveLen(5))
 
 	// check overlay
 	elOver.iterSources("prefix1/node1", mi.visitEdge)

--- a/plugins/kvscheduler/internal/graph/edge_lookup_test.go
+++ b/plugins/kvscheduler/internal/graph/edge_lookup_test.go
@@ -61,7 +61,7 @@ func TestLookupOverNodeKeys(t *testing.T) {
 
 	mi := newMockIter()
 
-	el := newEdgeLookup()
+	el := newEdgeLookup(nil)
 	Expect(el).ToNot(BeNil())
 
 	el.iterTargets("some-key", false, mi.visitNode)
@@ -151,7 +151,7 @@ func TestLookupOverNodeKeysWithOverlay(t *testing.T) {
 
 	mi := newMockIter()
 
-	el := newEdgeLookup()
+	el := newEdgeLookup(nil)
 	Expect(el).ToNot(BeNil())
 
 	el.addNodeKey("prefix1/node1")
@@ -332,7 +332,7 @@ func TestLookupOverEdges(t *testing.T) {
 
 	mi := newMockIter()
 
-	el := newEdgeLookup()
+	el := newEdgeLookup(nil)
 	Expect(el).ToNot(BeNil())
 
 	el.iterSources("some-key", mi.visitEdge)
@@ -497,7 +497,7 @@ func TestLookupOverEdgesWithOverlay(t *testing.T) {
 
 	mi := newMockIter()
 
-	el := newEdgeLookup()
+	el := newEdgeLookup(nil)
 	Expect(el).ToNot(BeNil())
 
 	el.addEdge(edge{ // "prefix1/node2" -> "prefix1/node1"

--- a/plugins/kvscheduler/internal/graph/graph_impl.go
+++ b/plugins/kvscheduler/internal/graph/graph_impl.go
@@ -68,7 +68,7 @@ func NewGraph(opts Opts) Graph {
 		permanentInitPeriod: time.Duration(opts.PermanentInitPeriod) * time.Minute,
 		methodTracker:       opts.MethodTracker,
 	}
-	kvgraph.graph = newGraphR()
+	kvgraph.graph = newGraphR(opts.MethodTracker)
 	kvgraph.graph.parent = kvgraph
 	return kvgraph
 }

--- a/plugins/kvscheduler/internal/graph/graph_read.go
+++ b/plugins/kvscheduler/internal/graph/graph_read.go
@@ -47,14 +47,14 @@ type graphR struct {
 }
 
 // newGraphR creates and initializes a new instance of graphR.
-func newGraphR() *graphR {
+func newGraphR(mt MethodTracker) *graphR {
 	var el *edgeLookup
 	if benchEl != nil {
 		// this is a benchmark
 		el = benchEl
 		el.reset()
 	} else {
-		el = newEdgeLookup()
+		el = newEdgeLookup(mt)
 	}
 	return &graphR{
 		edgeLookup: el,


### PR DESCRIPTION
Improved `edgeLookup` from `kvscheduler/internal/graph` to avoid very expensive memmove of data with pointers - from the CPU profile of GRPC perf test:
```
      flat  flat%   sum%        cum   cum%
    12.83s 33.46% 33.46%     12.83s 33.46%  runtime.memmove
     3.20s  8.34% 41.80%      3.20s  8.34%  runtime.futex
     2.59s  6.75% 48.55%      2.92s  7.61%  syscall.Syscall
     1.41s  3.68% 52.23%      1.41s  3.68%  runtime.usleep
     0.74s  1.93% 54.16%      0.74s  1.93%  runtime.epollwait
     0.68s  1.77% 55.93%      1.57s  4.09%  runtime.scanobject
     0.52s  1.36% 57.29%      2.19s  5.71%  runtime.mallocgc
     0.44s  1.15% 58.44%      0.44s  1.15%  runtime.memclrNoHeapPointers
     0.41s  1.07% 59.50%      0.41s  1.07%  cmpbody
     0.35s  0.91% 60.42%      0.42s  1.10%  runtime.findObject
```

With this improvement, the time spent in `Graph.SetNode` and especially in `Graph.SetTargets` should decrease significantly. 

Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>