### PR TITLE
Add fixes for punt plugin

### DIFF
--- a/plugins/vpp/puntplugin/descriptor/ip_punt_redirect.go
+++ b/plugins/vpp/puntplugin/descriptor/ip_punt_redirect.go
@@ -19,8 +19,10 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/ligato/cn-infra/logging"
+
 	interfaces "github.com/ligato/vpp-agent/api/models/vpp/interfaces"
 	punt "github.com/ligato/vpp-agent/api/models/vpp/punt"
+	"github.com/ligato/vpp-agent/pkg/models"
 	kvs "github.com/ligato/vpp-agent/plugins/kvscheduler/api"
 	"github.com/ligato/vpp-agent/plugins/vpp/puntplugin/descriptor/adapter"
 	"github.com/ligato/vpp-agent/plugins/vpp/puntplugin/vppcalls"
@@ -32,6 +34,7 @@ const (
 
 	// dependency labels
 	ipRedirectTxInterfaceDep = "tx-interface-exists"
+	ipRedirectRxInterfaceDep = "rx-interface-exists"
 )
 
 // A list of non-retriable errors:
@@ -130,16 +133,36 @@ func (d *IPRedirectDescriptor) Delete(key string, redirect *punt.IPRedirect, met
 
 // Retrieve returns all configured VPP punt to host entries.
 func (d *IPRedirectDescriptor) Retrieve(correlate []adapter.IPPuntRedirectKVWithMetadata) (dump []adapter.IPPuntRedirectKVWithMetadata, err error) {
-	// TODO dump for IP redirect missing in api
-	d.log.Info("Dump IP punt redirect is not supported by the VPP")
-	return []adapter.IPPuntRedirectKVWithMetadata{}, nil
+	punts, err := d.puntHandler.DumpPuntRedirect()
+	if err != nil {
+		d.log.Error(err)
+		return nil, err
+	}
+
+	for _, p := range punts {
+		dump = append(dump, adapter.IPPuntRedirectKVWithMetadata{
+			Key:    models.Key(p),
+			Value:  p,
+			Origin: kvs.FromNB,
+		})
+	}
+
+	return dump, nil
 }
 
 // Dependencies for IP punt redirect are represented by tx interface
 func (d *IPRedirectDescriptor) Dependencies(key string, redirect *punt.IPRedirect) (dependencies []kvs.Dependency) {
+	// TX interface
 	dependencies = append(dependencies, kvs.Dependency{
 		Label: ipRedirectTxInterfaceDep,
 		Key:   interfaces.InterfaceKey(redirect.TxInterface),
 	})
+	// RX interface
+	if redirect.RxInterface != "" {
+		dependencies = append(dependencies, kvs.Dependency{
+			Label: ipRedirectRxInterfaceDep,
+			Key:   interfaces.InterfaceKey(redirect.RxInterface),
+		})
+	}
 	return dependencies
 }

--- a/plugins/vpp/puntplugin/options.go
+++ b/plugins/vpp/puntplugin/options.go
@@ -16,6 +16,7 @@ package puntplugin
 
 import (
 	"github.com/ligato/cn-infra/logging"
+
 	"github.com/ligato/vpp-agent/plugins/govppmux"
 	"github.com/ligato/vpp-agent/plugins/kvscheduler"
 	"github.com/ligato/vpp-agent/plugins/vpp/ifplugin"

--- a/plugins/vpp/puntplugin/vppcalls/punt_vppcalls.go
+++ b/plugins/vpp/puntplugin/vppcalls/punt_vppcalls.go
@@ -22,19 +22,22 @@ import (
 	"github.com/ligato/vpp-agent/plugins/vpp/ifplugin/ifaceidx"
 )
 
-// PuntDetails includes proto-modelled punt object and its socket path
+// PuntDetails includes punt model and socket path from VPP.
 type PuntDetails struct {
 	PuntData   *punt.ToHost
 	SocketPath string
 }
 
+// ReasonDetails includes reason model and its matching ID from VPP.
 type ReasonDetails struct {
 	Reason *punt.Reason
 	ID     uint32
 }
 
+// ExceptionDetails include punt model and socket path from VPP.
 type ExceptionDetails struct {
-	Exception *punt.Exception
+	Exception  *punt.Exception
+	SocketPath string
 }
 
 // PuntVppAPI provides methods for managing VPP punt configuration.
@@ -53,9 +56,9 @@ type PuntVppAPI interface {
 	AddPuntRedirect(punt *punt.IPRedirect) error
 	// DeletePuntRedirect removes existing redirect entry
 	DeletePuntRedirect(punt *punt.IPRedirect) error
-	// AddPuntException configures new punt exception
-	AddPuntException(punt *punt.Exception) error
-	// DeletePuntException removes punt exception entry
+	// AddPuntException registers new punt exception
+	AddPuntException(punt *punt.Exception) (string, error)
+	// DeletePuntException deregisters punt exception entry
 	DeletePuntException(punt *punt.Exception) error
 }
 
@@ -67,6 +70,8 @@ type PuntVPPRead interface {
 	DumpExceptions() ([]*ExceptionDetails, error)
 	// DumpPuntReasons returns all known punt reasons from VPP
 	DumpPuntReasons() ([]*ReasonDetails, error)
+	// DumpPuntRedirect dump IP redirect punts
+	DumpPuntRedirect() ([]*punt.IPRedirect, error)
 }
 
 var Versions = map[string]HandlerVersion{}

--- a/plugins/vpp/puntplugin/vppcalls/vpp1901/dump_vppcalls.go
+++ b/plugins/vpp/puntplugin/vppcalls/vpp1901/dump_vppcalls.go
@@ -24,6 +24,11 @@ import (
 // FIXME: temporary solutions for providing data in dump
 var socketPathMap = make(map[uint32]*vpp.PuntToHost)
 
+func (h *PuntVppHandler) DumpPuntRedirect() (punts []*vpp_punt.IPRedirect, err error) {
+	h.log.Debugf("dump for ip redirect punt not implemented")
+	return nil, nil
+}
+
 // DumpRegisteredPuntSockets returns punt to host via registered socket entries
 // TODO since the binary API is not available, all data are read from local cache for now
 func (h *PuntVppHandler) DumpRegisteredPuntSockets() (punts []*vppcalls.PuntDetails, err error) {

--- a/plugins/vpp/puntplugin/vppcalls/vpp1901/punt_vppcalls.go
+++ b/plugins/vpp/puntplugin/vppcalls/vpp1901/punt_vppcalls.go
@@ -79,10 +79,6 @@ func (h *PuntVppHandler) RegisterPuntSocket(toHost *punt.ToHost) (string, error)
 	p.SocketPath = strings.SplitN(string(reply.Pathname), "\x00", 2)[0]
 	socketPathMap[toHost.Port] = &p
 
-	/*if h.RegisterSocketFn != nil {
-		h.RegisterSocketFn(true, toHost, p.SocketPath)
-	}*/
-
 	return p.SocketPath, nil
 }
 
@@ -100,12 +96,6 @@ func (h *PuntVppHandler) DeregisterPuntSocket(toHost *punt.ToHost) error {
 	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return err
 	}
-
-	/*if h.RegisterSocketFn != nil {
-		if p, ok := socketPathMap[toHost.Port]; ok {
-			h.RegisterSocketFn(false, toHost, p.SocketPath)
-		}
-	}*/
 
 	delete(socketPathMap, toHost.Port)
 
@@ -247,8 +237,8 @@ func boolToUint(input bool) uint8 {
 	return 0
 }
 
-func (h *PuntVppHandler) AddPuntException(punt *punt.Exception) error {
-	return fmt.Errorf("punt exceptions are not supported")
+func (h *PuntVppHandler) AddPuntException(punt *punt.Exception) (string, error) {
+	return "", fmt.Errorf("punt exceptions are not supported")
 }
 
 func (h *PuntVppHandler) DeletePuntException(punt *punt.Exception) error {

--- a/plugins/vpp/puntplugin/vppcalls/vpp1904/dump_vppcalls.go
+++ b/plugins/vpp/puntplugin/vppcalls/vpp1904/dump_vppcalls.go
@@ -24,6 +24,11 @@ import (
 // FIXME: temporary solutions for providing data in dump
 var socketPathMap = make(map[uint32]*vpp.PuntToHost)
 
+func (h *PuntVppHandler) DumpPuntRedirect() (punts []*vpp_punt.IPRedirect, err error) {
+	h.log.Debugf("dump for ip redirect punt not implemented")
+	return nil, nil
+}
+
 // DumpRegisteredPuntSockets returns punt to host via registered socket entries
 // TODO since the binary API is not available, all data are read from local cache for now
 func (h *PuntVppHandler) DumpRegisteredPuntSockets() (punts []*vppcalls.PuntDetails, err error) {

--- a/plugins/vpp/puntplugin/vppcalls/vpp1904/punt_vppcalls.go
+++ b/plugins/vpp/puntplugin/vppcalls/vpp1904/punt_vppcalls.go
@@ -79,10 +79,6 @@ func (h *PuntVppHandler) RegisterPuntSocket(toHost *punt.ToHost) (string, error)
 	p.SocketPath = strings.SplitN(string(reply.Pathname), "\x00", 2)[0]
 	socketPathMap[toHost.Port] = &p
 
-	/*if h.RegisterSocketFn != nil {
-		h.RegisterSocketFn(true, toHost, p.SocketPath)
-	}*/
-
 	return p.SocketPath, nil
 }
 
@@ -100,12 +96,6 @@ func (h *PuntVppHandler) DeregisterPuntSocket(toHost *punt.ToHost) error {
 	if err := h.callsChannel.SendRequest(req).ReceiveReply(reply); err != nil {
 		return err
 	}
-
-	/*if h.RegisterSocketFn != nil {
-		if p, ok := socketPathMap[toHost.Port]; ok {
-			h.RegisterSocketFn(false, toHost, p.SocketPath)
-		}
-	}*/
 
 	delete(socketPathMap, toHost.Port)
 
@@ -247,8 +237,8 @@ func boolToUint(input bool) uint8 {
 	return 0
 }
 
-func (h *PuntVppHandler) AddPuntException(punt *punt.Exception) error {
-	return fmt.Errorf("punt exceptions are not supported")
+func (h *PuntVppHandler) AddPuntException(punt *punt.Exception) (string, error) {
+	return "", fmt.Errorf("punt exceptions are not supported")
 }
 
 func (h *PuntVppHandler) DeletePuntException(punt *punt.Exception) error {


### PR DESCRIPTION
- do not check socket path for punt exceptions to prevent recreation
- add depenency for RX interface to ip redirect punt
- implement IP redirect dump (only for 19.08)
- add workaround for publishing socket to punt exceptions as well
- properly deregister punt exeption on delete
- return pathname from registration when adding punt exception
- add workaround with ! prefix to punt exceptions
- publish socket paths to status with client TTL