### PR TITLE
test: use relative path for copying VPP API executor to device

### DIFF
--- a/tests/robot/libraries/setup-teardown.robot
+++ b/tests/robot/libraries/setup-teardown.robot
@@ -28,7 +28,7 @@ Testsuite Setup
     Start ETCD Server
     Get Env And SW Version      docker
     Make Datastore Snapshots    startup
-    Copy File To Machine    docker    tools/vpp_api_executor.py    ${DOCKER_PAPI_FOLDER}/vpp_api_executor.py
+    Copy File To Machine    docker    ${CURDIR}/../tools/vpp_api_executor.py    ${DOCKER_PAPI_FOLDER}/vpp_api_executor.py
 
 Testsuite Teardown
     Make Datastore Snapshots    teardown


### PR DESCRIPTION
Make path independent of pybot execution directory. Use relative
path from library dir instead.

Signed-off-by: samuel.elias <samelias@cisco.com>