### PR TITLE
Fix ACL/IPv6ACL CRUD tests

### DIFF
--- a/tests/robot/libraries/etcdctl.robot
+++ b/tests/robot/libraries/etcdctl.robot
@@ -1,9 +1,10 @@
 [Documentation]     Keywords for working with VPP Ctl container
 
 *** Settings ***
-Library        etcdctl.py
 Library        String
 
+Library        etcdctl.py
+Library        vpp_term.py
 *** Variables ***
 
 *** Keywords ***
@@ -442,17 +443,26 @@ Get Linux Route As Json
 
 Check ACL Reply
     [Arguments]         ${node}    ${acl_name}   ${reply_json}    ${reply_term}    ${api_h}=$(API_HANDLER}
+    [Documentation]     Get ACL data from VAT terminal and verify response against expected data.
     ${acl_d}=           Get ACL As Json    ${node}    ${acl_name}
     ${term_d}=          vat_term: Check ACL     ${node}    ${acl_name}
-    ${term_d_lines}=    Split To Lines    ${term_d}
     ${data}=            OperatingSystem.Get File    ${reply_json}
     ${data}=            Replace Variables      ${data}
     Should Be Equal     ${data}   ${acl_d}
     ${data}=            OperatingSystem.Get File    ${reply_term}
     ${data}=            Replace Variables      ${data}
-    ${t_data_lines}=    Split To Lines    ${data}
-    List Should Contain Sub List    ${term_d_lines}    ${t_data_lines}
+    Verify API Response    ${term_d}    ${data}
 
+Check ACL All Reply
+    [Arguments]         ${node}    ${reply_json}     ${reply_term}
+    ${acl_d}=           Get All ACL As Json    ${node}
+    ${term_d}=          vat_term: Check All ACL     ${node}
+    ${data}=            OperatingSystem.Get File    ${reply_json}
+    ${data}=            Replace Variables      ${data}
+    Should Be Equal     ${data}   ${acl_d}
+    ${data}=            OperatingSystem.Get File    ${reply_term}
+    ${data}=            Replace Variables      ${data}
+    Verify API Response    ${term_d}    ${data}
 
 Put ARP
     [Arguments]    ${node}    ${interface}    ${ipv4}    ${MAC}    ${static}

--- a/tests/robot/libraries/vpp_term.py
+++ b/tests/robot/libraries/vpp_term.py
@@ -1,5 +1,7 @@
 # input - output from sh int addr
 # output - list of words containing ip/prefix
+from robot.api import logger
+
 def Find_IPV4_In_Text(text):
     ipv4 = []
     for word in text.split():
@@ -63,3 +65,42 @@ def parse_stn_rule(info):
             pass
 
     return state['ip_address'], state['iface'], state['next_node']
+
+def verify_api_response(data, response):
+    """Verify VAT terminal response against expected data.
+
+    :param data: Expected data.
+    :param response: Data in API response.
+    :type data: str
+    :type response: str
+    :raises RuntimeError: If the response does not match expected data.
+    """
+
+    data_lines = data.splitlines()
+    response_lines = response.splitlines()
+
+    # Strip API name and handler ID from the response
+    for index, line in enumerate(response_lines):
+        if line.startswith("vl_api"):
+            parts = line.split(":")
+            response_lines[index] = ":".join(parts[2:])
+
+    # Strip API name and handler ID from expected data
+    for index, line in enumerate(data_lines):
+        if line.startswith("vl_api"):
+            parts = line.split(":")
+            data_lines[index] = ":".join(parts[2:])
+
+    # Strip whitespaces
+    data_lines = [x.strip() for x in data_lines]
+    response_lines = [x.strip() for x in response_lines]
+
+    for data_line in data_lines:
+        if data_line in response_lines:
+            logger.trace("Data line '''{line}''' matched to response line.".format(line=data_line))
+        else:
+            logger.debug("full response: '''{response}'''".format(response=response_lines))
+            raise RuntimeError(
+                "Expected data line '''{line}''' not present in response."
+                    .format(line=data_line)
+            )

--- a/tests/robot/suites/crud/acl_crud.robot
+++ b/tests/robot/suites/crud/acl_crud.robot
@@ -19,7 +19,6 @@ Test Teardown     TestTeardown
 ${REPLY_DATA_FOLDER}            ${CURDIR}/replyACL
 ${VARIABLES}=       common
 ${ENV}=             common
-${api_handler}=     222
 ${ACL1_NAME}=       acl1_tcp
 ${ACL2_NAME}=       acl2_tcp
 ${ACL3_NAME}=       acl3_UDP
@@ -60,7 +59,6 @@ Configure Environment
     ${DATA_FOLDER}=       Catenate     SEPARATOR=/       ${CURDIR}         ${TEST_DATA_FOLDER}
     Set Suite Variable          ${DATA_FOLDER}
     Configure Environment 2        acl_basic.conf
-    Set Suite Variable    ${API_HANDLER}    ${api_handler}
 
 Show ACL Before Setup
     Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    Check ACL Reply    agent_vpp_1    ${ACL1_NAME}    ${REPLY_DATA_FOLDER}/reply_acl_empty.txt     ${REPLY_DATA_FOLDER}/reply_acl_empty_term.txt
@@ -163,19 +161,6 @@ Check All 6 ACLs Added
     Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    Check ACL All Reply    agent_vpp_1     ${REPLY_DATA_FOLDER}/reply_acl_all.txt        ${REPLY_DATA_FOLDER}/reply_acl_all_term.txt
 
 *** Keywords ***
-
-Check ACL All Reply
-    [Arguments]         ${node}    ${reply_json}     ${reply_term}
-    ${acl_d}=           Get All ACL As Json    ${node}
-    ${term_d}=          vat_term: Check All ACL     ${node}
-    ${term_d_lines}=    Split To Lines    ${term_d}
-    ${data}=            OperatingSystem.Get File    ${reply_json}
-    ${data}=            Replace Variables      ${data}
-    Should Be Equal     ${data}   ${acl_d}
-    ${data}=            OperatingSystem.Get File    ${reply_term}
-    ${data}=            Replace Variables      ${data}
-    ${t_data_lines}=    Split To Lines    ${data}
-    List Should Contain Sub List    ${term_d_lines}    ${t_data_lines}
 
 TestSetup
     Make Datastore Snapshots    ${TEST_NAME}_test_setup

--- a/tests/robot/suites/crud/replyACL/reply_acl1_tcp_term.txt
+++ b/tests/robot/suites/crud/replyACL/reply_acl1_tcp_term.txt
@@ -1,3 +1,3 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl1_tcp}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 6 sport 10-2000 dport 80-1000 tcpflags 10 mask 20

--- a/tests/robot/suites/crud/replyACL/reply_acl1_update_tcp_term.txt
+++ b/tests/robot/suites/crud/replyACL/reply_acl1_update_tcp_term.txt
@@ -1,6 +1,6 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl1_tcp}
    ipv4 action 2 src 10.0.0.0/32 dst 10.0.0.0/32 proto 6 sport 10-2000 dport 80-1000 tcpflags 10 mask 20
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 1, count: 1
+acl_index: 1, count: 1
    tag {acl2_tcp}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 6 sport 20010-20020 dport 2000-2200 tcpflags 10 mask 20

--- a/tests/robot/suites/crud/replyACL/reply_acl2_delete_tcp_term.txt
+++ b/tests/robot/suites/crud/replyACL/reply_acl2_delete_tcp_term.txt
@@ -1,3 +1,3 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl1_tcp}
    ipv4 action 2 src 10.0.0.0/32 dst 10.0.0.0/32 proto 6 sport 10-2000 dport 80-1000 tcpflags 10 mask 20

--- a/tests/robot/suites/crud/replyACL/reply_acl2_tcp_term.txt
+++ b/tests/robot/suites/crud/replyACL/reply_acl2_tcp_term.txt
@@ -1,6 +1,6 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl1_tcp}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 6 sport 10-2000 dport 80-1000 tcpflags 10 mask 20
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 1, count: 1
+acl_index: 1, count: 1
    tag {acl2_tcp}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 6 sport 20010-20020 dport 2000-2200 tcpflags 10 mask 20

--- a/tests/robot/suites/crud/replyACL/reply_acl3_udp_term.txt
+++ b/tests/robot/suites/crud/replyACL/reply_acl3_udp_term.txt
@@ -1,3 +1,3 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl3_UDP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0

--- a/tests/robot/suites/crud/replyACL/reply_acl4IPv6_udp_term.txt
+++ b/tests/robot/suites/crud/replyACL/reply_acl4IPv6_udp_term.txt
@@ -1,6 +1,6 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl3_UDP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 1, count: 1
+acl_index: 1, count: 1
    tag {acl4_UDP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0

--- a/tests/robot/suites/crud/replyACL/reply_acl4_udp_term.txt
+++ b/tests/robot/suites/crud/replyACL/reply_acl4_udp_term.txt
@@ -1,6 +1,6 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl3_UDP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 1, count: 1
+acl_index: 1, count: 1
    tag {acl4_UDP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0

--- a/tests/robot/suites/crud/replyACL/reply_acl5_icmp_term.txt
+++ b/tests/robot/suites/crud/replyACL/reply_acl5_icmp_term.txt
@@ -1,3 +1,3 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl5_ICMP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0

--- a/tests/robot/suites/crud/replyACL/reply_acl6_all_term.txt
+++ b/tests/robot/suites/crud/replyACL/reply_acl6_all_term.txt
@@ -1,18 +1,18 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl1_tcp}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 6 sport 10-2000 dport 80-1000 tcpflags 10 mask 20
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 1, count: 1
+acl_index: 1, count: 1
    tag {acl2_tcp}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 6 sport 20010-20020 dport 2000-2200 tcpflags 10 mask 20
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 2, count: 1
+acl_index: 2, count: 1
    tag {acl3_UDP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0 
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 3, count: 1
+acl_index: 3, count: 1
    tag {acl4_UDP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 4, count: 1
+acl_index: 4, count: 1
    tag {acl5_ICMP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 5, count: 1
+acl_index: 5, count: 1
    tag {acl6_ICMP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0

--- a/tests/robot/suites/crud/replyACL/reply_acl6_icmp_term.txt
+++ b/tests/robot/suites/crud/replyACL/reply_acl6_icmp_term.txt
@@ -1,6 +1,6 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl5_ICMP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 1, count: 1
+acl_index: 1, count: 1
    tag {acl6_ICMP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0

--- a/tests/robot/suites/crud/replyACL/reply_acl_all_term.txt
+++ b/tests/robot/suites/crud/replyACL/reply_acl_all_term.txt
@@ -1,18 +1,18 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl1_tcp}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 6 sport 10-2000 dport 80-1000 tcpflags 10 mask 20
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 1, count: 1
+acl_index: 1, count: 1
    tag {acl2_tcp}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 6 sport 20010-20020 dport 2000-2200 tcpflags 10 mask 20
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 2, count: 1
+acl_index: 2, count: 1
    tag {acl3_UDP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 3, count: 1
+acl_index: 3, count: 1
    tag {acl4_UDP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 4, count: 1
+acl_index: 4, count: 1
    tag {acl5_ICMP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 5, count: 1
+acl_index: 5, count: 1
    tag {acl6_ICMP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0

--- a/tests/robot/suites/crudIPv6/acl_crudIPv6.robot
+++ b/tests/robot/suites/crudIPv6/acl_crudIPv6.robot
@@ -19,7 +19,6 @@ Test Teardown     TestTeardown
 ${REPLY_DATA_FOLDER}            ${CURDIR}/replyACL
 ${VARIABLES}=       common
 ${ENV}=             common
-${api_handler}=     222
 ${ACL1_NAME}=       acl1_tcp
 ${ACL2_NAME}=       acl2_tcp
 ${ACL3_NAME}=       acl3_UDP
@@ -158,20 +157,6 @@ Check All 6 ACLs Added
     Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    Check ACL All Reply    agent_vpp_1     ${REPLY_DATA_FOLDER}/reply_aclIPv6_all.txt        ${REPLY_DATA_FOLDER}/reply_aclIPv6_all_term.txt
 
 *** Keywords ***
-
-Check ACL All Reply
-    [Arguments]         ${node}    ${reply_json}     ${reply_term}
-    ${acl_d}=           Get All ACL As Json    ${node}
-    ${term_d}=          vat_term: Check All ACL     ${node}
-    ${term_d_lines}=    Split To Lines    ${term_d}
-    ${data}=            OperatingSystem.Get File    ${reply_json}
-    ${data}=            Replace Variables      ${data}
-    Should Be Equal     ${data}   ${acl_d}
-    ${data}=            OperatingSystem.Get File    ${reply_term}
-    ${data}=            Replace Variables      ${data}
-    ${t_data_lines}=    Split To Lines    ${data}
-    List Should Contain Sub List    ${term_d_lines}    ${t_data_lines}
-
 
 TestSetup
     Make Datastore Snapshots    ${TEST_NAME}_test_setup

--- a/tests/robot/suites/crudIPv6/replyACL/reply_acl1IPv6_tcp_term.txt
+++ b/tests/robot/suites/crudIPv6/replyACL/reply_acl1IPv6_tcp_term.txt
@@ -1,3 +1,3 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl1_tcp}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 6 sport 10-2000 dport 80-1000 tcpflags 10 mask 20

--- a/tests/robot/suites/crudIPv6/replyACL/reply_acl1IPv6_update_tcp_term.txt
+++ b/tests/robot/suites/crudIPv6/replyACL/reply_acl1IPv6_update_tcp_term.txt
@@ -1,6 +1,6 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl1_tcp}
    ipv6 action 2 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 6 sport 10-2000 dport 80-1000 tcpflags 10 mask 20
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 1, count: 1
+acl_index: 1, count: 1
    tag {acl2_tcp}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 6 sport 20010-20020 dport 2000-2200 tcpflags 10 mask 20

--- a/tests/robot/suites/crudIPv6/replyACL/reply_acl2IPv6_delete_tcp_term.txt
+++ b/tests/robot/suites/crudIPv6/replyACL/reply_acl2IPv6_delete_tcp_term.txt
@@ -1,3 +1,3 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl1_tcp}
    ipv6 action 2 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 6 sport 10-2000 dport 80-1000 tcpflags 10 mask 20

--- a/tests/robot/suites/crudIPv6/replyACL/reply_acl2IPv6_tcp_term.txt
+++ b/tests/robot/suites/crudIPv6/replyACL/reply_acl2IPv6_tcp_term.txt
@@ -1,6 +1,6 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl1_tcp}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 6 sport 10-2000 dport 80-1000 tcpflags 10 mask 20
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 1, count: 1
+acl_index: 1, count: 1
    tag {acl2_tcp}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 6 sport 20010-20020 dport 2000-2200 tcpflags 10 mask 20

--- a/tests/robot/suites/crudIPv6/replyACL/reply_acl3IPv6_udp_term.txt
+++ b/tests/robot/suites/crudIPv6/replyACL/reply_acl3IPv6_udp_term.txt
@@ -1,3 +1,3 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl3_UDP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0

--- a/tests/robot/suites/crudIPv6/replyACL/reply_acl4IPv6_udp_term.txt
+++ b/tests/robot/suites/crudIPv6/replyACL/reply_acl4IPv6_udp_term.txt
@@ -1,6 +1,6 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl3_UDP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 1, count: 1
+acl_index: 1, count: 1
    tag {acl4_UDP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0

--- a/tests/robot/suites/crudIPv6/replyACL/reply_acl5IPv6_icmp_term.txt
+++ b/tests/robot/suites/crudIPv6/replyACL/reply_acl5IPv6_icmp_term.txt
@@ -1,3 +1,3 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl5_ICMP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0

--- a/tests/robot/suites/crudIPv6/replyACL/reply_acl6IPv6_all_term.txt
+++ b/tests/robot/suites/crudIPv6/replyACL/reply_acl6IPv6_all_term.txt
@@ -1,18 +1,18 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl1_tcp}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 6 sport 10-2000 dport 80-1000 tcpflags 10 mask 20
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 1, count: 1
+acl_index: 1, count: 1
    tag {acl2_tcp}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 6 sport 20010-20020 dport 2000-2200 tcpflags 10 mask 20
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 2, count: 1
+acl_index: 2, count: 1
    tag {acl3_UDP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 3, count: 1
+acl_index: 3, count: 1
    tag {acl4_UDP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 4, count: 1
+acl_index: 4, count: 1
    tag {acl5_ICMP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 5, count: 1
+acl_index: 5, count: 1
    tag {acl6_ICMP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0

--- a/tests/robot/suites/crudIPv6/replyACL/reply_acl6IPv6_icmp_term.txt
+++ b/tests/robot/suites/crudIPv6/replyACL/reply_acl6IPv6_icmp_term.txt
@@ -1,6 +1,6 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl5_ICMP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 1, count: 1
+acl_index: 1, count: 1
    tag {acl6_ICMP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0

--- a/tests/robot/suites/crudIPv6/replyACL/reply_aclIPv6_all_term.txt
+++ b/tests/robot/suites/crudIPv6/replyACL/reply_aclIPv6_all_term.txt
@@ -1,18 +1,18 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl1_tcp}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 6 sport 10-2000 dport 80-1000 tcpflags 10 mask 20
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 1, count: 1
+acl_index: 1, count: 1
    tag {acl2_tcp}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 6 sport 20010-20020 dport 2000-2200 tcpflags 10 mask 20
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 2, count: 1
+acl_index: 2, count: 1
    tag {acl3_UDP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 3, count: 1
+acl_index: 3, count: 1
    tag {acl4_UDP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 4, count: 1
+acl_index: 4, count: 1
    tag {acl5_ICMP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 5, count: 1
+acl_index: 5, count: 1
    tag {acl6_ICMP}
    ipv6 action 1 src fd30:0:0:1:e::/64 dst fd30:0:0:1:e::/64 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0

--- a/tests/robot/suites/crudIPv6/replyACL/reply_acl_all_term.txt
+++ b/tests/robot/suites/crudIPv6/replyACL/reply_acl_all_term.txt
@@ -1,18 +1,18 @@
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 0, count: 1
+acl_index: 0, count: 1
    tag {acl1_tcp}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 6 sport 10-2000 dport 80-1000 tcpflags 10 mask 20
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 1, count: 1
+acl_index: 1, count: 1
    tag {acl2_tcp}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 6 sport 20010-20020 dport 2000-2200 tcpflags 10 mask 20
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 2, count: 1
+acl_index: 2, count: 1
    tag {acl3_UDP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 3, count: 1
+acl_index: 3, count: 1
    tag {acl4_UDP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 4, count: 1
+acl_index: 4, count: 1
    tag {acl5_ICMP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0
-vl_api_acl_details_t_handler:${API_HANDLER}: acl_index: 5, count: 1
+acl_index: 5, count: 1
    tag {acl6_ICMP}
    ipv4 action 1 src 10.0.0.0/32 dst 10.0.0.0/32 proto 17 sport 10-2000 dport 80-1000 tcpflags 0 mask 0


### PR DESCRIPTION
- do not check API name and API handler ID in received response
- start moving low-level functionality to Python code

Signed-off-by: samuel.elias <samelias@cisco.com>