### PR TITLE
tweaked interface statistics

### DIFF
--- a/plugins/vpp/ifplugin/publish_state.go
+++ b/plugins/vpp/ifplugin/publish_state.go
@@ -101,18 +101,16 @@ func (p *IfPlugin) publishIfStateEvents() {
 
 			p.Log.Debugf("Publishing interface state: %+v", ifState)
 
-			if p.PublishStatistics != nil {
-				err := p.PublishStatistics.Put(key, ifState.State)
-				if err != nil {
-					if lastPublishErr == nil || lastPublishErr.Error() != err.Error() {
-						p.Log.Error(err)
-					}
+			err := p.PublishStatistics.Put(key, ifState.State)
+			if err != nil {
+				if lastPublishErr == nil || lastPublishErr.Error() != err.Error() {
+					p.Log.Error(err)
 				}
-				lastPublishErr = err
 			}
+			lastPublishErr = err
 
 			// Marshall data into JSON & send kafka message.
-			if p.NotifyStates != nil && ifState.Type == interfaces.InterfaceNotification_UPDOWN {
+			if ifState.Type == interfaces.InterfaceNotification_UPDOWN {
 				err := p.NotifyStates.Put(key, ifState.State)
 				if err != nil {
 					if lastNotifErr == nil || lastNotifErr.Error() != err.Error() {


### PR DESCRIPTION
In the current state, the interface and interface stats plugins are starting goroutines for statistics handling even if no publishers are set. Statistics and counters are read and processed and then dropped since there is nowhere to send them. Changes:
* watcher for status events is started only when at least one status publisher is enabled
* reading counters and updating if-state details is started only when some status publisher or messaging plugin is enabled. Especially `doUpdatesIfStateDetails` may have a major impact since it periodically calls `DumpInterfaces` and was always started.

Since there is no way how to find out whether the messaging plugin is usable (as in this case where the Kafka plugin is hard-coded but mostly disabled), the messaging was temporarily removed from the agent. 

Signed-off-by: Vladimir Lavor <vlavor@cisco.com>