### PR TITLE
Fix ACL ICMP rules

### DIFF
--- a/plugins/vpp/aclplugin/vppcalls/vpp1904/acl_vppcalls.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp1904/acl_vppcalls.go
@@ -312,7 +312,7 @@ func icmpACL(icmpRule *acl.ACL_Rule_IpRule_Icmp, aclRule *aclapi.ACLRule) *aclap
 		aclRule.SrcportOrIcmptypeLast = uint16(icmpRule.IcmpTypeRange.Last)
 		// ICMPv6 code range
 		aclRule.DstportOrIcmpcodeFirst = uint16(icmpRule.IcmpCodeRange.First)
-		aclRule.DstportOrIcmpcodeLast = uint16(icmpRule.IcmpCodeRange.First)
+		aclRule.DstportOrIcmpcodeLast = uint16(icmpRule.IcmpCodeRange.Last)
 	} else {
 		aclRule.Proto = vppcalls.ICMPv4Proto // IANA ICMPv4
 		aclRule.IsIPv6 = 0

--- a/plugins/vpp/aclplugin/vppcalls/vpp1904/dump_vppcalls.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp1904/dump_vppcalls.go
@@ -628,9 +628,15 @@ func (h *ACLVppHandler) getUDPMatchRule(r acl_api.ACLRule) *acl.ACL_Rule_IpRule_
 // format into the ACL Plugin's NB format
 func (h *ACLVppHandler) getIcmpMatchRule(r acl_api.ACLRule) *acl.ACL_Rule_IpRule_Icmp {
 	icmp := &acl.ACL_Rule_IpRule_Icmp{
-		Icmpv6:        r.IsIPv6 > 0,
-		IcmpCodeRange: &acl.ACL_Rule_IpRule_Icmp_Range{},
-		IcmpTypeRange: &acl.ACL_Rule_IpRule_Icmp_Range{},
+		Icmpv6: r.IsIPv6 > 0,
+		IcmpCodeRange: &acl.ACL_Rule_IpRule_Icmp_Range{
+			First: uint32(r.DstportOrIcmpcodeFirst),
+			Last:  uint32(r.DstportOrIcmpcodeLast),
+		},
+		IcmpTypeRange: &acl.ACL_Rule_IpRule_Icmp_Range{
+			First: uint32(r.SrcportOrIcmptypeFirst),
+			Last:  uint32(r.SrcportOrIcmptypeLast),
+		},
 	}
 	return icmp
 }

--- a/plugins/vpp/aclplugin/vppcalls/vpp1908/acl_vppcalls.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp1908/acl_vppcalls.go
@@ -312,7 +312,7 @@ func icmpACL(icmpRule *acl.ACL_Rule_IpRule_Icmp, aclRule *aclapi.ACLRule) *aclap
 		aclRule.SrcportOrIcmptypeLast = uint16(icmpRule.IcmpTypeRange.Last)
 		// ICMPv6 code range
 		aclRule.DstportOrIcmpcodeFirst = uint16(icmpRule.IcmpCodeRange.First)
-		aclRule.DstportOrIcmpcodeLast = uint16(icmpRule.IcmpCodeRange.First)
+		aclRule.DstportOrIcmpcodeLast = uint16(icmpRule.IcmpCodeRange.Last)
 	} else {
 		aclRule.Proto = vppcalls.ICMPv4Proto // IANA ICMPv4
 		aclRule.IsIPv6 = 0

--- a/plugins/vpp/aclplugin/vppcalls/vpp1908/dump_vppcalls.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp1908/dump_vppcalls.go
@@ -629,8 +629,14 @@ func (h *ACLVppHandler) getUDPMatchRule(r acl_api.ACLRule) *acl.ACL_Rule_IpRule_
 func (h *ACLVppHandler) getIcmpMatchRule(r acl_api.ACLRule) *acl.ACL_Rule_IpRule_Icmp {
 	icmp := &acl.ACL_Rule_IpRule_Icmp{
 		Icmpv6:        r.IsIPv6 > 0,
-		IcmpCodeRange: &acl.ACL_Rule_IpRule_Icmp_Range{},
-		IcmpTypeRange: &acl.ACL_Rule_IpRule_Icmp_Range{},
+		IcmpCodeRange: &acl.ACL_Rule_IpRule_Icmp_Range{
+			First: uint32(r.DstportOrIcmpcodeFirst),
+			Last:  uint32(r.DstportOrIcmpcodeLast),
+		},
+		IcmpTypeRange: &acl.ACL_Rule_IpRule_Icmp_Range{
+			First: uint32(r.SrcportOrIcmptypeFirst),
+			Last:  uint32(r.SrcportOrIcmptypeLast),
+		},
 	}
 	return icmp
 }

--- a/plugins/vpp/aclplugin/vppcalls/vpp2001/acl_vppcalls.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp2001/acl_vppcalls.go
@@ -312,7 +312,7 @@ func icmpACL(icmpRule *acl.ACL_Rule_IpRule_Icmp, aclRule *vpp_acl.ACLRule) *vpp_
 		aclRule.SrcportOrIcmptypeLast = uint16(icmpRule.IcmpTypeRange.Last)
 		// ICMPv6 code range
 		aclRule.DstportOrIcmpcodeFirst = uint16(icmpRule.IcmpCodeRange.First)
-		aclRule.DstportOrIcmpcodeLast = uint16(icmpRule.IcmpCodeRange.First)
+		aclRule.DstportOrIcmpcodeLast = uint16(icmpRule.IcmpCodeRange.Last)
 	} else {
 		aclRule.Proto = vppcalls.ICMPv4Proto // IANA ICMPv4
 		aclRule.IsIPv6 = 0

--- a/plugins/vpp/aclplugin/vppcalls/vpp2001/acl_vppcalls_test.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp2001/acl_vppcalls_test.go
@@ -139,12 +139,12 @@ var aclIPrules = []*acl.ACL_Rule{
 			Icmp: &acl.ACL_Rule_IpRule_Icmp{
 				Icmpv6: false,
 				IcmpCodeRange: &acl.ACL_Rule_IpRule_Icmp_Range{
-					First: 150,
-					Last:  250,
+					First: 1,
+					Last:  2,
 				},
 				IcmpTypeRange: &acl.ACL_Rule_IpRule_Icmp_Range{
-					First: 1150,
-					Last:  1250,
+					First: 3,
+					Last:  4,
 				},
 			},
 		},
@@ -156,12 +156,12 @@ var aclIPrules = []*acl.ACL_Rule{
 			Icmp: &acl.ACL_Rule_IpRule_Icmp{
 				Icmpv6: true,
 				IcmpCodeRange: &acl.ACL_Rule_IpRule_Icmp_Range{
-					First: 150,
-					Last:  250,
+					First: 10,
+					Last:  20,
 				},
 				IcmpTypeRange: &acl.ACL_Rule_IpRule_Icmp_Range{
-					First: 1150,
-					Last:  1250,
+					First: 30,
+					Last:  40,
 				},
 			},
 		},

--- a/plugins/vpp/aclplugin/vppcalls/vpp2001/dump_vppcalls.go
+++ b/plugins/vpp/aclplugin/vppcalls/vpp2001/dump_vppcalls.go
@@ -629,8 +629,14 @@ func (h *ACLVppHandler) getUDPMatchRule(r vpp_acl.ACLRule) *acl.ACL_Rule_IpRule_
 func (h *ACLVppHandler) getIcmpMatchRule(r vpp_acl.ACLRule) *acl.ACL_Rule_IpRule_Icmp {
 	icmp := &acl.ACL_Rule_IpRule_Icmp{
 		Icmpv6:        r.IsIPv6 > 0,
-		IcmpCodeRange: &acl.ACL_Rule_IpRule_Icmp_Range{},
-		IcmpTypeRange: &acl.ACL_Rule_IpRule_Icmp_Range{},
+		IcmpCodeRange: &acl.ACL_Rule_IpRule_Icmp_Range{
+			First: uint32(r.DstportOrIcmpcodeFirst),
+			Last:  uint32(r.DstportOrIcmpcodeLast),
+		},
+		IcmpTypeRange: &acl.ACL_Rule_IpRule_Icmp_Range{
+			First: uint32(r.SrcportOrIcmptypeFirst),
+			Last:  uint32(r.SrcportOrIcmptypeLast),
+		},
 	}
 	return icmp
 }


### PR DESCRIPTION
Fixed in all supported VPP versions:
* ICMP code range 'last' filled with the correct value for IPv6 rule
* Fixed dump of ICMP code range and type range values


Signed-off-by: Vladimir Lavor <vlavor@cisco.com>