### PR TITLE
kvscheduler: keep node in the graph during recreate

### DIFF
--- a/plugins/kvscheduler/api/txn_record.go
+++ b/plugins/kvscheduler/api/txn_record.go
@@ -244,7 +244,7 @@ func (op *RecordedTxnOp) StringWithOpts(index int, verbose bool, indent int) str
 		flags = append(flags, "WAS-UNIMPLEMENTED")
 	}
 	//  -> REMOVED / MISSING
-	if op.PrevState == ValueState_REMOVED && !op.IsRecreate {
+	if op.PrevState == ValueState_REMOVED && op.Operation == TxnOperation_DELETE {
 		flags = append(flags, "ALREADY-REMOVED")
 	}
 	if op.PrevState == ValueState_MISSING {

--- a/plugins/kvscheduler/internal/test/model/values.pb.go
+++ b/plugins/kvscheduler/internal/test/model/values.pb.go
@@ -3,9 +3,11 @@
 
 package model
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
+import (
+	fmt "fmt"
+	proto "github.com/gogo/protobuf/proto"
+	math "math"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -19,7 +21,8 @@ var _ = math.Inf
 const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
 type ArrayValue struct {
-	Items                []string `protobuf:"bytes,1,rep,name=items" json:"items,omitempty"`
+	Items                []string `protobuf:"bytes,1,rep,name=items,proto3" json:"items,omitempty"`
+	ItemSuffix           string   `protobuf:"bytes,2,opt,name=item_suffix,json=itemSuffix,proto3" json:"item_suffix,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -29,7 +32,7 @@ func (m *ArrayValue) Reset()         { *m = ArrayValue{} }
 func (m *ArrayValue) String() string { return proto.CompactTextString(m) }
 func (*ArrayValue) ProtoMessage()    {}
 func (*ArrayValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_values_f4aee9239d9ccefd, []int{0}
+	return fileDescriptor_5d19e76c3b90e014, []int{0}
 }
 func (m *ArrayValue) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ArrayValue.Unmarshal(m, b)
@@ -37,8 +40,8 @@ func (m *ArrayValue) XXX_Unmarshal(b []byte) error {
 func (m *ArrayValue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ArrayValue.Marshal(b, m, deterministic)
 }
-func (dst *ArrayValue) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ArrayValue.Merge(dst, src)
+func (m *ArrayValue) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ArrayValue.Merge(m, src)
 }
 func (m *ArrayValue) XXX_Size() int {
 	return xxx_messageInfo_ArrayValue.Size(m)
@@ -56,6 +59,13 @@ func (m *ArrayValue) GetItems() []string {
 	return nil
 }
 
+func (m *ArrayValue) GetItemSuffix() string {
+	if m != nil {
+		return m.ItemSuffix
+	}
+	return ""
+}
+
 type StringValue struct {
 	Value                string   `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -67,7 +77,7 @@ func (m *StringValue) Reset()         { *m = StringValue{} }
 func (m *StringValue) String() string { return proto.CompactTextString(m) }
 func (*StringValue) ProtoMessage()    {}
 func (*StringValue) Descriptor() ([]byte, []int) {
-	return fileDescriptor_values_f4aee9239d9ccefd, []int{1}
+	return fileDescriptor_5d19e76c3b90e014, []int{1}
 }
 func (m *StringValue) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StringValue.Unmarshal(m, b)
@@ -75,8 +85,8 @@ func (m *StringValue) XXX_Unmarshal(b []byte) error {
 func (m *StringValue) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StringValue.Marshal(b, m, deterministic)
 }
-func (dst *StringValue) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StringValue.Merge(dst, src)
+func (m *StringValue) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StringValue.Merge(m, src)
 }
 func (m *StringValue) XXX_Size() int {
 	return xxx_messageInfo_StringValue.Size(m)
@@ -99,15 +109,16 @@ func init() {
 	proto.RegisterType((*StringValue)(nil), "model.StringValue")
 }
 
-func init() { proto.RegisterFile("values.proto", fileDescriptor_values_f4aee9239d9ccefd) }
+func init() { proto.RegisterFile("values.proto", fileDescriptor_5d19e76c3b90e014) }
 
-var fileDescriptor_values_f4aee9239d9ccefd = []byte{
-	// 102 bytes of a gzipped FileDescriptorProto
+var fileDescriptor_5d19e76c3b90e014 = []byte{
+	// 125 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0x29, 0x4b, 0xcc, 0x29,
 	0x4d, 0x2d, 0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x62, 0xcd, 0xcd, 0x4f, 0x49, 0xcd, 0x51,
-	0x52, 0xe2, 0xe2, 0x72, 0x2c, 0x2a, 0x4a, 0xac, 0x0c, 0x03, 0xc9, 0x09, 0x89, 0x70, 0xb1, 0x66,
-	0x96, 0xa4, 0xe6, 0x16, 0x4b, 0x30, 0x2a, 0x30, 0x6b, 0x70, 0x06, 0x41, 0x38, 0x4a, 0xca, 0x5c,
-	0xdc, 0xc1, 0x25, 0x45, 0x99, 0x79, 0xe9, 0x70, 0x45, 0x60, 0x93, 0x24, 0x18, 0x15, 0x18, 0x41,
-	0x8a, 0xc0, 0x9c, 0x24, 0x36, 0xb0, 0xb1, 0xc6, 0x80, 0x00, 0x00, 0x00, 0xff, 0xff, 0xf9, 0xec,
-	0xab, 0xd4, 0x66, 0x00, 0x00, 0x00,
+	0x72, 0xe6, 0xe2, 0x72, 0x2c, 0x2a, 0x4a, 0xac, 0x0c, 0x03, 0xc9, 0x09, 0x89, 0x70, 0xb1, 0x66,
+	0x96, 0xa4, 0xe6, 0x16, 0x4b, 0x30, 0x2a, 0x30, 0x6b, 0x70, 0x06, 0x41, 0x38, 0x42, 0xf2, 0x5c,
+	0xdc, 0x20, 0x46, 0x7c, 0x71, 0x69, 0x5a, 0x5a, 0x66, 0x85, 0x04, 0x93, 0x02, 0xa3, 0x06, 0x67,
+	0x10, 0x17, 0x48, 0x28, 0x18, 0x2c, 0xa2, 0xa4, 0xcc, 0xc5, 0x1d, 0x5c, 0x52, 0x94, 0x99, 0x97,
+	0x0e, 0x37, 0x05, 0x6c, 0x95, 0x04, 0x23, 0x58, 0x25, 0x84, 0x93, 0xc4, 0x06, 0xb6, 0xd7, 0x18,
+	0x10, 0x00, 0x00, 0xff, 0xff, 0xb5, 0x67, 0x1c, 0xed, 0x87, 0x00, 0x00, 0x00,
 }

--- a/plugins/kvscheduler/internal/test/model/values.proto
+++ b/plugins/kvscheduler/internal/test/model/values.proto
@@ -4,6 +4,7 @@ package model;
 
 message ArrayValue {
     repeated string items = 1;
+    string item_suffix = 2;
 }
 
 message StringValue {

--- a/plugins/kvscheduler/internal/test/southbound.go
+++ b/plugins/kvscheduler/internal/test/southbound.go
@@ -210,15 +210,17 @@ func (ms *MockSouthbound) executeChange(descriptor string, opType MockOpType, ke
 		}
 		err := plannedErrors[0].err
 		clb := plannedErrors[0].afterErrClb
-		operation.Err = err
-		ms.opHistory = append(ms.opHistory, operation)
-		ms.Unlock()
+		if err != nil {
+			operation.Err = err
+			ms.opHistory = append(ms.opHistory, operation)
+			ms.Unlock()
 
-		if clb != nil {
-			clb()
+			if clb != nil {
+				clb()
+			}
+
+			return err
 		}
-
-		return err
 	}
 
 	// the simulated operation has succeeded

--- a/plugins/kvscheduler/internal/test/values.go
+++ b/plugins/kvscheduler/internal/test/values.go
@@ -33,6 +33,12 @@ func NewArrayValue(items ...string) proto.Message {
 	return &ArrayValue{Items: items}
 }
 
+// NewArrayValue creates a new instance of ArrayValue with a suffix
+// appended into each item value (but not key).
+func NewArrayValueWithSuffix(suffix string, items ...string) proto.Message {
+	return &ArrayValue{Items: items, ItemSuffix: suffix}
+}
+
 // StringValueComparator is (a custom) KVDescriptor.ValueComparator for string values.
 func StringValueComparator(key string, v1, v2 proto.Message) bool {
 	sv1, isStringVal1 := v1.(*StringValue)
@@ -52,7 +58,7 @@ func ArrayValueDerBuilder(key string, value proto.Message) []KeyValuePair {
 		for _, item := range arrayVal.Items {
 			derivedVals = append(derivedVals, KeyValuePair{
 				Key:   key + "/" + item,
-				Value: NewStringValue(item),
+				Value: NewStringValue(item + arrayVal.ItemSuffix),
 			})
 		}
 	}


### PR DESCRIPTION
This patch fixes issues reported in #1418.

During recreate (Delete+Create) the node would be completely
removed from the graph by Delete and all the associated flags
(metadata) were therefore lost.
When the subsequent Create fails, the scheduler needs to access
the flags, which in this case are undefined, causing the scheduler
to panic by dereferencing nil pointer.
This patch ensures that the node and its flags are preserved
during re-creation.

An in-progress refactor of the scheduling algorithm
will approach value recreation in a much cleaner
way...

Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>