### PR TITLE
Fix dumps for unavailable handlers

### DIFF
--- a/cmd/vpp-agent/app/vpp_agent.go
+++ b/cmd/vpp-agent/app/vpp_agent.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ligato/cn-infra/health/statuscheck"
 	"github.com/ligato/cn-infra/logging/logmanager"
 	"github.com/ligato/cn-infra/messaging/kafka"
-	"github.com/ligato/vpp-agent/plugins/vpp/srplugin"
 
 	"github.com/ligato/vpp-agent/plugins/configurator"
 	linux_ifplugin "github.com/ligato/vpp-agent/plugins/linux/ifplugin"
@@ -45,6 +44,7 @@ import (
 	"github.com/ligato/vpp-agent/plugins/vpp/l3plugin"
 	"github.com/ligato/vpp-agent/plugins/vpp/natplugin"
 	"github.com/ligato/vpp-agent/plugins/vpp/puntplugin"
+	"github.com/ligato/vpp-agent/plugins/vpp/srplugin"
 	"github.com/ligato/vpp-agent/plugins/vpp/stnplugin"
 )
 

--- a/plugins/configurator/dump.go
+++ b/plugins/configurator/dump.go
@@ -1,7 +1,6 @@
 package configurator
 
 import (
-	"github.com/go-errors/errors"
 	"github.com/ligato/cn-infra/logging"
 	"golang.org/x/net/context"
 
@@ -12,6 +11,7 @@ import (
 	vpp_ipsec "github.com/ligato/vpp-agent/api/models/vpp/ipsec"
 	vpp_l2 "github.com/ligato/vpp-agent/api/models/vpp/l2"
 	vpp_l3 "github.com/ligato/vpp-agent/api/models/vpp/l3"
+	vpp_nat "github.com/ligato/vpp-agent/api/models/vpp/nat"
 	vpp_punt "github.com/ligato/vpp-agent/api/models/vpp/punt"
 	iflinuxcalls "github.com/ligato/vpp-agent/plugins/linux/ifplugin/linuxcalls"
 	l3linuxcalls "github.com/ligato/vpp-agent/plugins/linux/l3plugin/linuxcalls"
@@ -29,19 +29,24 @@ type dumpService struct {
 	log logging.Logger
 
 	// VPP Handlers
-	aclHandler   aclvppcalls.ACLVppRead
-	abfHandler   abfvppcalls.ABFVppRead
+
+	// core
 	ifHandler    ifvppcalls.InterfaceVppRead
-	natHandler   natvppcalls.NatVppRead
 	l2Handler    l2vppcalls.L2VppAPI
 	l3Handler    l3vppcalls.L3VppAPI
 	ipsecHandler ipsecvppcalls.IPSecVPPRead
-	puntHandler  vppcalls.PuntVPPRead
+	// plugins
+	aclHandler  aclvppcalls.ACLVppRead
+	abfHandler  abfvppcalls.ABFVppRead
+	natHandler  natvppcalls.NatVppRead
+	puntHandler vppcalls.PuntVPPRead
+
 	// Linux handlers
 	linuxIfHandler iflinuxcalls.NetlinkAPIRead
 	linuxL3Handler l3linuxcalls.NetlinkAPIRead
 }
 
+// Dump implements Dump method for Configurator
 func (svc *dumpService) Dump(context.Context, *rpc.DumpRequest) (*rpc.DumpResponse, error) {
 	defer trackOperation("Dump")()
 
@@ -51,44 +56,15 @@ func (svc *dumpService) Dump(context.Context, *rpc.DumpRequest) (*rpc.DumpRespon
 
 	var err error
 
+	// core
 	dump.VppConfig.Interfaces, err = svc.DumpInterfaces()
 	if err != nil {
 		svc.log.Errorf("DumpInterfaces failed: %v", err)
 		return nil, err
 	}
-	dump.VppConfig.Acls, err = svc.DumpAcls()
-	if err != nil {
-		svc.log.Errorf("DumpAcls failed: %v", err)
-		return nil, err
-	}
-	dump.VppConfig.Abfs, err = svc.DumpAbfs()
-	if err != nil {
-		svc.log.Errorf("DumpAbfs failed: %v", err)
-		return nil, err
-	}
-	dump.VppConfig.IpsecSpds, err = svc.DumpIPSecSPDs()
-	if err != nil {
-		svc.log.Errorf("DumpIPSecSPDs failed: %v", err)
-		return nil, err
-	}
-	dump.VppConfig.IpsecSas, err = svc.DumpIPSecSAs()
-	if err != nil {
-		svc.log.Errorf("DumpIPSecSAs failed: %v", err)
-		return nil, err
-	}
 	dump.VppConfig.BridgeDomains, err = svc.DumpBDs()
 	if err != nil {
 		svc.log.Errorf("DumpBDs failed: %v", err)
-		return nil, err
-	}
-	dump.VppConfig.Routes, err = svc.DumpRoutes()
-	if err != nil {
-		svc.log.Errorf("DumpRoutes failed: %v", err)
-		return nil, err
-	}
-	dump.VppConfig.Arps, err = svc.DumpARPs()
-	if err != nil {
-		svc.log.Errorf("DumpARPs failed: %v", err)
 		return nil, err
 	}
 	dump.VppConfig.Fibs, err = svc.DumpFIBs()
@@ -101,25 +77,212 @@ func (svc *dumpService) Dump(context.Context, *rpc.DumpRequest) (*rpc.DumpRespon
 		svc.log.Errorf("DumpXConnects failed: %v", err)
 		return nil, err
 	}
+	dump.VppConfig.Routes, err = svc.DumpRoutes()
+	if err != nil {
+		svc.log.Errorf("DumpRoutes failed: %v", err)
+		return nil, err
+	}
+	dump.VppConfig.Arps, err = svc.DumpARPs()
+	if err != nil {
+		svc.log.Errorf("DumpARPs failed: %v", err)
+		return nil, err
+	}
+	dump.VppConfig.IpsecSpds, err = svc.DumpIPSecSPDs()
+	if err != nil {
+		svc.log.Errorf("DumpIPSecSPDs failed: %v", err)
+		return nil, err
+	}
+	dump.VppConfig.IpsecSas, err = svc.DumpIPSecSAs()
+	if err != nil {
+		svc.log.Errorf("DumpIPSecSAs failed: %v", err)
+		return nil, err
+	}
+
+	// plugins
+	dump.VppConfig.Acls, err = svc.DumpACLs()
+	if err != nil {
+		svc.log.Errorf("DumpACLs failed: %v", err)
+		return nil, err
+	}
+	dump.VppConfig.Abfs, err = svc.DumpABFs()
+	if err != nil {
+		svc.log.Errorf("DumpABFs failed: %v", err)
+		return nil, err
+	}
+	dump.VppConfig.Nat44Global, err = svc.DumpNAT44Global()
+	if err != nil {
+		svc.log.Errorf("DumpNAT44Global failed: %v", err)
+		return nil, err
+	}
+	dump.VppConfig.Dnat44S, err = svc.DumpDNAT44s()
+	if err != nil {
+		svc.log.Errorf("DumpDNAT44s failed: %v", err)
+		return nil, err
+	}
 	dump.VppConfig.PuntTohosts, err = svc.DumpPunt()
 	if err != nil {
 		svc.log.Errorf("DumpPunt failed: %v", err)
 		return nil, err
 	}
 
-	// FIXME: linux interface handler should return known proto instead of netlink
+	// FIXME: linux interfaces should return known proto instead of netlink
 	// state.LinuxData.Interfaces, _ = svc.DumpLinuxInterfaces()
 
 	return &rpc.DumpResponse{Dump: dump}, nil
 }
 
-// DumpAcls reads IP/MACIP access lists and returns them as an *AclResponse. If reading ends up with error,
+// DumpInterfaces reads interfaces and returns them as an *InterfaceResponse. If reading ends up with error,
 // only error is send back in response
-func (svc *dumpService) DumpAcls() ([]*vpp_acl.ACL, error) {
-	var acls []*vpp_acl.ACL
-	if svc.aclHandler == nil {
-		return nil, errors.New("aclHandler is not available")
+func (svc *dumpService) DumpInterfaces() (ifs []*vpp_interfaces.Interface, err error) {
+	if svc.ifHandler == nil {
+		// handler is not available
+		return nil, nil
 	}
+
+	ifDetails, err := svc.ifHandler.DumpInterfaces()
+	if err != nil {
+		return nil, err
+	}
+	for _, iface := range ifDetails {
+		ifs = append(ifs, iface.Interface)
+	}
+	return ifs, nil
+}
+
+// DumpIPSecSPDs reads IPSec SPD and returns them as an *IPSecSPDResponse. If reading ends up with error,
+// only error is send back in response
+func (svc *dumpService) DumpIPSecSPDs() (spds []*vpp_ipsec.SecurityPolicyDatabase, err error) {
+	if svc.ipsecHandler == nil {
+		// handler is not available
+		return nil, nil
+	}
+
+	spdDetails, err := svc.ipsecHandler.DumpIPSecSPD()
+	if err != nil {
+		return nil, err
+	}
+	for _, spd := range spdDetails {
+		spds = append(spds, spd.Spd)
+	}
+	return spds, nil
+}
+
+// DumpIPSecSAs reads IPSec SA and returns them as an *IPSecSAResponse. If reading ends up with error,
+// only error is send back in response
+func (svc *dumpService) DumpIPSecSAs() (sas []*vpp_ipsec.SecurityAssociation, err error) {
+	if svc.ipsecHandler == nil {
+		// handler is not available
+		return nil, nil
+	}
+
+	saDetails, err := svc.ipsecHandler.DumpIPSecSA()
+	if err != nil {
+		return nil, err
+	}
+	for _, sa := range saDetails {
+		sas = append(sas, sa.Sa)
+	}
+	return sas, nil
+}
+
+// DumpBDs reads bridge domains and returns them as an *BDResponse. If reading ends up with error,
+// only error is send back in response
+func (svc *dumpService) DumpBDs() (bds []*vpp_l2.BridgeDomain, err error) {
+	if svc.l2Handler == nil {
+		// handler is not available
+		return nil, nil
+	}
+
+	bdDetails, err := svc.l2Handler.DumpBridgeDomains()
+	if err != nil {
+		return nil, err
+	}
+	for _, bd := range bdDetails {
+		bds = append(bds, bd.Bd)
+	}
+	return bds, nil
+}
+
+// DumpFIBs reads FIBs and returns them as an *FibResponse. If reading ends up with error,
+// only error is send back in response
+func (svc *dumpService) DumpFIBs() (fibs []*vpp_l2.FIBEntry, err error) {
+	if svc.l2Handler == nil {
+		// handler is not available
+		return nil, nil
+	}
+
+	fibDetails, err := svc.l2Handler.DumpL2FIBs()
+	if err != nil {
+		return nil, err
+	}
+	for _, fib := range fibDetails {
+		fibs = append(fibs, fib.Fib)
+	}
+	return fibs, nil
+}
+
+// DumpXConnects reads cross connects and returns them as an *XcResponse. If reading ends up with error,
+// only error is send back in response
+func (svc *dumpService) DumpXConnects() (xcs []*vpp_l2.XConnectPair, err error) {
+	if svc.l2Handler == nil {
+		// handler is not available
+		return nil, nil
+	}
+
+	xcDetails, err := svc.l2Handler.DumpXConnectPairs()
+	if err != nil {
+		return nil, err
+	}
+	for _, xc := range xcDetails {
+		xcs = append(xcs, xc.Xc)
+	}
+	return xcs, nil
+}
+
+// DumpRoutes reads VPP routes and returns them as an *RoutesResponse. If reading ends up with error,
+// only error is send back in response
+func (svc *dumpService) DumpRoutes() (routes []*vpp_l3.Route, err error) {
+	if svc.l3Handler == nil {
+		// handler is not available
+		return nil, nil
+	}
+
+	rtDetails, err := svc.l3Handler.DumpRoutes()
+	if err != nil {
+		return nil, err
+	}
+	for _, rt := range rtDetails {
+		routes = append(routes, rt.Route)
+	}
+	return routes, nil
+}
+
+// DumpARPs reads VPP ARPs and returns them as an *ARPsResponse. If reading ends up with error,
+// only error is send back in response
+func (svc *dumpService) DumpARPs() (arps []*vpp_l3.ARPEntry, err error) {
+	if svc.l3Handler == nil {
+		// handler is not available
+		return nil, nil
+	}
+
+	arpDetails, err := svc.l3Handler.DumpArpEntries()
+	if err != nil {
+		return nil, err
+	}
+	for _, arp := range arpDetails {
+		arps = append(arps, arp.Arp)
+	}
+	return arps, nil
+}
+
+// DumpACLs reads IP/MACIP access lists and returns them as an *AclResponse. If reading ends up with error,
+// only error is send back in response
+func (svc *dumpService) DumpACLs() (acls []*vpp_acl.ACL, err error) {
+	if svc.aclHandler == nil {
+		// handler is not available
+		return nil, nil
+	}
+
 	ipACLs, err := svc.aclHandler.DumpACL()
 	if err != nil {
 		return nil, err
@@ -134,17 +297,17 @@ func (svc *dumpService) DumpAcls() ([]*vpp_acl.ACL, error) {
 	for _, aclDetails := range macIPACLs {
 		acls = append(acls, aclDetails.ACL)
 	}
-
 	return acls, nil
 }
 
-// DumpAbfs reads the ACL-based forwarding and returns data read as an *AbfResponse. If the reading ends up with
+// DumpABFs reads the ACL-based forwarding and returns data read as an *AbfResponse. If the reading ends up with
 // an error, only the error is send back in the response
-func (svc *dumpService) DumpAbfs() ([]*vpp_abf.ABF, error) {
-	var abfs []*vpp_abf.ABF
+func (svc *dumpService) DumpABFs() (abfs []*vpp_abf.ABF, err error) {
 	if svc.abfHandler == nil {
-		return nil, errors.New("abfHandler is not available")
+		// handler is not available
+		return nil, nil
 	}
+
 	abfPolicy, err := svc.abfHandler.DumpABFPolicy()
 	if err != nil {
 		return nil, err
@@ -152,161 +315,48 @@ func (svc *dumpService) DumpAbfs() ([]*vpp_abf.ABF, error) {
 	for _, abfDetails := range abfPolicy {
 		abfs = append(abfs, abfDetails.ABF)
 	}
-
 	return abfs, nil
 }
 
-// DumpInterfaces reads interfaces and returns them as an *InterfaceResponse. If reading ends up with error,
-// only error is send back in response
-func (svc *dumpService) DumpInterfaces() ([]*vpp_interfaces.Interface, error) {
-	var ifs []*vpp_interfaces.Interface
-	ifDetails, err := svc.ifHandler.DumpInterfaces()
+// DumpNAT44GLobal dumps NAT44Global
+func (svc *dumpService) DumpNAT44Global() (glob *vpp_nat.Nat44Global, err error) {
+	if svc.natHandler == nil {
+		// handler is not available
+		return nil, nil
+	}
+
+	glob, err = svc.natHandler.Nat44GlobalConfigDump()
 	if err != nil {
 		return nil, err
 	}
-	for _, iface := range ifDetails {
-		ifs = append(ifs, iface.Interface)
-	}
-
-	return ifs, nil
+	return glob, nil
 }
 
-// DumpIPSecSPDs reads IPSec SPD and returns them as an *IPSecSPDResponse. If reading ends up with error,
-// only error is send back in response
-func (svc *dumpService) DumpIPSecSPDs() ([]*vpp_ipsec.SecurityPolicyDatabase, error) {
-	var spds []*vpp_ipsec.SecurityPolicyDatabase
-	if svc.ipsecHandler == nil {
-		return nil, errors.New("ipsecHandler is not available")
+// DumpDNAT44s dumps DNat44
+func (svc *dumpService) DumpDNAT44s() (dnats []*vpp_nat.DNat44, err error) {
+	if svc.natHandler == nil {
+		// handler is not available
+		return nil, nil
 	}
-	spdDetails, err := svc.ipsecHandler.DumpIPSecSPD()
+
+	dnats, err = svc.natHandler.DNat44Dump()
 	if err != nil {
 		return nil, err
 	}
-	for _, spd := range spdDetails {
-		spds = append(spds, spd.Spd)
-	}
-
-	return spds, nil
-}
-
-// DumpIPSecSAs reads IPSec SA and returns them as an *IPSecSAResponse. If reading ends up with error,
-// only error is send back in response
-func (svc *dumpService) DumpIPSecSAs() ([]*vpp_ipsec.SecurityAssociation, error) {
-	var sas []*vpp_ipsec.SecurityAssociation
-	if svc.ipsecHandler == nil {
-		return nil, errors.New("ipsecHandler is not available")
-	}
-	saDetails, err := svc.ipsecHandler.DumpIPSecSA()
-	if err != nil {
-		return nil, err
-	}
-	for _, sa := range saDetails {
-		sas = append(sas, sa.Sa)
-	}
-
-	return sas, nil
-}
-
-// DumpIPSecTunnels reads IPSec tunnels and returns them as an *IPSecTunnelResponse. If reading ends up with error,
-// only error is send back in response
-/*func (svc *dumpService) DumpIPSecTunnels() (*rpc.IPSecTunnelResponse, error) {
-	var tuns []*vpp_ipsec.
-	tunDetails, err := svc.ipSecHandler.DumpIPSecTunnelInterfaces()
-	if err != nil {
-		return nil, err
-	}
-	for _, tun := range tunDetails {
-		tuns = append(tuns, tun.Tunnel)
-	}
-
-	return &rpc.IPSecTunnelResponse{Tunnels: tuns}, nil
-}*/
-
-// DumpBDs reads bridge domains and returns them as an *BDResponse. If reading ends up with error,
-// only error is send back in response
-func (svc *dumpService) DumpBDs() ([]*vpp_l2.BridgeDomain, error) {
-	var bds []*vpp_l2.BridgeDomain
-	bdDetails, err := svc.l2Handler.DumpBridgeDomains()
-	if err != nil {
-		return nil, err
-	}
-	for _, bd := range bdDetails {
-		bds = append(bds, bd.Bd)
-	}
-
-	return bds, nil
-}
-
-// DumpFIBs reads FIBs and returns them as an *FibResponse. If reading ends up with error,
-// only error is send back in response
-func (svc *dumpService) DumpFIBs() ([]*vpp_l2.FIBEntry, error) {
-	var fibs []*vpp_l2.FIBEntry
-	fibDetails, err := svc.l2Handler.DumpL2FIBs()
-	if err != nil {
-		return nil, err
-	}
-	for _, fib := range fibDetails {
-		fibs = append(fibs, fib.Fib)
-	}
-
-	return fibs, nil
-}
-
-// DumpXConnects reads cross connects and returns them as an *XcResponse. If reading ends up with error,
-// only error is send back in response
-func (svc *dumpService) DumpXConnects() ([]*vpp_l2.XConnectPair, error) {
-	var xcs []*vpp_l2.XConnectPair
-	xcDetails, err := svc.l2Handler.DumpXConnectPairs()
-	if err != nil {
-		return nil, err
-	}
-	for _, xc := range xcDetails {
-		xcs = append(xcs, xc.Xc)
-	}
-
-	return xcs, nil
-}
-
-// DumpRoutes reads VPP routes and returns them as an *RoutesResponse. If reading ends up with error,
-// only error is send back in response
-func (svc *dumpService) DumpRoutes() ([]*vpp_l3.Route, error) {
-	var routes []*vpp_l3.Route
-	rtDetails, err := svc.l3Handler.DumpRoutes()
-	if err != nil {
-		return nil, err
-	}
-	for _, rt := range rtDetails {
-		routes = append(routes, rt.Route)
-	}
-
-	return routes, nil
-}
-
-// DumpARPs reads VPP ARPs and returns them as an *ARPsResponse. If reading ends up with error,
-// only error is send back in response
-func (svc *dumpService) DumpARPs() ([]*vpp_l3.ARPEntry, error) {
-	var arps []*vpp_l3.ARPEntry
-	arpDetails, err := svc.l3Handler.DumpArpEntries()
-	if err != nil {
-		return nil, err
-	}
-	for _, arp := range arpDetails {
-		arps = append(arps, arp.Arp)
-	}
-
-	return arps, nil
+	return dnats, nil
 }
 
 // DumpPunt reads VPP Punt socket registrations and returns them as an *PuntResponse.
 func (svc *dumpService) DumpPunt() (punts []*vpp_punt.ToHost, err error) {
 	if svc.puntHandler == nil {
-		return nil, errors.New("puntHandler is not available")
+		// handler is not available
+		return nil, nil
 	}
+
 	punts, err = svc.puntHandler.DumpRegisteredPuntSockets()
 	if err != nil {
 		return nil, err
 	}
-
 	return punts, nil
 }
 

--- a/plugins/configurator/plugin.go
+++ b/plugins/configurator/plugin.go
@@ -16,27 +16,28 @@ package configurator
 
 import (
 	"git.fd.io/govpp.git/api"
-	"github.com/ligato/vpp-agent/api/models/vpp"
-	"github.com/ligato/vpp-agent/plugins/orchestrator"
-	abfvppcalls "github.com/ligato/vpp-agent/plugins/vpp/abfplugin/vppcalls"
-	"github.com/ligato/vpp-agent/plugins/vpp/aclplugin"
-	ipsecvppcalls "github.com/ligato/vpp-agent/plugins/vpp/ipsecplugin/vppcalls"
-	puntvppcalls "github.com/ligato/vpp-agent/plugins/vpp/puntplugin/vppcalls"
 
 	"github.com/ligato/cn-infra/infra"
 	"github.com/ligato/cn-infra/rpc/grpc"
+	"github.com/ligato/cn-infra/utils/safeclose"
 
 	rpc "github.com/ligato/vpp-agent/api/configurator"
+	"github.com/ligato/vpp-agent/api/models/vpp"
 	"github.com/ligato/vpp-agent/plugins/govppmux"
 	iflinuxcalls "github.com/ligato/vpp-agent/plugins/linux/ifplugin/linuxcalls"
 	l3linuxcalls "github.com/ligato/vpp-agent/plugins/linux/l3plugin/linuxcalls"
+	"github.com/ligato/vpp-agent/plugins/orchestrator"
+	abfvppcalls "github.com/ligato/vpp-agent/plugins/vpp/abfplugin/vppcalls"
+	"github.com/ligato/vpp-agent/plugins/vpp/aclplugin"
 	aclvppcalls "github.com/ligato/vpp-agent/plugins/vpp/aclplugin/vppcalls"
 	"github.com/ligato/vpp-agent/plugins/vpp/ifplugin"
 	ifvppcalls "github.com/ligato/vpp-agent/plugins/vpp/ifplugin/vppcalls"
+	ipsecvppcalls "github.com/ligato/vpp-agent/plugins/vpp/ipsecplugin/vppcalls"
 	"github.com/ligato/vpp-agent/plugins/vpp/l2plugin"
 	l2vppcalls "github.com/ligato/vpp-agent/plugins/vpp/l2plugin/vppcalls"
 	l3vppcalls "github.com/ligato/vpp-agent/plugins/vpp/l3plugin/vppcalls"
 	natvppcalls "github.com/ligato/vpp-agent/plugins/vpp/natplugin/vppcalls"
+	puntvppcalls "github.com/ligato/vpp-agent/plugins/vpp/puntplugin/vppcalls"
 )
 
 // Plugin registers VPP GRPC services in *grpc.Server.
@@ -46,8 +47,7 @@ type Plugin struct {
 	configurator configuratorServer
 
 	// Channels
-	vppChan  api.Channel
-	dumpChan api.Channel
+	vppChan api.Channel
 }
 
 // Deps - dependencies of Plugin
@@ -92,7 +92,7 @@ func (p *Plugin) Init() error {
 
 // Close does nothing.
 func (p *Plugin) Close() error {
-	return nil
+	return safeclose.Close(p.vppChan)
 }
 
 // helper method initializes all VPP/Linux plugin handlers
@@ -101,25 +101,50 @@ func (p *Plugin) initHandlers() (err error) {
 	if p.vppChan, err = p.GoVppmux.NewAPIChannel(); err != nil {
 		return err
 	}
-	if p.dumpChan, err = p.GoVppmux.NewAPIChannel(); err != nil {
-		return err
-	}
 
 	// VPP Indexes
-	aclIndexes := p.VPPACLPlugin.GetACLIndex()
 	ifIndexes := p.VPPIfPlugin.GetInterfaceIndex()
-	bdIndexes := p.VPPL2Plugin.GetBDIndex()
 	dhcpIndexes := p.VPPIfPlugin.GetDHCPIndex()
+	bdIndexes := p.VPPL2Plugin.GetBDIndex()
+	aclIndexes := p.VPPACLPlugin.GetACLIndex() // TODO: make ACL optional
 
-	// Initialize VPP handlers
-	p.configurator.abfHandler = abfvppcalls.CompatibleABFVppHandler(p.vppChan, p.dumpChan, aclIndexes, ifIndexes, p.Log)
-	p.configurator.aclHandler = aclvppcalls.CompatibleACLVppHandler(p.vppChan, p.dumpChan, ifIndexes, p.Log)
+	// VPP handlers
+
+	// core
 	p.configurator.ifHandler = ifvppcalls.CompatibleInterfaceVppHandler(p.vppChan, p.Log)
-	p.configurator.natHandler = natvppcalls.CompatibleNatVppHandler(p.vppChan, ifIndexes, dhcpIndexes, p.Log)
+	if p.configurator.ifHandler == nil {
+		p.Log.Info("VPP Interface handler is not available, it will be skipped")
+	}
 	p.configurator.l2Handler = l2vppcalls.CompatibleL2VppHandler(p.vppChan, ifIndexes, bdIndexes, p.Log)
+	if p.configurator.l2Handler == nil {
+		p.Log.Info("VPP L2 handler is not available, it will be skipped")
+	}
 	p.configurator.l3Handler = l3vppcalls.CompatibleL3VppHandler(p.vppChan, ifIndexes, p.Log)
+	if p.configurator.l3Handler == nil {
+		p.Log.Info("VPP L3 handler is not available, it will be skipped")
+	}
 	p.configurator.ipsecHandler = ipsecvppcalls.CompatibleIPSecVppHandler(p.vppChan, ifIndexes, p.Log)
+	if p.configurator.ipsecHandler == nil {
+		p.Log.Info("VPP IPSec handler is not available, it will be skipped")
+	}
+
+	// plugins
+	p.configurator.abfHandler = abfvppcalls.CompatibleABFVppHandler(p.vppChan, aclIndexes, ifIndexes, p.Log)
+	if p.configurator.abfHandler == nil {
+		p.Log.Info("VPP ABF handler is not available, it will be skipped")
+	}
+	p.configurator.aclHandler = aclvppcalls.CompatibleACLVppHandler(p.vppChan, ifIndexes, p.Log)
+	if p.configurator.aclHandler == nil {
+		p.Log.Info("VPP ACL handler is not available, it will be skipped")
+	}
+	p.configurator.natHandler = natvppcalls.CompatibleNatVppHandler(p.vppChan, ifIndexes, dhcpIndexes, p.Log)
+	if p.configurator.natHandler == nil {
+		p.Log.Info("VPP NAT handler is not available, it will be skipped")
+	}
 	p.configurator.puntHandler = puntvppcalls.CompatiblePuntVppHandler(p.vppChan, ifIndexes, p.Log)
+	if p.configurator.puntHandler == nil {
+		p.Log.Info("VPP Punt handler is not available, it will be skipped")
+	}
 
 	// Linux indexes and handlers
 	p.configurator.linuxIfHandler = iflinuxcalls.NewNetLinkHandler()

--- a/plugins/govppmux/plugin_impl_govppmux.go
+++ b/plugins/govppmux/plugin_impl_govppmux.go
@@ -37,6 +37,7 @@ import (
 
 	_ "github.com/ligato/vpp-agent/plugins/govppmux/vppcalls/vpp1901"
 	_ "github.com/ligato/vpp-agent/plugins/govppmux/vppcalls/vpp1904"
+	_ "github.com/ligato/vpp-agent/plugins/govppmux/vppcalls/vpp1908"
 )
 
 // Default path to socket for VPP stats

--- a/plugins/restapi/handlers.go
+++ b/plugins/restapi/handlers.go
@@ -32,31 +32,35 @@ import (
 	"github.com/ligato/vpp-agent/plugins/restapi/resturl"
 )
 
+var (
+	// ErrHandlerUnavailable represents error returned when particular
+	// handler is not available
+	ErrHandlerUnavailable = errors.New("Handler is not available")
+)
+
 // Registers ABF REST handler
 func (p *Plugin) registerABFHandler() {
-	unavailHandler := errors.New("abfHandler is not available")
 	p.registerHTTPHandler(resturl.ABF, GET, func() (interface{}, error) {
 		if p.abfHandler == nil {
-			return nil, unavailHandler
+			return nil, ErrHandlerUnavailable
 		}
 		return p.abfHandler.DumpABFPolicy()
 	})
 }
 
 // Registers access list REST handlers
-func (p *Plugin) registerAccessListHandlers() {
-	unavailHandler := errors.New("aclHandler is not available")
+func (p *Plugin) registerACLHandlers() {
 	// GET IP ACLs
 	p.registerHTTPHandler(resturl.ACLIP, GET, func() (interface{}, error) {
 		if p.aclHandler == nil {
-			return nil, unavailHandler
+			return nil, ErrHandlerUnavailable
 		}
 		return p.aclHandler.DumpACL()
 	})
 	// GET MACIP ACLs
 	p.registerHTTPHandler(resturl.ACLMACIP, GET, func() (interface{}, error) {
 		if p.aclHandler == nil {
-			return nil, unavailHandler
+			return nil, ErrHandlerUnavailable
 		}
 		return p.aclHandler.DumpMACIPACL()
 	})
@@ -95,23 +99,18 @@ func (p *Plugin) registerInterfaceHandlers() {
 }
 
 // Registers NAT REST handlers
-func (p *Plugin) registerNatHandlers() {
-	unavailHandler := errors.New("natHandler is not available")
-	// GET NAT configuration
-	/*p.registerHTTPHandler(resturl.NatURL, GET, func() (interface{}, error) {
-		return p.natHandler.Nat44Dump()
-	})*/
+func (p *Plugin) registerNATHandlers() {
 	// GET NAT global config
 	p.registerHTTPHandler(resturl.NatGlobal, GET, func() (interface{}, error) {
 		if p.natHandler == nil {
-			return nil, unavailHandler
+			return nil, ErrHandlerUnavailable
 		}
 		return p.natHandler.Nat44GlobalConfigDump()
 	})
 	// GET DNAT config
 	p.registerHTTPHandler(resturl.NatDNat, GET, func() (interface{}, error) {
 		if p.natHandler == nil {
-			return nil, unavailHandler
+			return nil, ErrHandlerUnavailable
 		}
 		return p.natHandler.DNat44Dump()
 	})
@@ -121,14 +120,23 @@ func (p *Plugin) registerNatHandlers() {
 func (p *Plugin) registerL2Handlers() {
 	// GET bridge domains
 	p.registerHTTPHandler(resturl.Bd, GET, func() (interface{}, error) {
+		if p.l2Handler == nil {
+			return nil, ErrHandlerUnavailable
+		}
 		return p.l2Handler.DumpBridgeDomains()
 	})
 	// GET FIB entries
 	p.registerHTTPHandler(resturl.Fib, GET, func() (interface{}, error) {
+		if p.l2Handler == nil {
+			return nil, ErrHandlerUnavailable
+		}
 		return p.l2Handler.DumpL2FIBs()
 	})
 	// GET cross connects
 	p.registerHTTPHandler(resturl.Xc, GET, func() (interface{}, error) {
+		if p.l2Handler == nil {
+			return nil, ErrHandlerUnavailable
+		}
 		return p.l2Handler.DumpXConnectPairs()
 	})
 }
@@ -137,22 +145,37 @@ func (p *Plugin) registerL2Handlers() {
 func (p *Plugin) registerL3Handlers() {
 	// GET ARP entries
 	p.registerHTTPHandler(resturl.Arps, GET, func() (interface{}, error) {
+		if p.l3Handler == nil {
+			return nil, ErrHandlerUnavailable
+		}
 		return p.l3Handler.DumpArpEntries()
 	})
 	// GET proxy ARP interfaces
 	p.registerHTTPHandler(resturl.PArpIfs, GET, func() (interface{}, error) {
+		if p.l3Handler == nil {
+			return nil, ErrHandlerUnavailable
+		}
 		return p.l3Handler.DumpProxyArpInterfaces()
 	})
 	// GET proxy ARP ranges
 	p.registerHTTPHandler(resturl.PArpRngs, GET, func() (interface{}, error) {
+		if p.l3Handler == nil {
+			return nil, ErrHandlerUnavailable
+		}
 		return p.l3Handler.DumpProxyArpRanges()
 	})
 	// GET static routes
 	p.registerHTTPHandler(resturl.Routes, GET, func() (interface{}, error) {
+		if p.l3Handler == nil {
+			return nil, ErrHandlerUnavailable
+		}
 		return p.l3Handler.DumpRoutes()
 	})
 	// GET scan ip neighbor setup
 	p.registerHTTPHandler(resturl.IPScanNeigh, GET, func() (interface{}, error) {
+		if p.l3Handler == nil {
+			return nil, ErrHandlerUnavailable
+		}
 		return p.l3Handler.GetIPScanNeighbor()
 	})
 }
@@ -161,10 +184,16 @@ func (p *Plugin) registerL3Handlers() {
 func (p *Plugin) registerIPSecHandlers() {
 	// GET IPSec SPD entries
 	p.registerHTTPHandler(resturl.SPDs, GET, func() (interface{}, error) {
+		if p.ipSecHandler == nil {
+			return nil, ErrHandlerUnavailable
+		}
 		return p.ipSecHandler.DumpIPSecSPD()
 	})
 	// GET IPSec SA entries
 	p.registerHTTPHandler(resturl.SAs, GET, func() (interface{}, error) {
+		if p.ipSecHandler == nil {
+			return nil, ErrHandlerUnavailable
+		}
 		return p.ipSecHandler.DumpIPSecSA()
 	})
 }
@@ -173,6 +202,9 @@ func (p *Plugin) registerIPSecHandlers() {
 func (p *Plugin) registerPuntHandlers() {
 	// GET punt registered socket entries
 	p.registerHTTPHandler(resturl.PuntSocket, GET, func() (interface{}, error) {
+		if p.puntHandler == nil {
+			return nil, ErrHandlerUnavailable
+		}
 		return p.puntHandler.DumpRegisteredPuntSockets()
 	})
 }

--- a/plugins/restapi/plugin_restapi.go
+++ b/plugins/restapi/plugin_restapi.go
@@ -18,9 +18,6 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/ligato/vpp-agent/plugins/vpp/abfplugin/vppcalls"
-	"github.com/ligato/vpp-agent/plugins/vpp/aclplugin"
-
 	"git.fd.io/govpp.git/api"
 	"github.com/ligato/cn-infra/infra"
 	"github.com/ligato/cn-infra/rpc/rest"
@@ -33,6 +30,8 @@ import (
 	l3linuxcalls "github.com/ligato/vpp-agent/plugins/linux/l3plugin/linuxcalls"
 	"github.com/ligato/vpp-agent/plugins/restapi/resturl"
 	telemetryvppcalls "github.com/ligato/vpp-agent/plugins/telemetry/vppcalls"
+	abfvppcalls "github.com/ligato/vpp-agent/plugins/vpp/abfplugin/vppcalls"
+	"github.com/ligato/vpp-agent/plugins/vpp/aclplugin"
 	aclvppcalls "github.com/ligato/vpp-agent/plugins/vpp/aclplugin/vppcalls"
 	"github.com/ligato/vpp-agent/plugins/vpp/ifplugin"
 	ifvppcalls "github.com/ligato/vpp-agent/plugins/vpp/ifplugin/vppcalls"
@@ -58,14 +57,13 @@ type Plugin struct {
 	index *index
 
 	// Channels
-	vppChan  api.Channel
-	dumpChan api.Channel
+	vppChan api.Channel
 
 	// Handlers
 	vpeHandler  vpevppcalls.VpeVppAPI
 	teleHandler telemetryvppcalls.TelemetryVppAPI
 	// VPP Handlers
-	abfHandler   vppcalls.ABFVppRead
+	abfHandler   abfvppcalls.ABFVppRead
 	aclHandler   aclvppcalls.ACLVppRead
 	ifHandler    ifvppcalls.InterfaceVppRead
 	natHandler   natvppcalls.NatVppRead
@@ -103,44 +101,66 @@ type indexItem struct {
 
 // Init initializes the Rest Plugin
 func (p *Plugin) Init() (err error) {
-	// Check VPP dependency
-	/*if p.VPP == nil {
-		return fmt.Errorf("REST plugin requires VPP plugin API")
-	}*/
-
 	// VPP channels
 	if p.vppChan, err = p.GoVppmux.NewAPIChannel(); err != nil {
 		return err
 	}
-	if p.dumpChan, err = p.GoVppmux.NewAPIChannel(); err != nil {
-		return err
-	}
 
 	// VPP Indexes
-	aclIndexes := p.VPPACLPlugin.GetACLIndex()
 	ifIndexes := p.VPPIfPlugin.GetInterfaceIndex()
 	bdIndexes := p.VPPL2Plugin.GetBDIndex()
 	dhcpIndexes := p.VPPIfPlugin.GetDHCPIndex()
+	aclIndexes := p.VPPACLPlugin.GetACLIndex() // TODO: make ACL optional
 
-	// Initialize handlers
+	// Initialize VPP handlers
 	p.vpeHandler = vpevppcalls.CompatibleVpeHandler(p.vppChan)
+	if p.vpeHandler == nil {
+		p.Log.Info("VPP main handler is not available, it will be skipped")
+	}
 	p.teleHandler = telemetryvppcalls.CompatibleTelemetryHandler(p.vppChan, p.GoVppmux)
+	if p.teleHandler == nil {
+		p.Log.Info("VPP Telemetry handler is not available, it will be skipped")
+	}
 
-	// VPP handlers
-	p.abfHandler = vppcalls.CompatibleABFVppHandler(p.vppChan, p.dumpChan, aclIndexes, ifIndexes, p.Log)
-	p.aclHandler = aclvppcalls.CompatibleACLVppHandler(p.vppChan, p.dumpChan, ifIndexes, p.Log)
+	// core
 	p.ifHandler = ifvppcalls.CompatibleInterfaceVppHandler(p.vppChan, p.Log)
-	p.natHandler = natvppcalls.CompatibleNatVppHandler(p.vppChan, ifIndexes, dhcpIndexes, p.Log)
+	if p.ifHandler == nil {
+		p.Log.Info("VPP Interface handler is not available, it will be skipped")
+	}
 	p.l2Handler = l2vppcalls.CompatibleL2VppHandler(p.vppChan, ifIndexes, bdIndexes, p.Log)
+	if p.l2Handler == nil {
+		p.Log.Info("VPP L2 handler is not available, it will be skipped")
+	}
 	p.l3Handler = l3vppcalls.CompatibleL3VppHandler(p.vppChan, ifIndexes, p.Log)
+	if p.l3Handler == nil {
+		p.Log.Info("VPP L3 handler is not available, it will be skipped")
+	}
 	p.ipSecHandler = ipsecvppcalls.CompatibleIPSecVppHandler(p.vppChan, ifIndexes, p.Log)
+	if p.ipSecHandler == nil {
+		p.Log.Info("VPP IPSec handler is not available, it will be skipped")
+	}
+
+	// plugins (might not be available - disabled)
+	p.abfHandler = abfvppcalls.CompatibleABFVppHandler(p.vppChan, aclIndexes, ifIndexes, p.Log)
+	if p.abfHandler == nil {
+		p.Log.Infof("ABF handler is not available, it will be skipped")
+	}
+	p.aclHandler = aclvppcalls.CompatibleACLVppHandler(p.vppChan, ifIndexes, p.Log)
+	if p.aclHandler == nil {
+		p.Log.Infof("ACL handler is not available, it will be skipped")
+	}
+	p.natHandler = natvppcalls.CompatibleNatVppHandler(p.vppChan, ifIndexes, dhcpIndexes, p.Log)
+	if p.natHandler == nil {
+		p.Log.Infof("NAT handler is not available, it will be skipped")
+	}
 	p.puntHandler = puntvppcalls.CompatiblePuntVppHandler(p.vppChan, ifIndexes, p.Log)
+	if p.puntHandler == nil {
+		p.Log.Infof("Punt handler is not available, it will be skipped")
+	}
 
 	// Linux handlers
-	//if p.Linux != nil {
 	p.linuxIfHandler = iflinuxcalls.NewNetLinkHandler()
 	p.linuxL3Handler = l3linuxcalls.NewNetLinkHandler()
-	//}
 
 	p.index = &index{
 		ItemMap: getIndexPageItems(),
@@ -157,26 +177,27 @@ func (p *Plugin) AfterInit() (err error) {
 	p.Log.Debug("REST API Plugin is up and running")
 
 	// VPP handlers
-	p.registerABFHandler()
-	p.registerAccessListHandlers()
+	p.registerTelemetryHandlers()
+	p.registerCommandHandler()
+
+	// core
 	p.registerInterfaceHandlers()
-	p.registerNatHandlers()
 	p.registerL2Handlers()
 	p.registerL3Handlers()
 	p.registerIPSecHandlers()
+
+	// plugins
+	p.registerABFHandler()
+	p.registerACLHandlers()
+	p.registerNATHandlers()
 	p.registerPuntHandlers()
 
 	// Linux handlers
-	//if p.Linux != nil {
 	p.registerLinuxInterfaceHandlers()
 	p.registerLinuxL3Handlers()
-	//}
 
-	// Telemetry, command, index, tracer
-	p.registerTelemetryHandlers()
-	p.registerCommandHandler()
+	// Index and stats handlers
 	p.registerIndexHandlers()
-
 	p.registerStatsHandler()
 
 	return nil
@@ -184,7 +205,7 @@ func (p *Plugin) AfterInit() (err error) {
 
 // Close is used to clean up resources used by Plugin
 func (p *Plugin) Close() (err error) {
-	return safeclose.Close(p.vppChan, p.dumpChan)
+	return safeclose.Close(p.vppChan)
 }
 
 // Fill index item lists
@@ -253,6 +274,7 @@ func getPermissionsGroups() []*access.PermissionGroup {
 		Name: "dump",
 		Permissions: []*access.PermissionGroup_Permissions{
 			newPermission(resturl.Index, GET),
+			newPermission(resturl.ABF, GET),
 			newPermission(resturl.ACLIP, GET),
 			newPermission(resturl.ACLMACIP, GET),
 			newPermission(resturl.Interface, GET),

--- a/plugins/vpp/abfplugin/abfplugin.go
+++ b/plugins/vpp/abfplugin/abfplugin.go
@@ -39,8 +39,7 @@ type ABFPlugin struct {
 	Deps
 
 	// GoVPP channels
-	vppCh     govppapi.Channel
-	dumpVppCh govppapi.Channel
+	vppCh govppapi.Channel
 
 	abfHandler             vppcalls.ABFVppAPI
 	abfDescriptor          *descriptor.ABFDescriptor
@@ -68,12 +67,9 @@ func (p *ABFPlugin) Init() error {
 	if p.vppCh, err = p.GoVppmux.NewAPIChannel(); err != nil {
 		return errors.Errorf("failed to create GoVPP API channel: %v", err)
 	}
-	if p.dumpVppCh, err = p.GoVppmux.NewAPIChannel(); err != nil {
-		return errors.Errorf("failed to create GoVPP API dump channel: %v", err)
-	}
 
 	// init handler
-	p.abfHandler = vppcalls.CompatibleABFVppHandler(p.vppCh, p.dumpVppCh, p.ACLPlugin.GetACLIndex(), p.IfPlugin.GetInterfaceIndex(), p.Log)
+	p.abfHandler = vppcalls.CompatibleABFVppHandler(p.vppCh, p.ACLPlugin.GetACLIndex(), p.IfPlugin.GetInterfaceIndex(), p.Log)
 	if p.abfHandler == nil {
 		return errors.New("abfHandler is not available")
 	}

--- a/plugins/vpp/abfplugin/vppcalls/abf_vppcalls.go
+++ b/plugins/vpp/abfplugin/vppcalls/abf_vppcalls.go
@@ -66,7 +66,7 @@ type HandlerVersion struct {
 	New  func(govppapi.Channel, aclidx.ACLMetadataIndex, ifaceidx.IfaceMetadataIndex) ABFVppAPI
 }
 
-func CompatibleABFVppHandler(ch, dch govppapi.Channel, aclIdx aclidx.ACLMetadataIndex, ifIdx ifaceidx.IfaceMetadataIndex, log logging.Logger) ABFVppAPI {
+func CompatibleABFVppHandler(ch govppapi.Channel, aclIdx aclidx.ACLMetadataIndex, ifIdx ifaceidx.IfaceMetadataIndex, log logging.Logger) ABFVppAPI {
 	if len(Versions) == 0 {
 		// abfplugin is not loaded
 		return nil

--- a/plugins/vpp/abfplugin/vppcalls/vpp1901/abf_vppcalls_test.go
+++ b/plugins/vpp/abfplugin/vppcalls/vpp1901/abf_vppcalls_test.go
@@ -19,13 +19,14 @@ import (
 	"testing"
 
 	"github.com/ligato/cn-infra/logging/logrus"
-	"github.com/ligato/vpp-agent/api/models/vpp/abf"
+	. "github.com/onsi/gomega"
+
+	vpp_abf "github.com/ligato/vpp-agent/api/models/vpp/abf"
 	"github.com/ligato/vpp-agent/plugins/vpp/abfplugin/vppcalls"
 	"github.com/ligato/vpp-agent/plugins/vpp/aclplugin/aclidx"
 	"github.com/ligato/vpp-agent/plugins/vpp/binapi/vpp1901/abf"
 	"github.com/ligato/vpp-agent/plugins/vpp/ifplugin/ifaceidx"
 	"github.com/ligato/vpp-agent/plugins/vpp/vppcallmock"
-	. "github.com/onsi/gomega"
 )
 
 func TestGetABFVersion(t *testing.T) {
@@ -270,6 +271,6 @@ func abfTestSetup(t *testing.T) (*vppcallmock.TestCtx, vppcalls.ABFVppAPI, iface
 	log := logrus.NewLogger("test-log")
 	aclIdx := aclidx.NewACLIndex(log, "acl-index")
 	ifIdx := ifaceidx.NewIfaceIndex(log, "if-index")
-	abfHandler := NewABFVppHandler(ctx.MockChannel, nil, aclIdx, ifIdx)
+	abfHandler := NewABFVppHandler(ctx.MockChannel, aclIdx, ifIdx)
 	return ctx, abfHandler, ifIdx
 }

--- a/plugins/vpp/abfplugin/vppcalls/vpp1901/dump_abf_vppcalls.go
+++ b/plugins/vpp/abfplugin/vppcalls/vpp1901/dump_abf_vppcalls.go
@@ -55,7 +55,7 @@ func (h *ABFVppHandler) dumpABFInterfaces() (map[uint32][]*vpp_abf.ABF_AttachedI
 	abfIfs := make(map[uint32][]*vpp_abf.ABF_AttachedInterface)
 
 	req := &abf.AbfItfAttachDump{}
-	reqCtx := h.dumpChannel.SendMultiRequest(req)
+	reqCtx := h.callsChannel.SendMultiRequest(req)
 
 	for {
 		reply := &abf.AbfItfAttachDetails{}
@@ -93,7 +93,7 @@ func (h *ABFVppHandler) dumpABFInterfaces() (map[uint32][]*vpp_abf.ABF_AttachedI
 func (h *ABFVppHandler) dumpABFPolicy() ([]*vppcalls.ABFDetails, error) {
 	var abfs []*vppcalls.ABFDetails
 	req := &abf.AbfPolicyDump{}
-	reqCtx := h.dumpChannel.SendMultiRequest(req)
+	reqCtx := h.callsChannel.SendMultiRequest(req)
 
 	for {
 		reply := &abf.AbfPolicyDetails{}

--- a/plugins/vpp/abfplugin/vppcalls/vpp1901/vppcalls_handlers.go
+++ b/plugins/vpp/abfplugin/vppcalls/vpp1901/vppcalls_handlers.go
@@ -32,7 +32,6 @@ func init() {
 		New: func(ch govppapi.Channel, aclIndexes aclidx.ACLMetadataIndex, ifIndexes ifaceidx.IfaceMetadataIndex) vppcalls.ABFVppAPI {
 			return &ABFVppHandler{
 				callsChannel: ch,
-				dumpChannel:  ch,
 				aclIndexes:   aclIndexes,
 				ifIndexes:    ifIndexes,
 			}
@@ -43,12 +42,11 @@ func init() {
 // ABFVppHandler is accessor for abfrelated vppcalls methods
 type ABFVppHandler struct {
 	callsChannel govppapi.Channel
-	dumpChannel  govppapi.Channel
 	aclIndexes   aclidx.ACLMetadataIndex
 	ifIndexes    ifaceidx.IfaceMetadataIndex
 }
 
 // NewABFVppHandler returns new ABFVppHandler.
 func NewABFVppHandler(calls, dump govppapi.Channel, aclIdx aclidx.ACLMetadataIndex, ifIdx ifaceidx.IfaceMetadataIndex) *ABFVppHandler {
-	return &ABFVppHandler{calls, dump, aclIdx, ifIdx}
+	return &ABFVppHandler{calls, aclIdx, ifIdx}
 }

--- a/plugins/vpp/abfplugin/vppcalls/vpp1901/vppcalls_handlers.go
+++ b/plugins/vpp/abfplugin/vppcalls/vpp1901/vppcalls_handlers.go
@@ -16,9 +16,9 @@ package vpp1901
 
 import (
 	govppapi "git.fd.io/govpp.git/api"
-	"github.com/ligato/vpp-agent/plugins/vpp/aclplugin/aclidx"
 
 	"github.com/ligato/vpp-agent/plugins/vpp/abfplugin/vppcalls"
+	"github.com/ligato/vpp-agent/plugins/vpp/aclplugin/aclidx"
 	"github.com/ligato/vpp-agent/plugins/vpp/binapi/vpp1901/abf"
 	"github.com/ligato/vpp-agent/plugins/vpp/ifplugin/ifaceidx"
 )
@@ -30,11 +30,7 @@ func init() {
 	vppcalls.Versions["vpp1901"] = vppcalls.HandlerVersion{
 		Msgs: msgs,
 		New: func(ch govppapi.Channel, aclIndexes aclidx.ACLMetadataIndex, ifIndexes ifaceidx.IfaceMetadataIndex) vppcalls.ABFVppAPI {
-			return &ABFVppHandler{
-				callsChannel: ch,
-				aclIndexes:   aclIndexes,
-				ifIndexes:    ifIndexes,
-			}
+			return NewABFVppHandler(ch, aclIndexes, ifIndexes)
 		},
 	}
 }
@@ -47,6 +43,10 @@ type ABFVppHandler struct {
 }
 
 // NewABFVppHandler returns new ABFVppHandler.
-func NewABFVppHandler(calls, dump govppapi.Channel, aclIdx aclidx.ACLMetadataIndex, ifIdx ifaceidx.IfaceMetadataIndex) *ABFVppHandler {
-	return &ABFVppHandler{calls, aclIdx, ifIdx}
+func NewABFVppHandler(calls govppapi.Channel, aclIdx aclidx.ACLMetadataIndex, ifIdx ifaceidx.IfaceMetadataIndex) *ABFVppHandler {
+	return &ABFVppHandler{
+		callsChannel: calls,
+		aclIndexes:   aclIdx,
+		ifIndexes:    ifIdx,
+	}
 }

--- a/plugins/vpp/abfplugin/vppcalls/vpp1904/abf_vppcalls_test.go
+++ b/plugins/vpp/abfplugin/vppcalls/vpp1904/abf_vppcalls_test.go
@@ -19,13 +19,14 @@ import (
 	"testing"
 
 	"github.com/ligato/cn-infra/logging/logrus"
-	"github.com/ligato/vpp-agent/api/models/vpp/abf"
+	. "github.com/onsi/gomega"
+
+	vpp_abf "github.com/ligato/vpp-agent/api/models/vpp/abf"
 	"github.com/ligato/vpp-agent/plugins/vpp/abfplugin/vppcalls"
 	"github.com/ligato/vpp-agent/plugins/vpp/aclplugin/aclidx"
 	"github.com/ligato/vpp-agent/plugins/vpp/binapi/vpp1904/abf"
 	"github.com/ligato/vpp-agent/plugins/vpp/ifplugin/ifaceidx"
 	"github.com/ligato/vpp-agent/plugins/vpp/vppcallmock"
-	. "github.com/onsi/gomega"
 )
 
 func TestGetABFVersion(t *testing.T) {
@@ -270,6 +271,6 @@ func abfTestSetup(t *testing.T) (*vppcallmock.TestCtx, vppcalls.ABFVppAPI, iface
 	log := logrus.NewLogger("test-log")
 	aclIdx := aclidx.NewACLIndex(log, "acl-index")
 	ifIdx := ifaceidx.NewIfaceIndex(log, "if-index")
-	abfHandler := NewABFVppHandler(ctx.MockChannel, nil, aclIdx, ifIdx)
+	abfHandler := NewABFVppHandler(ctx.MockChannel, aclIdx, ifIdx)
 	return ctx, abfHandler, ifIdx
 }

--- a/plugins/vpp/abfplugin/vppcalls/vpp1904/dump_abf_vppcalls.go
+++ b/plugins/vpp/abfplugin/vppcalls/vpp1904/dump_abf_vppcalls.go
@@ -55,7 +55,7 @@ func (h *ABFVppHandler) dumpABFInterfaces() (map[uint32][]*vpp_abf.ABF_AttachedI
 	abfIfs := make(map[uint32][]*vpp_abf.ABF_AttachedInterface)
 
 	req := &abf.AbfItfAttachDump{}
-	reqCtx := h.dumpChannel.SendMultiRequest(req)
+	reqCtx := h.callsChannel.SendMultiRequest(req)
 
 	for {
 		reply := &abf.AbfItfAttachDetails{}
@@ -93,7 +93,7 @@ func (h *ABFVppHandler) dumpABFInterfaces() (map[uint32][]*vpp_abf.ABF_AttachedI
 func (h *ABFVppHandler) dumpABFPolicy() ([]*vppcalls.ABFDetails, error) {
 	var abfs []*vppcalls.ABFDetails
 	req := &abf.AbfPolicyDump{}
-	reqCtx := h.dumpChannel.SendMultiRequest(req)
+	reqCtx := h.callsChannel.SendMultiRequest(req)
 
 	for {
 		reply := &abf.AbfPolicyDetails{}

--- a/plugins/vpp/abfplugin/vppcalls/vpp1904/vppcalls_handlers.go
+++ b/plugins/vpp/abfplugin/vppcalls/vpp1904/vppcalls_handlers.go
@@ -30,11 +30,7 @@ func init() {
 	vppcalls.Versions["vpp1904"] = vppcalls.HandlerVersion{
 		Msgs: msgs,
 		New: func(ch govppapi.Channel, aclIndexes aclidx.ACLMetadataIndex, ifIndexes ifaceidx.IfaceMetadataIndex) vppcalls.ABFVppAPI {
-			return &ABFVppHandler{
-				callsChannel: ch,
-				aclIndexes:   aclIndexes,
-				ifIndexes:    ifIndexes,
-			}
+			return NewABFVppHandler(ch, aclIndexes, ifIndexes)
 		},
 	}
 }
@@ -47,6 +43,10 @@ type ABFVppHandler struct {
 }
 
 // NewABFVppHandler returns new ABFVppHandler.
-func NewABFVppHandler(calls, dump govppapi.Channel, aclIdx aclidx.ACLMetadataIndex, ifIdx ifaceidx.IfaceMetadataIndex) *ABFVppHandler {
-	return &ABFVppHandler{calls, aclIdx, ifIdx}
+func NewABFVppHandler(calls govppapi.Channel, aclIdx aclidx.ACLMetadataIndex, ifIdx ifaceidx.IfaceMetadataIndex) *ABFVppHandler {
+	return &ABFVppHandler{
+		callsChannel: calls,
+		aclIndexes:   aclIdx,
+		ifIndexes:    ifIdx,
+	}
 }

--- a/plugins/vpp/abfplugin/vppcalls/vpp1904/vppcalls_handlers.go
+++ b/plugins/vpp/abfplugin/vppcalls/vpp1904/vppcalls_handlers.go
@@ -16,9 +16,9 @@ package vpp1904
 
 import (
 	govppapi "git.fd.io/govpp.git/api"
-	"github.com/ligato/vpp-agent/plugins/vpp/aclplugin/aclidx"
 
 	"github.com/ligato/vpp-agent/plugins/vpp/abfplugin/vppcalls"
+	"github.com/ligato/vpp-agent/plugins/vpp/aclplugin/aclidx"
 	"github.com/ligato/vpp-agent/plugins/vpp/binapi/vpp1904/abf"
 	"github.com/ligato/vpp-agent/plugins/vpp/ifplugin/ifaceidx"
 )
@@ -32,7 +32,6 @@ func init() {
 		New: func(ch govppapi.Channel, aclIndexes aclidx.ACLMetadataIndex, ifIndexes ifaceidx.IfaceMetadataIndex) vppcalls.ABFVppAPI {
 			return &ABFVppHandler{
 				callsChannel: ch,
-				dumpChannel:  ch,
 				aclIndexes:   aclIndexes,
 				ifIndexes:    ifIndexes,
 			}
@@ -43,12 +42,11 @@ func init() {
 // ABFVppHandler is accessor for abfrelated vppcalls methods
 type ABFVppHandler struct {
 	callsChannel govppapi.Channel
-	dumpChannel  govppapi.Channel
 	aclIndexes   aclidx.ACLMetadataIndex
 	ifIndexes    ifaceidx.IfaceMetadataIndex
 }
 
 // NewABFVppHandler returns new ABFVppHandler.
 func NewABFVppHandler(calls, dump govppapi.Channel, aclIdx aclidx.ACLMetadataIndex, ifIdx ifaceidx.IfaceMetadataIndex) *ABFVppHandler {
-	return &ABFVppHandler{calls, dump, aclIdx, ifIdx}
+	return &ABFVppHandler{calls, aclIdx, ifIdx}
 }

--- a/plugins/vpp/abfplugin/vppcalls/vpp1908/abf_vppcalls_test.go
+++ b/plugins/vpp/abfplugin/vppcalls/vpp1908/abf_vppcalls_test.go
@@ -19,13 +19,14 @@ import (
 	"testing"
 
 	"github.com/ligato/cn-infra/logging/logrus"
-	"github.com/ligato/vpp-agent/api/models/vpp/abf"
+	. "github.com/onsi/gomega"
+
+	vpp_abf "github.com/ligato/vpp-agent/api/models/vpp/abf"
 	"github.com/ligato/vpp-agent/plugins/vpp/abfplugin/vppcalls"
 	"github.com/ligato/vpp-agent/plugins/vpp/aclplugin/aclidx"
 	"github.com/ligato/vpp-agent/plugins/vpp/binapi/vpp1908/abf"
 	"github.com/ligato/vpp-agent/plugins/vpp/ifplugin/ifaceidx"
 	"github.com/ligato/vpp-agent/plugins/vpp/vppcallmock"
-	. "github.com/onsi/gomega"
 )
 
 func TestGetABFVersion(t *testing.T) {
@@ -270,6 +271,6 @@ func abfTestSetup(t *testing.T) (*vppcallmock.TestCtx, vppcalls.ABFVppAPI, iface
 	log := logrus.NewLogger("test-log")
 	aclIdx := aclidx.NewACLIndex(log, "acl-index")
 	ifIdx := ifaceidx.NewIfaceIndex(log, "if-index")
-	abfHandler := NewABFVppHandler(ctx.MockChannel, nil, aclIdx, ifIdx)
+	abfHandler := NewABFVppHandler(ctx.MockChannel, aclIdx, ifIdx)
 	return ctx, abfHandler, ifIdx
 }

--- a/plugins/vpp/abfplugin/vppcalls/vpp1908/dump_abf_vppcalls.go
+++ b/plugins/vpp/abfplugin/vppcalls/vpp1908/dump_abf_vppcalls.go
@@ -55,7 +55,7 @@ func (h *ABFVppHandler) dumpABFInterfaces() (map[uint32][]*vpp_abf.ABF_AttachedI
 	abfIfs := make(map[uint32][]*vpp_abf.ABF_AttachedInterface)
 
 	req := &abf.AbfItfAttachDump{}
-	reqCtx := h.dumpChannel.SendMultiRequest(req)
+	reqCtx := h.callsChannel.SendMultiRequest(req)
 
 	for {
 		reply := &abf.AbfItfAttachDetails{}
@@ -93,7 +93,7 @@ func (h *ABFVppHandler) dumpABFInterfaces() (map[uint32][]*vpp_abf.ABF_AttachedI
 func (h *ABFVppHandler) dumpABFPolicy() ([]*vppcalls.ABFDetails, error) {
 	var abfs []*vppcalls.ABFDetails
 	req := &abf.AbfPolicyDump{}
-	reqCtx := h.dumpChannel.SendMultiRequest(req)
+	reqCtx := h.callsChannel.SendMultiRequest(req)
 
 	for {
 		reply := &abf.AbfPolicyDetails{}

--- a/plugins/vpp/abfplugin/vppcalls/vpp1908/vppcalls_handlers.go
+++ b/plugins/vpp/abfplugin/vppcalls/vpp1908/vppcalls_handlers.go
@@ -30,11 +30,7 @@ func init() {
 	vppcalls.Versions["vpp1908"] = vppcalls.HandlerVersion{
 		Msgs: msgs,
 		New: func(ch govppapi.Channel, aclIndexes aclidx.ACLMetadataIndex, ifIndexes ifaceidx.IfaceMetadataIndex) vppcalls.ABFVppAPI {
-			return &ABFVppHandler{
-				callsChannel: ch,
-				aclIndexes:   aclIndexes,
-				ifIndexes:    ifIndexes,
-			}
+			return NewABFVppHandler(ch, aclIndexes, ifIndexes)
 		},
 	}
 }
@@ -47,6 +43,10 @@ type ABFVppHandler struct {
 }
 
 // NewABFVppHandler returns new ABFVppHandler.
-func NewABFVppHandler(calls, dump govppapi.Channel, aclIdx aclidx.ACLMetadataIndex, ifIdx ifaceidx.IfaceMetadataIndex) *ABFVppHandler {
-	return &ABFVppHandler{calls, aclIdx, ifIdx}
+func NewABFVppHandler(calls govppapi.Channel, aclIdx aclidx.ACLMetadataIndex, ifIdx ifaceidx.IfaceMetadataIndex) *ABFVppHandler {
+	return &ABFVppHandler{
+		callsChannel: calls,
+		aclIndexes:   aclIdx,
+		ifIndexes:    ifIdx,
+	}
 }

--- a/plugins/vpp/abfplugin/vppcalls/vpp1908/vppcalls_handlers.go
+++ b/plugins/vpp/abfplugin/vppcalls/vpp1908/vppcalls_handlers.go
@@ -16,9 +16,9 @@ package vpp1908
 
 import (
 	govppapi "git.fd.io/govpp.git/api"
-	"github.com/ligato/vpp-agent/plugins/vpp/aclplugin/aclidx"
 
 	"github.com/ligato/vpp-agent/plugins/vpp/abfplugin/vppcalls"
+	"github.com/ligato/vpp-agent/plugins/vpp/aclplugin/aclidx"
 	"github.com/ligato/vpp-agent/plugins/vpp/binapi/vpp1908/abf"
 	"github.com/ligato/vpp-agent/plugins/vpp/ifplugin/ifaceidx"
 )
@@ -32,7 +32,6 @@ func init() {
 		New: func(ch govppapi.Channel, aclIndexes aclidx.ACLMetadataIndex, ifIndexes ifaceidx.IfaceMetadataIndex) vppcalls.ABFVppAPI {
 			return &ABFVppHandler{
 				callsChannel: ch,
-				dumpChannel:  ch,
 				aclIndexes:   aclIndexes,
 				ifIndexes:    ifIndexes,
 			}
@@ -43,12 +42,11 @@ func init() {
 // ABFVppHandler is accessor for abfrelated vppcalls methods
 type ABFVppHandler struct {
 	callsChannel govppapi.Channel
-	dumpChannel  govppapi.Channel
 	aclIndexes   aclidx.ACLMetadataIndex
 	ifIndexes    ifaceidx.IfaceMetadataIndex
 }
 
 // NewABFVppHandler returns new ABFVppHandler.
 func NewABFVppHandler(calls, dump govppapi.Channel, aclIdx aclidx.ACLMetadataIndex, ifIdx ifaceidx.IfaceMetadataIndex) *ABFVppHandler {
-	return &ABFVppHandler{calls, dump, aclIdx, ifIdx}
+	return &ABFVppHandler{calls, aclIdx, ifIdx}
 }

--- a/plugins/vpp/aclplugin/aclplugin.go
+++ b/plugins/vpp/aclplugin/aclplugin.go
@@ -40,8 +40,7 @@ type ACLPlugin struct {
 	Deps
 
 	// GoVPP channels
-	vppCh     govppapi.Channel
-	dumpVppCh govppapi.Channel
+	vppCh govppapi.Channel
 
 	aclHandler             vppcalls.ACLVppAPI
 	aclDescriptor          *descriptor.ACLDescriptor
@@ -68,12 +67,9 @@ func (p *ACLPlugin) Init() error {
 	if p.vppCh, err = p.GoVppmux.NewAPIChannel(); err != nil {
 		return errors.Errorf("failed to create GoVPP API channel: %v", err)
 	}
-	if p.dumpVppCh, err = p.GoVppmux.NewAPIChannel(); err != nil {
-		return errors.Errorf("failed to create GoVPP API dump channel: %v", err)
-	}
 
 	// init handlers
-	p.aclHandler = vppcalls.CompatibleACLVppHandler(p.vppCh, p.dumpVppCh, p.IfPlugin.GetInterfaceIndex(), p.Log)
+	p.aclHandler = vppcalls.CompatibleACLVppHandler(p.vppCh, p.IfPlugin.GetInterfaceIndex(), p.Log)
 	if p.aclHandler == nil {
 		return errors.New("aclHandler is not available")
 	}

--- a/plugins/vpp/aclplugin/vppcalls/acl_vppcalls.go
+++ b/plugins/vpp/aclplugin/vppcalls/acl_vppcalls.go
@@ -115,7 +115,7 @@ type HandlerVersion struct {
 	New  func(govppapi.Channel, ifaceidx.IfaceMetadataIndex) ACLVppAPI
 }
 
-func CompatibleACLVppHandler(ch, dch govppapi.Channel, idx ifaceidx.IfaceMetadataIndex, log logging.Logger) ACLVppAPI {
+func CompatibleACLVppHandler(ch govppapi.Channel, idx ifaceidx.IfaceMetadataIndex, log logging.Logger) ACLVppAPI {
 	if len(Versions) == 0 {
 		// aclplugin is not loaded
 		return nil

--- a/plugins/vpp/aclplugin/vppcalls/vpp1901/acl_vppcalls_test.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp1901/acl_vppcalls_test.go
@@ -233,7 +233,7 @@ func setupACLTest(t *testing.T) *testCtx {
 	ctx := vppcallmock.SetupTestCtx(t)
 
 	ifaceIdx := ifaceidx.NewIfaceIndex(logrus.NewLogger("test"), "test")
-	aclHandler := NewACLVppHandler(ctx.MockChannel, ctx.MockChannel, ifaceIdx)
+	aclHandler := NewACLVppHandler(ctx.MockChannel, ifaceIdx)
 
 	return &testCtx{
 		TestCtx:    ctx,

--- a/plugins/vpp/aclplugin/vppcalls/vpp1901/dump_vppcalls.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp1901/dump_vppcalls.go
@@ -150,7 +150,7 @@ func (h *ACLVppHandler) DumpACLInterfaces(indices []uint32) (map[uint32]*acl.ACL
 	msgIP := &acl_api.ACLInterfaceListDump{
 		SwIfIndex: 0xffffffff, // dump all
 	}
-	reqIP := h.dumpChannel.SendMultiRequest(msgIP)
+	reqIP := h.callsChannel.SendMultiRequest(msgIP)
 	for {
 		replyIP := &acl_api.ACLInterfaceListDetails{}
 		stop, err := reqIP.ReceiveReply(replyIP)
@@ -222,7 +222,7 @@ func (h *ACLVppHandler) DumpMACIPACLInterfaces(indices []uint32) (map[uint32]*ac
 	msgMACIP := &acl_api.MacipACLInterfaceListDump{
 		SwIfIndex: 0xffffffff, // dump all
 	}
-	reqMACIP := h.dumpChannel.SendMultiRequest(msgMACIP)
+	reqMACIP := h.callsChannel.SendMultiRequest(msgMACIP)
 	for {
 		replyMACIP := &acl_api.MacipACLInterfaceListDetails{}
 		stop, err := reqMACIP.ReceiveReply(replyMACIP)
@@ -278,7 +278,7 @@ func (h *ACLVppHandler) DumpIPAcls() (map[vppcalls.ACLMeta][]acl_api.ACLRule, er
 	req := &acl_api.ACLDump{
 		ACLIndex: 0xffffffff,
 	}
-	reqContext := h.dumpChannel.SendMultiRequest(req)
+	reqContext := h.callsChannel.SendMultiRequest(req)
 	for {
 		msg := &acl_api.ACLDetails{}
 		stop, err := reqContext.ReceiveReply(msg)
@@ -307,7 +307,7 @@ func (h *ACLVppHandler) DumpMacIPAcls() (map[vppcalls.ACLMeta][]acl_api.MacipACL
 	req := &acl_api.MacipACLDump{
 		ACLIndex: 0xffffffff,
 	}
-	reqContext := h.dumpChannel.SendMultiRequest(req)
+	reqContext := h.callsChannel.SendMultiRequest(req)
 	for {
 		msg := &acl_api.MacipACLDetails{}
 		stop, err := reqContext.ReceiveReply(msg)
@@ -377,7 +377,7 @@ func (h *ACLVppHandler) DumpInterfaceACLList(swIndex uint32) (*acl_api.ACLInterf
 	}
 	reply := &acl_api.ACLInterfaceListDetails{}
 
-	if err := h.dumpChannel.SendRequest(req).ReceiveReply(reply); err != nil {
+	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return nil, err
 	}
 
@@ -391,7 +391,7 @@ func (h *ACLVppHandler) DumpInterfaceMACIPACLList(swIndex uint32) (*acl_api.Maci
 	}
 	reply := &acl_api.MacipACLInterfaceListDetails{}
 
-	if err := h.dumpChannel.SendRequest(req).ReceiveReply(reply); err != nil {
+	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return nil, err
 	}
 
@@ -404,7 +404,7 @@ func (h *ACLVppHandler) DumpInterfacesLists() ([]*acl_api.ACLInterfaceListDetail
 		SwIfIndex: 0xffffffff, // dump all
 	}
 
-	reqIPACL := h.dumpChannel.SendMultiRequest(msgIPACL)
+	reqIPACL := h.callsChannel.SendMultiRequest(msgIPACL)
 
 	var IPaclInterfaces []*acl_api.ACLInterfaceListDetails
 	for {
@@ -424,7 +424,7 @@ func (h *ACLVppHandler) DumpInterfacesLists() ([]*acl_api.ACLInterfaceListDetail
 		SwIfIndex: 0xffffffff, // dump all
 	}
 
-	reqMACIPACL := h.dumpChannel.SendMultiRequest(msgMACIPACL)
+	reqMACIPACL := h.callsChannel.SendMultiRequest(msgMACIPACL)
 
 	var MACIPaclInterfaces []*acl_api.MacipACLInterfaceListDetails
 	for {
@@ -464,7 +464,7 @@ func (h *ACLVppHandler) getIPACLDetails(idx uint32) (aclRule *acl.ACL, err error
 	}
 
 	reply := &acl_api.ACLDetails{}
-	if err := h.dumpChannel.SendRequest(req).ReceiveReply(reply); err != nil {
+	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return nil, err
 	}
 
@@ -511,7 +511,7 @@ func (h *ACLVppHandler) getMACIPACLDetails(idx uint32) (aclRule *acl.ACL, err er
 	}
 
 	reply := &acl_api.MacipACLDetails{}
-	if err := h.dumpChannel.SendRequest(req).ReceiveReply(reply); err != nil {
+	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return nil, err
 	}
 

--- a/plugins/vpp/aclplugin/vppcalls/vpp1901/vppcalls_handlers.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp1901/vppcalls_handlers.go
@@ -29,7 +29,7 @@ func init() {
 	vppcalls.Versions["vpp1901"] = vppcalls.HandlerVersion{
 		Msgs: msgs,
 		New: func(ch govppapi.Channel, ifIdx ifaceidx.IfaceMetadataIndex) vppcalls.ACLVppAPI {
-			return NewACLVppHandler(ch, ch, ifIdx)
+			return NewACLVppHandler(ch, ifIdx)
 		},
 	}
 }
@@ -37,14 +37,12 @@ func init() {
 // ACLVppHandler is accessor for acl-related vppcalls methods
 type ACLVppHandler struct {
 	callsChannel govppapi.Channel
-	dumpChannel  govppapi.Channel
 	ifIndexes    ifaceidx.IfaceMetadataIndex
 }
 
-func NewACLVppHandler(ch, dch govppapi.Channel, ifIdx ifaceidx.IfaceMetadataIndex) *ACLVppHandler {
+func NewACLVppHandler(ch govppapi.Channel, ifIdx ifaceidx.IfaceMetadataIndex) *ACLVppHandler {
 	return &ACLVppHandler{
 		callsChannel: ch,
-		dumpChannel:  dch,
 		ifIndexes:    ifIdx,
 	}
 }

--- a/plugins/vpp/aclplugin/vppcalls/vpp1904/acl_vppcalls_test.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp1904/acl_vppcalls_test.go
@@ -233,7 +233,7 @@ func setupACLTest(t *testing.T) *testCtx {
 	ctx := vppcallmock.SetupTestCtx(t)
 
 	ifaceIdx := ifaceidx.NewIfaceIndex(logrus.NewLogger("test"), "test")
-	aclHandler := NewACLVppHandler(ctx.MockChannel, ctx.MockChannel, ifaceIdx)
+	aclHandler := NewACLVppHandler(ctx.MockChannel, ifaceIdx)
 
 	return &testCtx{
 		TestCtx:    ctx,

--- a/plugins/vpp/aclplugin/vppcalls/vpp1904/dump_vppcalls.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp1904/dump_vppcalls.go
@@ -150,7 +150,7 @@ func (h *ACLVppHandler) DumpACLInterfaces(indices []uint32) (map[uint32]*acl.ACL
 	msgIP := &acl_api.ACLInterfaceListDump{
 		SwIfIndex: 0xffffffff, // dump all
 	}
-	reqIP := h.dumpChannel.SendMultiRequest(msgIP)
+	reqIP := h.callsChannel.SendMultiRequest(msgIP)
 	for {
 		replyIP := &acl_api.ACLInterfaceListDetails{}
 		stop, err := reqIP.ReceiveReply(replyIP)
@@ -222,7 +222,7 @@ func (h *ACLVppHandler) DumpMACIPACLInterfaces(indices []uint32) (map[uint32]*ac
 	msgMACIP := &acl_api.MacipACLInterfaceListDump{
 		SwIfIndex: 0xffffffff, // dump all
 	}
-	reqMACIP := h.dumpChannel.SendMultiRequest(msgMACIP)
+	reqMACIP := h.callsChannel.SendMultiRequest(msgMACIP)
 	for {
 		replyMACIP := &acl_api.MacipACLInterfaceListDetails{}
 		stop, err := reqMACIP.ReceiveReply(replyMACIP)
@@ -278,7 +278,7 @@ func (h *ACLVppHandler) DumpIPAcls() (map[vppcalls.ACLMeta][]acl_api.ACLRule, er
 	req := &acl_api.ACLDump{
 		ACLIndex: 0xffffffff,
 	}
-	reqContext := h.dumpChannel.SendMultiRequest(req)
+	reqContext := h.callsChannel.SendMultiRequest(req)
 	for {
 		msg := &acl_api.ACLDetails{}
 		stop, err := reqContext.ReceiveReply(msg)
@@ -307,7 +307,7 @@ func (h *ACLVppHandler) DumpMacIPAcls() (map[vppcalls.ACLMeta][]acl_api.MacipACL
 	req := &acl_api.MacipACLDump{
 		ACLIndex: 0xffffffff,
 	}
-	reqContext := h.dumpChannel.SendMultiRequest(req)
+	reqContext := h.callsChannel.SendMultiRequest(req)
 	for {
 		msg := &acl_api.MacipACLDetails{}
 		stop, err := reqContext.ReceiveReply(msg)
@@ -377,7 +377,7 @@ func (h *ACLVppHandler) DumpInterfaceACLList(swIndex uint32) (*acl_api.ACLInterf
 	}
 	reply := &acl_api.ACLInterfaceListDetails{}
 
-	if err := h.dumpChannel.SendRequest(req).ReceiveReply(reply); err != nil {
+	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return nil, err
 	}
 
@@ -391,7 +391,7 @@ func (h *ACLVppHandler) DumpInterfaceMACIPACLList(swIndex uint32) (*acl_api.Maci
 	}
 	reply := &acl_api.MacipACLInterfaceListDetails{}
 
-	if err := h.dumpChannel.SendRequest(req).ReceiveReply(reply); err != nil {
+	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return nil, err
 	}
 
@@ -404,7 +404,7 @@ func (h *ACLVppHandler) DumpInterfacesLists() ([]*acl_api.ACLInterfaceListDetail
 		SwIfIndex: 0xffffffff, // dump all
 	}
 
-	reqIPACL := h.dumpChannel.SendMultiRequest(msgIPACL)
+	reqIPACL := h.callsChannel.SendMultiRequest(msgIPACL)
 
 	var IPaclInterfaces []*acl_api.ACLInterfaceListDetails
 	for {
@@ -424,7 +424,7 @@ func (h *ACLVppHandler) DumpInterfacesLists() ([]*acl_api.ACLInterfaceListDetail
 		SwIfIndex: 0xffffffff, // dump all
 	}
 
-	reqMACIPACL := h.dumpChannel.SendMultiRequest(msgMACIPACL)
+	reqMACIPACL := h.callsChannel.SendMultiRequest(msgMACIPACL)
 
 	var MACIPaclInterfaces []*acl_api.MacipACLInterfaceListDetails
 	for {
@@ -464,7 +464,7 @@ func (h *ACLVppHandler) getIPACLDetails(idx uint32) (aclRule *acl.ACL, err error
 	}
 
 	reply := &acl_api.ACLDetails{}
-	if err := h.dumpChannel.SendRequest(req).ReceiveReply(reply); err != nil {
+	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return nil, err
 	}
 
@@ -511,7 +511,7 @@ func (h *ACLVppHandler) getMACIPACLDetails(idx uint32) (aclRule *acl.ACL, err er
 	}
 
 	reply := &acl_api.MacipACLDetails{}
-	if err := h.dumpChannel.SendRequest(req).ReceiveReply(reply); err != nil {
+	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return nil, err
 	}
 

--- a/plugins/vpp/aclplugin/vppcalls/vpp1904/vppcalls_handlers.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp1904/vppcalls_handlers.go
@@ -29,7 +29,7 @@ func init() {
 	vppcalls.Versions["vpp1904"] = vppcalls.HandlerVersion{
 		Msgs: msgs,
 		New: func(ch govppapi.Channel, ifIdx ifaceidx.IfaceMetadataIndex) vppcalls.ACLVppAPI {
-			return NewACLVppHandler(ch, ch, ifIdx)
+			return NewACLVppHandler(ch, ifIdx)
 		},
 	}
 }
@@ -37,14 +37,12 @@ func init() {
 // ACLVppHandler is accessor for acl-related vppcalls methods
 type ACLVppHandler struct {
 	callsChannel govppapi.Channel
-	dumpChannel  govppapi.Channel
 	ifIndexes    ifaceidx.IfaceMetadataIndex
 }
 
-func NewACLVppHandler(ch, dch govppapi.Channel, ifIdx ifaceidx.IfaceMetadataIndex) *ACLVppHandler {
+func NewACLVppHandler(ch govppapi.Channel, ifIdx ifaceidx.IfaceMetadataIndex) *ACLVppHandler {
 	return &ACLVppHandler{
 		callsChannel: ch,
-		dumpChannel:  dch,
 		ifIndexes:    ifIdx,
 	}
 }

--- a/plugins/vpp/aclplugin/vppcalls/vpp1908/acl_vppcalls_test.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp1908/acl_vppcalls_test.go
@@ -233,7 +233,7 @@ func setupACLTest(t *testing.T) *testCtx {
 	ctx := vppcallmock.SetupTestCtx(t)
 
 	ifaceIdx := ifaceidx.NewIfaceIndex(logrus.NewLogger("test"), "test")
-	aclHandler := NewACLVppHandler(ctx.MockChannel, ctx.MockChannel, ifaceIdx)
+	aclHandler := NewACLVppHandler(ctx.MockChannel, ifaceIdx)
 
 	return &testCtx{
 		TestCtx:    ctx,

--- a/plugins/vpp/aclplugin/vppcalls/vpp1908/dump_vppcalls.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp1908/dump_vppcalls.go
@@ -150,7 +150,7 @@ func (h *ACLVppHandler) DumpACLInterfaces(indices []uint32) (map[uint32]*acl.ACL
 	msgIP := &acl_api.ACLInterfaceListDump{
 		SwIfIndex: 0xffffffff, // dump all
 	}
-	reqIP := h.dumpChannel.SendMultiRequest(msgIP)
+	reqIP := h.callsChannel.SendMultiRequest(msgIP)
 	for {
 		replyIP := &acl_api.ACLInterfaceListDetails{}
 		stop, err := reqIP.ReceiveReply(replyIP)
@@ -222,7 +222,7 @@ func (h *ACLVppHandler) DumpMACIPACLInterfaces(indices []uint32) (map[uint32]*ac
 	msgMACIP := &acl_api.MacipACLInterfaceListDump{
 		SwIfIndex: 0xffffffff, // dump all
 	}
-	reqMACIP := h.dumpChannel.SendMultiRequest(msgMACIP)
+	reqMACIP := h.callsChannel.SendMultiRequest(msgMACIP)
 	for {
 		replyMACIP := &acl_api.MacipACLInterfaceListDetails{}
 		stop, err := reqMACIP.ReceiveReply(replyMACIP)
@@ -278,7 +278,7 @@ func (h *ACLVppHandler) DumpIPAcls() (map[vppcalls.ACLMeta][]acl_api.ACLRule, er
 	req := &acl_api.ACLDump{
 		ACLIndex: 0xffffffff,
 	}
-	reqContext := h.dumpChannel.SendMultiRequest(req)
+	reqContext := h.callsChannel.SendMultiRequest(req)
 	for {
 		msg := &acl_api.ACLDetails{}
 		stop, err := reqContext.ReceiveReply(msg)
@@ -307,7 +307,7 @@ func (h *ACLVppHandler) DumpMacIPAcls() (map[vppcalls.ACLMeta][]acl_api.MacipACL
 	req := &acl_api.MacipACLDump{
 		ACLIndex: 0xffffffff,
 	}
-	reqContext := h.dumpChannel.SendMultiRequest(req)
+	reqContext := h.callsChannel.SendMultiRequest(req)
 	for {
 		msg := &acl_api.MacipACLDetails{}
 		stop, err := reqContext.ReceiveReply(msg)
@@ -377,7 +377,7 @@ func (h *ACLVppHandler) DumpInterfaceACLList(swIndex uint32) (*acl_api.ACLInterf
 	}
 	reply := &acl_api.ACLInterfaceListDetails{}
 
-	if err := h.dumpChannel.SendRequest(req).ReceiveReply(reply); err != nil {
+	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return nil, err
 	}
 
@@ -391,7 +391,7 @@ func (h *ACLVppHandler) DumpInterfaceMACIPACLList(swIndex uint32) (*acl_api.Maci
 	}
 	reply := &acl_api.MacipACLInterfaceListDetails{}
 
-	if err := h.dumpChannel.SendRequest(req).ReceiveReply(reply); err != nil {
+	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return nil, err
 	}
 
@@ -404,7 +404,7 @@ func (h *ACLVppHandler) DumpInterfacesLists() ([]*acl_api.ACLInterfaceListDetail
 		SwIfIndex: 0xffffffff, // dump all
 	}
 
-	reqIPACL := h.dumpChannel.SendMultiRequest(msgIPACL)
+	reqIPACL := h.callsChannel.SendMultiRequest(msgIPACL)
 
 	var IPaclInterfaces []*acl_api.ACLInterfaceListDetails
 	for {
@@ -424,7 +424,7 @@ func (h *ACLVppHandler) DumpInterfacesLists() ([]*acl_api.ACLInterfaceListDetail
 		SwIfIndex: 0xffffffff, // dump all
 	}
 
-	reqMACIPACL := h.dumpChannel.SendMultiRequest(msgMACIPACL)
+	reqMACIPACL := h.callsChannel.SendMultiRequest(msgMACIPACL)
 
 	var MACIPaclInterfaces []*acl_api.MacipACLInterfaceListDetails
 	for {
@@ -464,7 +464,7 @@ func (h *ACLVppHandler) getIPACLDetails(idx uint32) (aclRule *acl.ACL, err error
 	}
 
 	reply := &acl_api.ACLDetails{}
-	if err := h.dumpChannel.SendRequest(req).ReceiveReply(reply); err != nil {
+	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return nil, err
 	}
 
@@ -511,7 +511,7 @@ func (h *ACLVppHandler) getMACIPACLDetails(idx uint32) (aclRule *acl.ACL, err er
 	}
 
 	reply := &acl_api.MacipACLDetails{}
-	if err := h.dumpChannel.SendRequest(req).ReceiveReply(reply); err != nil {
+	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return nil, err
 	}
 

--- a/plugins/vpp/aclplugin/vppcalls/vpp1908/vppcalls_handlers.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp1908/vppcalls_handlers.go
@@ -29,7 +29,7 @@ func init() {
 	vppcalls.Versions["vpp1908"] = vppcalls.HandlerVersion{
 		Msgs: msgs,
 		New: func(ch govppapi.Channel, ifIdx ifaceidx.IfaceMetadataIndex) vppcalls.ACLVppAPI {
-			return NewACLVppHandler(ch, ch, ifIdx)
+			return NewACLVppHandler(ch, ifIdx)
 		},
 	}
 }
@@ -37,14 +37,12 @@ func init() {
 // ACLVppHandler is accessor for acl-related vppcalls methods
 type ACLVppHandler struct {
 	callsChannel govppapi.Channel
-	dumpChannel  govppapi.Channel
 	ifIndexes    ifaceidx.IfaceMetadataIndex
 }
 
-func NewACLVppHandler(ch, dch govppapi.Channel, ifIdx ifaceidx.IfaceMetadataIndex) *ACLVppHandler {
+func NewACLVppHandler(ch govppapi.Channel, ifIdx ifaceidx.IfaceMetadataIndex) *ACLVppHandler {
 	return &ACLVppHandler{
 		callsChannel: ch,
-		dumpChannel:  dch,
 		ifIndexes:    ifIdx,
 	}
 }


### PR DESCRIPTION
- do not return error for dumps when some handlers are not available
- log all unavailable handlers during initialization of restapi/configurator
- remove unused dump channels from vppcalls