### PR TITLE
Add some (temporary) debug logs for interface state updates

### DIFF
--- a/plugins/vpp/ifplugin/descriptor/link_state.go
+++ b/plugins/vpp/ifplugin/descriptor/link_state.go
@@ -113,6 +113,8 @@ func (w *LinkStateDescriptor) UpdateLinkState(ifaceState *interfaces.InterfaceNo
 	w.linkStatesMx.Lock()
 	defer w.linkStatesMx.Unlock()
 
+	w.log.Debugf("Updating link state: %+v", ifaceState)
+
 	var notifs []kvs.KVWithMetadata
 
 	operStatus := ifaceState.State.OperStatus
@@ -130,6 +132,7 @@ func (w *LinkStateDescriptor) UpdateLinkState(ifaceState *interfaces.InterfaceNo
 				Value:    nil,
 				Metadata: nil,
 			})
+			delete(w.linkStates, ifaceName)
 		}
 	}
 

--- a/plugins/vpp/ifplugin/publish_state.go
+++ b/plugins/vpp/ifplugin/publish_state.go
@@ -99,6 +99,8 @@ func (p *IfPlugin) publishIfStateEvents() {
 			p.publishLock.Lock()
 			key := interfaces.InterfaceStateKey(ifState.State.Name)
 
+			p.Log.Debugf("Publishing interface state: %+v", ifState)
+
 			if p.PublishStatistics != nil {
 				err := p.PublishStatistics.Put(key, ifState.State)
 				if err != nil {


### PR DESCRIPTION
Added temporary logs to help with the issue https://github.com/ligato/vpp-agent/issues/1365
In the reported case it seems that ALL interface state notifications are lost somewhere along the way...

Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>