### PR TITLE
Fixed ignoring of installation vrf table setting for SRv6 proxy…

### DIFF
--- a/plugins/vpp/srplugin/vppcalls/vpp1901/srv6.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp1901/srv6.go
@@ -125,9 +125,9 @@ func (h *SRv6VppHandler) addSRProxy(sidAddr net.IP, localSID *srv6.LocalSID) err
 	// add SR-proxy using VPP CLI
 	var cmd string
 	if strings.TrimSpace(localSID.GetEndFunction_AD().L3ServiceAddress) == "" { // L2 service
-		cmd = fmt.Sprintf("sr localsid address %v behavior end.ad oif %v iif %v", sidAddr, outInterface, inInterface)
+		cmd = fmt.Sprintf("sr localsid address %v fib-table %v behavior end.ad oif %v iif %v", sidAddr, localSID.InstallationVrfId, outInterface, inInterface)
 	} else { // L3 service
-		cmd = fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidAddr, localSID.GetEndFunction_AD().L3ServiceAddress, outInterface, inInterface)
+		cmd = fmt.Sprintf("sr localsid address %v fib-table %v behavior end.ad nh %v oif %v iif %v", sidAddr, localSID.InstallationVrfId, localSID.GetEndFunction_AD().L3ServiceAddress, outInterface, inInterface)
 	}
 	data, err := h.RunCli(cmd)
 	if err != nil {

--- a/plugins/vpp/srplugin/vppcalls/vpp1901/srv6_test.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp1901/srv6_test.go
@@ -275,7 +275,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), memif1, memif2),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), memif1, memif2),
 			},
 		},
 		{
@@ -296,7 +296,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad oif %v iif %v", sidToStr(sidA), memif1, memif2),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad oif %v iif %v", sidToStr(sidA), memif1, memif2),
 			},
 		},
 		{
@@ -318,7 +318,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "local0", "tap0"),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "local0", "tap0"),
 			},
 		},
 		{
@@ -340,7 +340,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "host0", "vxlan0"),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "host0", "vxlan0"),
 			},
 		},
 		{
@@ -362,7 +362,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "ipsec0", "vmxnet3-0"),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "ipsec0", "vmxnet3-0"),
 			},
 		},
 		{
@@ -384,7 +384,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "loop0", "unknown0"),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "loop0", "unknown0"),
 			},
 		},
 		{

--- a/plugins/vpp/srplugin/vppcalls/vpp1904/srv6.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp1904/srv6.go
@@ -125,9 +125,9 @@ func (h *SRv6VppHandler) addSRProxy(sidAddr net.IP, localSID *srv6.LocalSID) err
 	// add SR-proxy using VPP CLI
 	var cmd string
 	if strings.TrimSpace(localSID.GetEndFunction_AD().L3ServiceAddress) == "" { // L2 service
-		cmd = fmt.Sprintf("sr localsid address %v behavior end.ad oif %v iif %v", sidAddr, outInterface, inInterface)
+		cmd = fmt.Sprintf("sr localsid address %v fib-table %v behavior end.ad oif %v iif %v", sidAddr, localSID.InstallationVrfId, outInterface, inInterface)
 	} else { // L3 service
-		cmd = fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidAddr, localSID.GetEndFunction_AD().L3ServiceAddress, outInterface, inInterface)
+		cmd = fmt.Sprintf("sr localsid address %v fib-table %v behavior end.ad nh %v oif %v iif %v", sidAddr, localSID.InstallationVrfId, localSID.GetEndFunction_AD().L3ServiceAddress, outInterface, inInterface)
 	}
 	data, err := h.RunCli(cmd)
 	if err != nil {

--- a/plugins/vpp/srplugin/vppcalls/vpp1904/srv6_test.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp1904/srv6_test.go
@@ -275,7 +275,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), memif1, memif2),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), memif1, memif2),
 			},
 		},
 		{
@@ -296,7 +296,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad oif %v iif %v", sidToStr(sidA), memif1, memif2),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad oif %v iif %v", sidToStr(sidA), memif1, memif2),
 			},
 		},
 		{
@@ -318,7 +318,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "local0", "tap0"),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "local0", "tap0"),
 			},
 		},
 		{
@@ -340,7 +340,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "host0", "vxlan0"),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "host0", "vxlan0"),
 			},
 		},
 		{
@@ -362,7 +362,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "ipsec0", "vmxnet3-0"),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "ipsec0", "vmxnet3-0"),
 			},
 		},
 		{
@@ -384,7 +384,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "loop0", "unknown0"),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "loop0", "unknown0"),
 			},
 		},
 		{

--- a/plugins/vpp/srplugin/vppcalls/vpp1908/srv6.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp1908/srv6.go
@@ -125,9 +125,9 @@ func (h *SRv6VppHandler) addSRProxy(sidAddr net.IP, localSID *srv6.LocalSID) err
 	// add SR-proxy using VPP CLI
 	var cmd string
 	if strings.TrimSpace(localSID.GetEndFunction_AD().L3ServiceAddress) == "" { // L2 service
-		cmd = fmt.Sprintf("sr localsid address %v behavior end.ad oif %v iif %v", sidAddr, outInterface, inInterface)
+		cmd = fmt.Sprintf("sr localsid address %v fib-table %v behavior end.ad oif %v iif %v", sidAddr, localSID.InstallationVrfId, outInterface, inInterface)
 	} else { // L3 service
-		cmd = fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidAddr, localSID.GetEndFunction_AD().L3ServiceAddress, outInterface, inInterface)
+		cmd = fmt.Sprintf("sr localsid address %v fib-table %v behavior end.ad nh %v oif %v iif %v", sidAddr, localSID.InstallationVrfId, localSID.GetEndFunction_AD().L3ServiceAddress, outInterface, inInterface)
 	}
 	data, err := h.RunCli(cmd)
 	if err != nil {

--- a/plugins/vpp/srplugin/vppcalls/vpp1908/srv6_test.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp1908/srv6_test.go
@@ -275,7 +275,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), memif1, memif2),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), memif1, memif2),
 			},
 		},
 		{
@@ -296,7 +296,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad oif %v iif %v", sidToStr(sidA), memif1, memif2),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad oif %v iif %v", sidToStr(sidA), memif1, memif2),
 			},
 		},
 		{
@@ -318,7 +318,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "local0", "tap0"),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "local0", "tap0"),
 			},
 		},
 		{
@@ -340,7 +340,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "host0", "vxlan0"),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "host0", "vxlan0"),
 			},
 		},
 		{
@@ -362,7 +362,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "ipsec0", "vmxnet3-0"),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "ipsec0", "vmxnet3-0"),
 			},
 		},
 		{
@@ -384,7 +384,7 @@ func TestAddLocalSID(t *testing.T) {
 				},
 			},
 			Expected: &vpe.CliInband{
-				Cmd: fmt.Sprintf("sr localsid address %v behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "loop0", "unknown0"),
+				Cmd: fmt.Sprintf("sr localsid address %v fib-table 10 behavior end.ad nh %v oif %v iif %v", sidToStr(sidA), nextHopIPv4.String(), "loop0", "unknown0"),
 			},
 		},
 		{


### PR DESCRIPTION
SRv6 localsid with END.AD (SRv6 dynamic proxy) is configured via VPP CLI command (using binary API VPP VPE) and the command didn't contain vrf table setting. Hence the SRv6 proxy routing was always inserted into vrf with id 0. The fix is about proper setting the vrf in CLI command as configured in NB API for localsid.

PS: CLI command is passing with all currently supported vpp version