### PR TITLE
Fix for SRv6 localsid delete in nonzero vrf tables

### DIFF
--- a/plugins/vpp/srplugin/descriptor/localsid.go
+++ b/plugins/vpp/srplugin/descriptor/localsid.go
@@ -182,9 +182,8 @@ func (d *LocalSIDDescriptor) Create(key string, value *srv6.LocalSID) (metadata 
 
 // Delete removes Local SID from VPP using VPP's binary api
 func (d *LocalSIDDescriptor) Delete(key string, value *srv6.LocalSID, metadata interface{}) error {
-	sid, _ := ParseIPv6(value.GetSid()) // already validated
-	if err := d.srHandler.DeleteLocalSid(sid); err != nil {
-		return errors.Errorf("failed to delete local sid %s: %v", sid.String(), err)
+	if err := d.srHandler.DeleteLocalSid(value); err != nil {
+		return errors.Errorf("failed to delete local sid %s: %v", value.GetSid(), err)
 	}
 	return nil
 }

--- a/plugins/vpp/srplugin/vppcalls/api_vppcalls.go
+++ b/plugins/vpp/srplugin/vppcalls/api_vppcalls.go
@@ -33,8 +33,8 @@ type SRv6VppAPI interface {
 type SRv6VPPWrite interface {
 	// AddLocalSid adds local sid <localSID> into VPP
 	AddLocalSid(localSID *srv6.LocalSID) error
-	// DeleteLocalSid delets local sid given by <sidAddr> in VPP
-	DeleteLocalSid(sidAddr net.IP) error
+	// DeleteLocalSid deletes local sid <localSID> in VPP
+	DeleteLocalSid(localSID *srv6.LocalSID) error
 	// SetEncapsSourceAddress sets for SRv6 in VPP the source address used for encapsulated packet
 	SetEncapsSourceAddress(address string) error
 	// AddPolicy adds SRv6 policy <policy> into VPP (including all policy's segment lists).

--- a/plugins/vpp/srplugin/vppcalls/vpp1901/srv6.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp1901/srv6.go
@@ -62,21 +62,21 @@ const (
 
 // AddLocalSid adds local sid <localSID> into VPP
 func (h *SRv6VppHandler) AddLocalSid(localSID *srv6.LocalSID) error {
-	sidAddr, err := parseIPv6(localSID.GetSid())
+	return h.addDelLocalSid(false, localSID)
+}
+
+// DeleteLocalSid deletes local sid <localSID> in VPP
+func (h *SRv6VppHandler) DeleteLocalSid(localSID *srv6.LocalSID) error {
+	return h.addDelLocalSid(true, localSID)
+}
+
+func (h *SRv6VppHandler) addDelLocalSid(deletion bool, localSID *srv6.LocalSID) error {
+	h.log.WithFields(logging.Fields{"localSID": localSID.GetSid(), "delete": deletion, "installationVrfID": h.installationVrfID(localSID), "end function": h.endFunction(localSID)}).
+		Debug("Adding/deleting Local SID", localSID.GetSid())
+	sidAddr, err := parseIPv6(localSID.GetSid()) // parsing to get some standard sid form
 	if err != nil {
 		return fmt.Errorf("sid address %s is not IPv6 address: %v", localSID.GetSid(), err) // calls from descriptor are already validated
 	}
-	return h.addDelLocalSid(false, sidAddr, localSID)
-}
-
-// DeleteLocalSid delets local sid given by <sidAddr> in VPP
-func (h *SRv6VppHandler) DeleteLocalSid(sidAddr net.IP) error {
-	return h.addDelLocalSid(true, sidAddr, nil)
-}
-
-func (h *SRv6VppHandler) addDelLocalSid(deletion bool, sidAddr net.IP, localSID *srv6.LocalSID) error {
-	h.log.WithFields(logging.Fields{"localSID": sidAddr, "delete": deletion, "installationVrfID": h.installationVrfID(localSID), "end function": h.endFunction(localSID)}).
-		Debug("Adding/deleting Local SID", sidAddr)
 	if !deletion && localSID.GetEndFunction_AD() != nil {
 		return h.addSRProxy(sidAddr, localSID)
 	}
@@ -84,9 +84,9 @@ func (h *SRv6VppHandler) addDelLocalSid(deletion bool, sidAddr net.IP, localSID 
 		IsDel:    boolToUint(deletion),
 		Localsid: sr.Srv6Sid{Addr: []byte(sidAddr)},
 	}
+	req.FibTable = localSID.InstallationVrfId // where to install localsid entry/from where to remove installed localsid entry
 	if !deletion {
-		req.FibTable = localSID.InstallationVrfId // where to install localsid entry
-		if err := h.writeEndFunction(req, sidAddr, localSID); err != nil {
+		if err := h.writeEndFunction(req, localSID); err != nil {
 			return err
 		}
 	}
@@ -202,7 +202,7 @@ func (h *SRv6VppHandler) endFunction(localSID *srv6.LocalSID) string {
 	}
 }
 
-func (h *SRv6VppHandler) writeEndFunction(req *sr.SrLocalsidAddDel, sidAddr net.IP, localSID *srv6.LocalSID) error {
+func (h *SRv6VppHandler) writeEndFunction(req *sr.SrLocalsidAddDel, localSID *srv6.LocalSID) error {
 	switch ef := localSID.EndFunction.(type) {
 	case *srv6.LocalSID_BaseEndFunction:
 		req.Behavior = BehaviorEnd
@@ -271,7 +271,7 @@ func (h *SRv6VppHandler) writeEndFunction(req *sr.SrLocalsidAddDel, sidAddr net.
 		req.Behavior = BehaviorDT6
 		req.SwIfIndex = ef.EndFunction_DT6.VrfId
 	case nil:
-		return fmt.Errorf("End function not set. Please configure end function for local SID %v ", sidAddr)
+		return fmt.Errorf("End function not set. Please configure end function for local SID %v ", localSID.GetSid())
 	default:
 		return fmt.Errorf("unknown end function (model link type %T)", ef) // EndFunction_AD is handled elsewhere
 	}

--- a/plugins/vpp/srplugin/vppcalls/vpp1901/srv6_test.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp1901/srv6_test.go
@@ -646,25 +646,63 @@ func TestDeleteLocalSID(t *testing.T) {
 	cases := []struct {
 		Name      string
 		Fail      bool
-		Sid       net.IP
+		Input     *srv6.LocalSID
 		MockReply govppapi.Message
 		Verify    func(error, govppapi.Message)
 	}{
 		{
-			Name:      "simple delete of local sid",
-			Sid:       sidA.Addr,
+			Name: "simple delete of local sid (using vrf table with id 0)",
+			Input: &srv6.LocalSID{
+				Sid:               sidToStr(sidA),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_BaseEndFunction{
+					BaseEndFunction: &srv6.LocalSID_End{
+						Psp: true,
+					},
+				},
+			},
 			MockReply: &sr.SrLocalsidAddDelReply{},
 			Verify: func(err error, catchedMsg govppapi.Message) {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(catchedMsg).To(Equal(&sr.SrLocalsidAddDel{
 					IsDel:    1,
 					Localsid: sidA,
+					FibTable: 0,
 				}))
 			},
 		},
 		{
-			Name:      "failure propagation from VPP",
-			Sid:       sidA.Addr,
+			Name: "simple delete of local sid (using vrf table with nonzero id)",
+			Input: &srv6.LocalSID{
+				Sid:               sidToStr(sidA),
+				InstallationVrfId: 10,
+				EndFunction: &srv6.LocalSID_BaseEndFunction{
+					BaseEndFunction: &srv6.LocalSID_End{
+						Psp: true,
+					},
+				},
+			},
+			MockReply: &sr.SrLocalsidAddDelReply{},
+			Verify: func(err error, catchedMsg govppapi.Message) {
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(catchedMsg).To(Equal(&sr.SrLocalsidAddDel{
+					IsDel:    1,
+					Localsid: sidA,
+					FibTable: 10,
+				}))
+			},
+		},
+		{
+			Name: "failure propagation from VPP",
+			Input: &srv6.LocalSID{
+				Sid:               sidToStr(sidA),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_BaseEndFunction{
+					BaseEndFunction: &srv6.LocalSID_End{
+						Psp: true,
+					},
+				},
+			},
 			MockReply: &sr.SrLocalsidAddDelReply{Retval: 1},
 			Verify: func(err error, msg govppapi.Message) {
 				Expect(err).Should(HaveOccurred())
@@ -677,20 +715,10 @@ func TestDeleteLocalSID(t *testing.T) {
 		t.Run(td.Name, func(t *testing.T) {
 			ctx, vppCalls := setup(t)
 			defer teardown(ctx)
-			// data and prepare case
-			localsid := &srv6.LocalSID{
-				Sid:               td.Sid.String(),
-				InstallationVrfId: 10,
-				EndFunction: &srv6.LocalSID_BaseEndFunction{
-					BaseEndFunction: &srv6.LocalSID_End{
-						Psp: true,
-					},
-				},
-			}
-			vppCalls.AddLocalSid(localsid)
+			// prepare for case
 			ctx.MockVpp.MockReply(td.MockReply)
 			// make the call and verify
-			err := vppCalls.DeleteLocalSid(td.Sid)
+			err := vppCalls.DeleteLocalSid(td.Input)
 			td.Verify(err, ctx.MockChannel.Msg)
 		})
 	}

--- a/plugins/vpp/srplugin/vppcalls/vpp1904/srv6.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp1904/srv6.go
@@ -62,21 +62,21 @@ const (
 
 // AddLocalSid adds local sid <localSID> into VPP
 func (h *SRv6VppHandler) AddLocalSid(localSID *srv6.LocalSID) error {
-	sidAddr, err := parseIPv6(localSID.GetSid())
+	return h.addDelLocalSid(false, localSID)
+}
+
+// DeleteLocalSid deletes local sid <localSID> in VPP
+func (h *SRv6VppHandler) DeleteLocalSid(localSID *srv6.LocalSID) error {
+	return h.addDelLocalSid(true, localSID)
+}
+
+func (h *SRv6VppHandler) addDelLocalSid(deletion bool, localSID *srv6.LocalSID) error {
+	h.log.WithFields(logging.Fields{"localSID": localSID.GetSid(), "delete": deletion, "installationVrfID": h.installationVrfID(localSID), "end function": h.endFunction(localSID)}).
+		Debug("Adding/deleting Local SID", localSID.GetSid())
+	sidAddr, err := parseIPv6(localSID.GetSid()) // parsing to get some standard sid form
 	if err != nil {
 		return fmt.Errorf("sid address %s is not IPv6 address: %v", localSID.GetSid(), err) // calls from descriptor are already validated
 	}
-	return h.addDelLocalSid(false, sidAddr, localSID)
-}
-
-// DeleteLocalSid delets local sid given by <sidAddr> in VPP
-func (h *SRv6VppHandler) DeleteLocalSid(sidAddr net.IP) error {
-	return h.addDelLocalSid(true, sidAddr, nil)
-}
-
-func (h *SRv6VppHandler) addDelLocalSid(deletion bool, sidAddr net.IP, localSID *srv6.LocalSID) error {
-	h.log.WithFields(logging.Fields{"localSID": sidAddr, "delete": deletion, "installationVrfID": h.installationVrfID(localSID), "end function": h.endFunction(localSID)}).
-		Debug("Adding/deleting Local SID", sidAddr)
 	if !deletion && localSID.GetEndFunction_AD() != nil {
 		return h.addSRProxy(sidAddr, localSID)
 	}
@@ -84,9 +84,9 @@ func (h *SRv6VppHandler) addDelLocalSid(deletion bool, sidAddr net.IP, localSID 
 		IsDel:    boolToUint(deletion),
 		Localsid: sr.Srv6Sid{Addr: []byte(sidAddr)},
 	}
+	req.FibTable = localSID.InstallationVrfId // where to install localsid entry/from where to remove installed localsid entry
 	if !deletion {
-		req.FibTable = localSID.InstallationVrfId // where to install localsid entry
-		if err := h.writeEndFunction(req, sidAddr, localSID); err != nil {
+		if err := h.writeEndFunction(req, localSID); err != nil {
 			return err
 		}
 	}
@@ -202,7 +202,7 @@ func (h *SRv6VppHandler) endFunction(localSID *srv6.LocalSID) string {
 	}
 }
 
-func (h *SRv6VppHandler) writeEndFunction(req *sr.SrLocalsidAddDel, sidAddr net.IP, localSID *srv6.LocalSID) error {
+func (h *SRv6VppHandler) writeEndFunction(req *sr.SrLocalsidAddDel, localSID *srv6.LocalSID) error {
 	switch ef := localSID.EndFunction.(type) {
 	case *srv6.LocalSID_BaseEndFunction:
 		req.Behavior = BehaviorEnd
@@ -271,7 +271,7 @@ func (h *SRv6VppHandler) writeEndFunction(req *sr.SrLocalsidAddDel, sidAddr net.
 		req.Behavior = BehaviorDT6
 		req.SwIfIndex = ef.EndFunction_DT6.VrfId
 	case nil:
-		return fmt.Errorf("End function not set. Please configure end function for local SID %v ", sidAddr)
+		return fmt.Errorf("End function not set. Please configure end function for local SID %v ", localSID.GetSid())
 	default:
 		return fmt.Errorf("unknown end function (model link type %T)", ef) // EndFunction_AD is handled elsewhere
 	}

--- a/plugins/vpp/srplugin/vppcalls/vpp1904/srv6_test.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp1904/srv6_test.go
@@ -646,25 +646,63 @@ func TestDeleteLocalSID(t *testing.T) {
 	cases := []struct {
 		Name      string
 		Fail      bool
-		Sid       net.IP
+		Input     *srv6.LocalSID
 		MockReply govppapi.Message
 		Verify    func(error, govppapi.Message)
 	}{
 		{
-			Name:      "simple delete of local sid",
-			Sid:       sidA.Addr,
+			Name: "simple delete of local sid (using vrf table with id 0)",
+			Input: &srv6.LocalSID{
+				Sid:               sidToStr(sidA),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_BaseEndFunction{
+					BaseEndFunction: &srv6.LocalSID_End{
+						Psp: true,
+					},
+				},
+			},
 			MockReply: &sr.SrLocalsidAddDelReply{},
 			Verify: func(err error, catchedMsg govppapi.Message) {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(catchedMsg).To(Equal(&sr.SrLocalsidAddDel{
 					IsDel:    1,
 					Localsid: sidA,
+					FibTable: 0,
 				}))
 			},
 		},
 		{
-			Name:      "failure propagation from VPP",
-			Sid:       sidA.Addr,
+			Name: "simple delete of local sid (using vrf table with nonzero id)",
+			Input: &srv6.LocalSID{
+				Sid:               sidToStr(sidA),
+				InstallationVrfId: 10,
+				EndFunction: &srv6.LocalSID_BaseEndFunction{
+					BaseEndFunction: &srv6.LocalSID_End{
+						Psp: true,
+					},
+				},
+			},
+			MockReply: &sr.SrLocalsidAddDelReply{},
+			Verify: func(err error, catchedMsg govppapi.Message) {
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(catchedMsg).To(Equal(&sr.SrLocalsidAddDel{
+					IsDel:    1,
+					Localsid: sidA,
+					FibTable: 10,
+				}))
+			},
+		},
+		{
+			Name: "failure propagation from VPP",
+			Input: &srv6.LocalSID{
+				Sid:               sidToStr(sidA),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_BaseEndFunction{
+					BaseEndFunction: &srv6.LocalSID_End{
+						Psp: true,
+					},
+				},
+			},
 			MockReply: &sr.SrLocalsidAddDelReply{Retval: 1},
 			Verify: func(err error, msg govppapi.Message) {
 				Expect(err).Should(HaveOccurred())
@@ -677,20 +715,10 @@ func TestDeleteLocalSID(t *testing.T) {
 		t.Run(td.Name, func(t *testing.T) {
 			ctx, vppCalls := setup(t)
 			defer teardown(ctx)
-			// data and prepare case
-			localsid := &srv6.LocalSID{
-				Sid:               td.Sid.String(),
-				InstallationVrfId: 10,
-				EndFunction: &srv6.LocalSID_BaseEndFunction{
-					BaseEndFunction: &srv6.LocalSID_End{
-						Psp: true,
-					},
-				},
-			}
-			vppCalls.AddLocalSid(localsid)
+			// prepare for case
 			ctx.MockVpp.MockReply(td.MockReply)
 			// make the call and verify
-			err := vppCalls.DeleteLocalSid(td.Sid)
+			err := vppCalls.DeleteLocalSid(td.Input)
 			td.Verify(err, ctx.MockChannel.Msg)
 		})
 	}


### PR DESCRIPTION
+ unit tests covering it