### PR TITLE
Make channel for notifications buffered

### DIFF
--- a/plugins/vpp/ifplugin/vppcalls/vpp1901/watch_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp1901/watch_vppcalls.go
@@ -32,7 +32,7 @@ import (
 var InterfaceEventTimeout = time.Second
 
 func (h *InterfaceVppHandler) WatchInterfaceEvents(events chan<- *vppcalls.InterfaceEvent) error {
-	notifChan := make(chan govppapi.Message)
+	notifChan := make(chan govppapi.Message, 10)
 
 	// subscribe for receiving SwInterfaceEvents notifications
 	vppNotifSubs, err := h.callsChannel.SubscribeNotification(notifChan, &binapi_interfaces.SwInterfaceEvent{})

--- a/plugins/vpp/ifplugin/vppcalls/vpp1904/watch_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp1904/watch_vppcalls.go
@@ -32,7 +32,7 @@ import (
 var InterfaceEventTimeout = time.Second
 
 func (h *InterfaceVppHandler) WatchInterfaceEvents(events chan<- *vppcalls.InterfaceEvent) error {
-	notifChan := make(chan govppapi.Message)
+	notifChan := make(chan govppapi.Message, 10)
 
 	// subscribe for receiving SwInterfaceEvents notifications
 	vppNotifSubs, err := h.callsChannel.SubscribeNotification(notifChan, &binapi_interfaces.SwInterfaceEvent{})


### PR DESCRIPTION
Even though notifications are processed quickly in separate go
routines, it still may not be enough if multiple of them are
received at roughly the same time, causing potential drops.
Added small buffer for the notification channel.