### PR TITLE
test: Cleanup e2e tests

### DIFF
--- a/tests/e2e/000_initial_test.go
+++ b/tests/e2e/000_initial_test.go
@@ -40,7 +40,7 @@ func TestStartStopMicroservice(t *testing.T) {
 	}
 
 	ctx.startMicroservice(msName)
-	Eventually(msState, msUpdateTimeout).Should(Equal(kvs.ValueState_OBTAINED))
+	Eventually(msState).Should(Equal(kvs.ValueState_OBTAINED))
 	ctx.stopMicroservice(msName)
-	Eventually(msState, msUpdateTimeout).Should(Equal(kvs.ValueState_NONEXISTENT))
+	Eventually(msState).Should(Equal(kvs.ValueState_NONEXISTENT))
 }

--- a/tests/e2e/020_netalloc_test.go
+++ b/tests/e2e/020_netalloc_test.go
@@ -194,9 +194,7 @@ func TestIPWithNeighGW(t *testing.T) {
 	linuxTapAddr.Gw = vppTapIP2
 
 	req = ctx.grpcClient.ChangeRequest()
-	err = req.Update(
-		vppLoopAddr, vppTapAddr, linuxTapAddr,
-	).Send(context.Background())
+	err = req.Update(vppLoopAddr, vppTapAddr, linuxTapAddr).Send(context.Background())
 	Expect(err).ToNot(HaveOccurred())
 	checkItemsAreConfigured(false, true)
 
@@ -210,9 +208,7 @@ func TestIPWithNeighGW(t *testing.T) {
 
 	// de-allocate loopback IP - the connection should not work anymore
 	req = ctx.grpcClient.ChangeRequest()
-	err = req.Delete(
-		vppLoopAddr,
-	).Send(context.Background())
+	err = req.Delete(vppLoopAddr).Send(context.Background())
 	Expect(err).ToNot(HaveOccurred())
 
 	// loopback is still created but without IP and route is pending
@@ -398,9 +394,7 @@ func TestIPWithNonLocalGW(t *testing.T) {
 	linuxTapAddr.Gw = vppTapIP2
 
 	req = ctx.grpcClient.ChangeRequest()
-	err = req.Update(
-		vppLoopAddr, vppTapAddr, linuxTapAddr,
-	).Send(context.Background())
+	err = req.Update(vppLoopAddr, vppTapAddr, linuxTapAddr).Send(context.Background())
 	Expect(err).ToNot(HaveOccurred())
 	checkItemsAreConfigured(false, true)
 
@@ -607,9 +601,7 @@ func TestVPPRoutesWithNetalloc(t *testing.T) {
 	linuxTapAddr.Gw = vppTapIP2
 
 	req = ctx.grpcClient.ChangeRequest()
-	err = req.Update(
-		linuxLoopNet1Addr, vppTapAddr, linuxTapAddr,
-	).Send(context.Background())
+	err = req.Update(linuxLoopNet1Addr, vppTapAddr, linuxTapAddr).Send(context.Background())
 	Expect(err).ToNot(HaveOccurred())
 	checkItemsAreConfigured(false, true)
 
@@ -621,9 +613,7 @@ func TestVPPRoutesWithNetalloc(t *testing.T) {
 
 	// de-allocate loopback IP in net2 - the connection to that IP should not work anymore
 	req = ctx.grpcClient.ChangeRequest()
-	err = req.Delete(
-		linuxLoopNet2Addr,
-	).Send(context.Background())
+	err = req.Delete(linuxLoopNet2Addr).Send(context.Background())
 	Expect(err).ToNot(HaveOccurred())
 
 	// loopback is still created but without IP and route is pending

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -16,6 +16,7 @@ package e2e
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -28,23 +29,24 @@ import (
 	"testing"
 	"time"
 
-	"encoding/json"
-
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/gogo/protobuf/proto"
-	"github.com/ligato/cn-infra/health/probe"
 	"github.com/mitchellh/go-ps"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
 
+	"github.com/ligato/cn-infra/logging"
+	"github.com/ligato/cn-infra/logging/logrus"
+
+	"github.com/ligato/cn-infra/health/probe"
 	"github.com/ligato/cn-infra/health/statuscheck/model/status"
 	"github.com/ligato/vpp-agent/api/genericmanager"
 	"github.com/ligato/vpp-agent/client"
 	"github.com/ligato/vpp-agent/client/remoteclient"
-	"github.com/ligato/vpp-agent/cmd/agentctl/utils"
 	"github.com/ligato/vpp-agent/pkg/models"
 	kvs "github.com/ligato/vpp-agent/plugins/kvscheduler/api"
 	nslinuxcalls "github.com/ligato/vpp-agent/plugins/linux/nsplugin/linuxcalls"
+	"github.com/ligato/vpp-agent/tests/e2e/utils"
 )
 
 var (
@@ -53,13 +55,16 @@ var (
 	vppSockAddr   = flag.String("vpp-sock-addr", "", "VPP binapi socket address")
 	agentHTTPPort = flag.Int("agent-http-port", 9191, "VPP-Agent HTTP port")
 	agentGrpcPort = flag.Int("agent-grpc-port", 9111, "VPP-Agent GRPC port")
+	debugHttp     = flag.Bool("debug-http", false, "Enable HTTP client debugging")
 
 	vppPingRegexp = regexp.MustCompile("Statistics: ([0-9]+) sent, ([0-9]+) received, ([0-9]+)% packet loss")
 )
 
 const (
-	agentInitTimeout   = time.Second * 15
-	processExitTimeout = time.Second * 3
+	agentInitTimeout     = time.Second * 15
+	processExitTimeout   = time.Second * 3
+	checkPollingInterval = time.Millisecond * 100
+	checkTimeout         = time.Second * 6
 
 	vppConf = `
 		unix {
@@ -86,7 +91,6 @@ const (
 
 func init() {
 	log.SetFlags(log.Lmicroseconds | log.Lshortfile)
-	flag.Parse()
 }
 
 type testCtx struct {
@@ -106,6 +110,9 @@ func setupE2E(t *testing.T) *testCtx {
 		t.Skip("skipping test for Travis")
 	}
 	RegisterTestingT(t)
+
+	SetDefaultEventuallyPollingInterval(checkPollingInterval)
+	SetDefaultEventuallyTimeout(checkTimeout)
 
 	// connect to the docker daemon
 	dockerClient, err := docker.NewClientFromEnv()
@@ -144,6 +151,11 @@ func setupE2E(t *testing.T) *testCtx {
 	// prepare HTTP client for access to REST API of the agent
 	httpAddr := fmt.Sprintf(":%d", *agentHTTPPort)
 	httpClient := utils.NewHTTPClient(httpAddr)
+
+	if *debugHttp {
+		httpClient.Log = logrus.NewLogger("http-client")
+		httpClient.Log.SetLevel(logging.DebugLevel)
+	}
 
 	waitUntilAgentReady(t, httpClient)
 
@@ -285,10 +297,10 @@ func (ctx *testCtx) pingFromVPPClb(destAddress string) func() error {
 	}
 }
 
-func (ctx *testCtx) testConnection(fromMs, toMs, dstAddr, listenAddr string, port uint16, udp bool) error {
+/*func (ctx *testCtx) testConnection(fromMs, toMs, dstAddr, listenAddr string, port uint16, udp bool) error {
 	// TODO (run nc client and server)
 	return nil
-}
+}*/
 
 func (ctx *testCtx) getValueState(value proto.Message) kvs.ValueState {
 	key := models.Key(value)
@@ -338,7 +350,7 @@ func waitUntilAgentReady(t *testing.T, httpClient *utils.HTTPClient) {
 	start := time.Now()
 	for {
 		select {
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(checkPollingInterval):
 			if time.Since(start) > agentInitTimeout {
 				t.Fatalf("agent failed to initialize within the timeout period of %v",
 					agentInitTimeout)
@@ -353,6 +365,7 @@ func waitUntilAgentReady(t *testing.T, httpClient *utils.HTTPClient) {
 			}
 			if agentStatus, ok := agentStatus.PluginStatus["VPPAgent"]; ok {
 				if agentStatus.State == status.OperationalState_OK {
+					t.Logf("agent ready, took %v", time.Since(start))
 					return
 				}
 			}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -55,7 +55,7 @@ var (
 	vppSockAddr   = flag.String("vpp-sock-addr", "", "VPP binapi socket address")
 	agentHTTPPort = flag.Int("agent-http-port", 9191, "VPP-Agent HTTP port")
 	agentGrpcPort = flag.Int("agent-grpc-port", 9111, "VPP-Agent GRPC port")
-	debugHttp     = flag.Bool("debug-http", false, "Enable HTTP client debugging")
+	debugHTTP     = flag.Bool("debug-http", false, "Enable HTTP client debugging")
 
 	vppPingRegexp = regexp.MustCompile("Statistics: ([0-9]+) sent, ([0-9]+) received, ([0-9]+)% packet loss")
 )
@@ -152,7 +152,7 @@ func setupE2E(t *testing.T) *testCtx {
 	httpAddr := fmt.Sprintf(":%d", *agentHTTPPort)
 	httpClient := utils.NewHTTPClient(httpAddr)
 
-	if *debugHttp {
+	if *debugHTTP {
 		httpClient.Log = logrus.NewLogger("http-client")
 		httpClient.Log.SetLevel(logging.DebugLevel)
 	}

--- a/tests/e2e/run_e2e.sh
+++ b/tests/e2e/run_e2e.sh
@@ -1,15 +1,24 @@
 #!/bin/bash
-set -eu
+set -euo pipefail
 
-# compile test
-go test -c ./tests/e2e -o ./tests/e2e/e2e.test
-go build -v -o ./tests/e2e/vpp-agent ./cmd/vpp-agent
+echo "preparing E2E test"
+set -x
 
-# start vpp image
+# compile vpp-agent
+go build -v -o ./tests/e2e/vpp-agent.test \
+  -ldflags "-X github.com/ligato/vpp-agent/vendor/github.com/ligato/cn-infra/agent.BuildVersion=TEST_E2E" \
+  ./cmd/vpp-agent
+
+# compile e2e test suite
+go test -c -o ./tests/e2e/e2e.test ./tests/e2e
+
+# start image
+# TODO: do not run docker image with pid=host,
+#  because any other vpp running now breaks tests
 cid=$(docker run -d -it \
-	-v $(pwd)/tests/e2e/e2e.test:/e2e.test:ro \
-	-v $(pwd)/tests/e2e/vpp-agent:/vpp-agent:ro \
-	-v $(pwd)/tests/e2e/grpc.conf:/etc/grpc.conf:ro \
+	-v $PWD/tests/e2e/e2e.test:/e2e.test:ro \
+	-v $PWD/tests/e2e/vpp-agent.test:/vpp-agent:ro \
+	-v $PWD/tests/e2e/grpc.conf:/etc/grpc.conf:ro \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	--label e2e.test="$*" \
 	--pid="host" \
@@ -20,18 +29,21 @@ cid=$(docker run -d -it \
 	${DOCKER_ARGS-} \
 	"$VPP_IMG" bash)
 
+set +x
 
-on_exit() {
+cleanup() {
+	echo "stopping test container"
+	set -x
 	docker stop -t 2 "$cid" >/dev/null
 	docker rm "$cid" >/dev/null
 }
 
 vppver=$(docker exec -i "$cid" dpkg-query -f '${Version}' -W vpp)
 
-trap 'on_exit' EXIT
+trap 'cleanup' EXIT
 
 echo "============================================================="
-echo -e " E2E Test - \e[1;33m${vppver}\e[0m"
+echo -e " E2E TEST - VPP \e[1;33m${vppver}\e[0m"
 echo "============================================================="
 
 # run e2e test
@@ -49,7 +61,7 @@ else
 	# dump container logs
 	logs=$(docker logs --tail 10 "$cid")
 	if [[ -n "$logs" ]]; then
-		echo >&2 -e "\e[1;30m$logs\e[0m"
+		echo >&2 -e "\e[1;30m${logs}\e[0m"
 	fi
 
 	exit $res

--- a/tests/e2e/utils/http_rest.go
+++ b/tests/e2e/utils/http_rest.go
@@ -1,0 +1,109 @@
+//  Copyright (c) 2019 Cisco and/or its affiliates.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at:
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/ligato/cn-infra/logging"
+)
+
+// HTTPClient provides client access to the HTTP server in agent.
+type HTTPClient struct {
+	addr string
+
+	httpClient *http.Client
+
+	Log logging.Logger
+}
+
+func NewHTTPClient(httpAddr string) *HTTPClient {
+	httpClient := &http.Client{}
+	return &HTTPClient{
+		addr:       httpAddr,
+		httpClient: httpClient,
+	}
+}
+
+func (c *HTTPClient) debugf(f string, a ...interface{}) {
+	if c.Log != nil {
+		c.Log.Debugf(f, a...)
+	}
+}
+
+func (c *HTTPClient) GET(path string) ([]byte, error) {
+	return c.send(http.MethodGet, path, nil)
+}
+
+func (c *HTTPClient) PUT(path string, data interface{}) ([]byte, error) {
+	return c.send(http.MethodPut, path, data)
+}
+
+func (c *HTTPClient) POST(path string, data interface{}) ([]byte, error) {
+	return c.send(http.MethodPost, path, data)
+}
+
+func (c *HTTPClient) send(method, path string, data interface{}) ([]byte, error) {
+	u, err := url.Parse("http://" + c.addr + path)
+	if err != nil {
+		return nil, err
+	}
+
+	var b []byte
+	var r io.Reader
+
+	if data != nil {
+		b, err = json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			return nil, err
+		}
+		r = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequest(method, u.String(), r)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	c.debugf("=> sending request: %s %s (%d bytes) request body:", req.Method, req.URL, req.ContentLength)
+	c.debugf("request body:%s", b)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	c.debugf("<= received response: %v (%d)", resp.Status, resp.StatusCode)
+	c.debugf("response body: %+v", resp)
+
+	if resp.StatusCode > 400 {
+		return nil, fmt.Errorf("response status: %s (%d)", resp.Status, resp.StatusCode)
+	}
+
+	msg, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return msg, nil
+}


### PR DESCRIPTION
This PR cleans up code for E2E tests.

- using `SetDefaultEventuallyPollingInterval` and `SetDefaultEventuallyTimeout` instead of setting it for each `Eventually(..)` call
- using more consistent and opionately more readable assertions:
  - `Expect(err).To(BeNil())` -> `Expect(err).ToNot(HaveOccurred())`
  - `Expect(ping(..)).To(BeNil())` -> `Expect(ping(..)).To(Succeed())`
- compiling test agent as `vpp-agent.test` so it's ignored by git and setting version to `TEST_E2E` to make it clear it's special build
- using `set -x` to display the actual commands in `run_e2e.sh` script