### PR TITLE
Print help with list of targets by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,37 +33,41 @@ endif
 
 COVER_DIR ?= /tmp
 
+help:
+	@echo "List of make targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sed 's/^[^:]*://g' | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
 build: cmd examples
 
 clean: clean-cmd clean-examples
 
-agent:
+agent: ## Build agent
 	@echo "=> installing agent ${VERSION}"
 	@go install -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}" ${GO_BUILD_ARGS} ./cmd/vpp-agent
 
-agentctl:
+agentctl: # Build agentctl
 	@echo "=> installing agentctl ${VERSION}"
 	@go install -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}" ${GO_BUILD_ARGS} ./cmd/agentctl
 
-install:
+install: ## Install commands
 	@echo "=> installing ${VERSION}"
 	go install -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}" ${GO_BUILD_ARGS} ./cmd/vpp-agent
 	go install -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}" ${GO_BUILD_ARGS} ./cmd/vpp-agent-init
 	go install -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}" ${GO_BUILD_ARGS} ./cmd/agentctl
 
-cmd:
+cmd: ## Build commands
 	@echo "=> building ${VERSION}"
 	cd cmd/vpp-agent && go build -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}" ${GO_BUILD_ARGS}
 	cd cmd/vpp-agent-init && go build -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}" ${GO_BUILD_ARGS}
 	cd cmd/agentctl && go build -ldflags "${LDFLAGS}" -tags="${GO_BUILD_TAGS}" ${GO_BUILD_ARGS}
 
-clean-cmd:
+clean-cmd: ## Clean commands
 	@echo "=> cleaning command binaries"
 	rm -f ./cmd/vpp-agent/vpp-agent
 	rm -f ./cmd/vpp-agent/vpp-agent-init
 	rm -f ./cmd/agentctl/agentctl
 
-examples:
+examples: ## Build examples
 	@echo "=> building examples"
 	cd examples/custom_model	    	 && go build -tags="${GO_BUILD_TAGS}" ${GO_BUILD_ARGS}
 	cd examples/govpp_call 		    	 && go build -tags="${GO_BUILD_TAGS}" ${GO_BUILD_ARGS}
@@ -82,7 +86,7 @@ examples:
 	cd examples/localclient_vpp/nat      && go build -tags="${GO_BUILD_TAGS}" ${GO_BUILD_ARGS}
 	cd examples/localclient_vpp/plugins	 && go build -tags="${GO_BUILD_TAGS}" ${GO_BUILD_ARGS}
 
-clean-examples:
+clean-examples: ## Clean examples
 	@echo "=> cleaning examples"
 	cd examples/custom_model	    		&& go clean
 	cd examples/govpp_call 		    		&& go clean
@@ -99,18 +103,18 @@ clean-examples:
 	cd examples/localclient_vpp/nat      	&& go clean
 	cd examples/localclient_vpp/plugins	 	&& go clean
 
-debug-remote:
+debug-remote: ## Debug remotely
 	cd ./cmd/vpp-agent && dlv debug --headless --listen=:2345 --api-version=2 --accept-multiclient
 
 # -------------------------------
 #  Testing
 # -------------------------------
 
-test:
+test: ## Run unit tests
 	@echo "=> running unit tests"
 	go test -tags="${GO_BUILD_TAGS}" ./...
 
-test-cover:
+test-cover: ## Run unit tests with coverage
 	@echo "=> running unit tests with coverage"
 	go test -tags="${GO_BUILD_TAGS}" -covermode=count -coverprofile=${COVER_DIR}/coverage.out ./...
 	@echo "=> coverage data generated into ${COVER_DIR}/coverage.out"
@@ -123,19 +127,19 @@ test-cover-xml: test-cover
 	gocov convert ${COVER_DIR}/coverage.out | gocov-xml > ${COVER_DIR}/coverage.xml
 	@echo "=> coverage report generated into ${COVER_DIR}/coverage.xml"
 
-perf:
+perf: ## Run quick performance test
 	@echo "=> running perf test"
 	./tests/perf/perf_test.sh grpc-perf 1000
 
-perf-all:
+perf-all: ## Run all performance tests
 	@echo "=> running all perf tests"
 	./tests/perf/run_all.sh
 
-integration-tests:
+integration-tests: ## Run integration tests
 	@echo "=> running integration tests"
 	VPP_IMG=$(VPP_IMG) ./tests/integration/vpp_integration.sh
 
-e2e-tests:
+e2e-tests: ## Run end-to-end tests
 	@echo "=> running end-to-end tests"
 	VPP_IMG=$(VPP_IMG) ./tests/e2e/run_e2e.sh
 
@@ -143,23 +147,23 @@ e2e-tests:
 #  Code generation
 # -------------------------------
 
-generate: generate-proto generate-binapi generate-desc-adapters
+generate: generate-proto generate-binapi generate-desc-adapters ## Generate all
 
 get-proto-generators:
 	@go install ./vendor/github.com/gogo/protobuf/protoc-gen-gogo
 
-generate-proto: get-proto-generators
+generate-proto: get-proto-generators ## Generate Go code for Protobuf files
 	@echo "=> generating proto"
 	./scripts/genprotos.sh
 
 get-binapi-generators:
 	@go install ./vendor/git.fd.io/govpp.git/cmd/binapi-generator
 
-generate-binapi: get-binapi-generators
+generate-binapi: get-binapi-generators ## Generate Go code for VPP binary API
 	@echo "=> generating binapi"
 	VPP_BINAPI=$(VPP_BINAPI) ./scripts/genbinapi.sh
 
-verify-binapi:
+verify-binapi: ## Verify generated VPP binary API
 	@echo "=> verifying binary api"
 	docker build -f docker/dev/Dockerfile \
 		--build-arg VPP_IMG=${VPP_IMG} \
@@ -169,7 +173,7 @@ verify-binapi:
 get-desc-adapter-generator:
 	@go install ./plugins/kvscheduler/descriptor-adapter
 
-generate-desc-adapters: get-desc-adapter-generator
+generate-desc-adapters: get-desc-adapter-generator ## Generate Go code for descriptors
 	@echo "=> generating descriptor adapters"
 	cd plugins/linux/ifplugin && go generate
 	cd plugins/linux/l3plugin && go generate
@@ -191,7 +195,7 @@ get-bindata:
 	go get -v github.com/elazarl/go-bindata-assetfs/...
 
 bindata: get-bindata
-	cd plugins/restplugin && go generate
+	go generate -x ./plugins/restplugin
 
 # -------------------------------
 #  Dependencies
@@ -209,7 +213,7 @@ dep-update: get-dep
 	@echo "=> updating all dependencies"
 	dep ensure -update
 
-dep-check: get-dep
+dep-check: get-dep ## Check Go dependencies
 	@echo "=> checking dependencies"
 	dep check
 
@@ -226,17 +230,17 @@ ifndef LINTER
 	gometalinter --install
 endif
 
-lint: get-linters
+lint: get-linters ## Lint Go code
 	@echo "=> running code analysis"
 	./scripts/static_analysis.sh golint vet
 
-format:
+format: ## Format Go code
 	@echo "=> formatting the code"
 	./scripts/gofmt.sh
 
 MDLINKCHECK := $(shell command -v markdown-link-check 2> /dev/null)
 
-get-linkcheck:
+get-linkcheck: ## Check links in Markdown files
 ifndef MDLINKCHECK
 	sudo apt-get update && sudo apt-get install -y npm
 	npm install -g markdown-link-check@3.6.2
@@ -248,7 +252,7 @@ check-links: get-linkcheck
 get-yamllint:
 	pip install --user yamllint
 
-yamllint: get-yamllint
+yamllint: get-yamllint ## Lint YAML files
 	@echo "=> linting the yaml files"
 	yamllint -c .yamllint.yml $(shell git ls-files '*.yaml' '*.yml' | grep -v 'vendor/')
 
@@ -256,44 +260,29 @@ yamllint: get-yamllint
 #  Images
 # -------------------------------
 
-images: dev-image prod-image
+images: dev-image prod-image ## Build all images
 
-dev-image:
+dev-image: ## Build developer image
 	@echo "=> building dev image"
 	IMAGE_TAG=$(IMAGE_TAG) \
 		VPP_IMG=$(VPP_IMG) VPP_BINAPI=$(VPP_BINAPI) \
 		VERSION=$(VERSION) COMMIT=$(COMMIT) DATE=$(DATE) \
 		./docker/dev/build.sh
 
-prod-image:
+prod-image: ## Build production image
 	@echo "=> building prod image"
 	IMAGE_TAG=$(IMAGE_TAG) \
     	./docker/prod/build.sh
 
-# -------------------------------
 
-travis:
-	@echo "=> TRAVIS: $$TRAVIS_BUILD_STAGE_NAME"
-	@echo "Build: #$$TRAVIS_BUILD_NUMBER ($$TRAVIS_BUILD_ID)"
-	@echo "Job: #$$TRAVIS_JOB_NUMBER ($$TRAVIS_JOB_ID)"
-	@echo "AllowFailure: $$TRAVIS_ALLOW_FAILURE TestResult: $$TRAVIS_TEST_RESULT"
-	@echo "Type: $$TRAVIS_EVENT_TYPE PullRequest: $$TRAVIS_PULL_REQUEST"
-	@echo "Repo: $$TRAVIS_REPO_SLUG Branch: $$TRAVIS_BRANCH"
-	@echo "Commit: $$TRAVIS_COMMIT"
-	@echo "$$TRAVIS_COMMIT_MESSAGE"
-	@echo "Range: $$TRAVIS_COMMIT_RANGE"
-	@echo "Files:"
-	@echo "$$(git diff --name-only $$TRAVIS_COMMIT_RANGE)"
-
-
-.PHONY: build clean \
-	install cmd examples clean-examples test \
-	test-cover test-cover-html test-cover-xml \
+.PHONY: help \
+	build clean install \
+	cmd examples clean-examples \
+	test test-cover test-cover-html test-cover-xml \
 	generate genereate-binapi generate-proto get-binapi-generators get-proto-generators \
 	get-dep dep-install dep-update dep-check \
 	get-linters lint format \
 	get-linkcheck check-links \
 	get-yamllint yamllint \
 	images dev-image prod-image \
-	perf perf-all \
-	travis
+	perf perf-all


### PR DESCRIPTION
Running `make` (without specifying any target) or `make help` will now print list of documented make targets.

```
➤ make
List of make targets:
agent                          Build agent
install                        Install commands
cmd                            Build commands
clean-cmd                      Clean commands
examples                       Build examples
clean-examples                 Clean examples
debug-remote                   Debug remotely
test                           Run unit tests
test-cover                     Run unit tests with coverage
perf                           Run quick performance test
perf-all                       Run all performance tests
integration-tests              Run integration tests
generate                       Generate all
generate-proto                 Generate Go code for Protobuf files
generate-binapi                Generate Go code for VPP binary API
verify-binapi                  Verify generated VPP binary API
generate-desc-adapters         Generate Go code for descriptors
dep-check                      Check Go dependencies
lint                           Lint Go code
format                         Format Go code
get-linkcheck                  Check links in Markdown files
yamllint                       Lint YAML files
images                         Build all images
dev-image                      Build developer image
prod-image                     Build production image
```

This is done by parsing Makefile and listing make targets that contain special comment, e.g.:

```Makefile
build: ## Builds agent
    ...
```