### PR TITLE
test: remove VAT terminal from afpacket CRUD tests

### DIFF
--- a/tests/robot/suites/crud/afpacket_crud.robot
+++ b/tests/robot/suites/crud/afpacket_crud.robot
@@ -1,12 +1,18 @@
 *** Settings ***
 Library      OperatingSystem
-#Library      RequestsLibrary
-#Library      SSHLibrary      timeout=60s
-#Library      String
 
 Resource     ../../variables/${VARIABLES}_variables.robot
 
-Resource     ../../libraries/all_libs.robot
+Resource     ../../libraries/vpp_api.robot
+Resource     ../../libraries/vpp_term.robot
+Resource     ../../libraries/docker.robot
+Resource     ../../libraries/setup-teardown.robot
+Resource     ../../libraries/configurations.robot
+Resource     ../../libraries/etcdctl.robot
+Resource     ../../libraries/linux.robot
+
+Resource     ../../libraries/interface/afpacket.robot
+Resource     ../../libraries/interface/interface_generic.robot
 
 Force Tags        crud     IPv4
 Suite Setup       Testsuite Setup
@@ -24,8 +30,12 @@ ${VETH4_MAC}=          4a:00:00:44:44:44
 ${AFP1_MAC}=           a2:01:01:01:01:01
 ${AFP2_MAC}=           a2:02:02:02:02:02
 ${AFP2_SEC_MAC}=       a2:22:22:22:22:22
-${WAIT_TIMEOUT}=     20s
-${SYNC_SLEEP}=       3s
+${IP_ADR}=             10.10.1.1
+${IP_ADR_MASK}=        10.10.1.1/24
+${IP_ADR2}=            20.20.1.1
+${IP_ADR_MASK2}=       20.20.1.1/24
+${WAIT_TIMEOUT}=       20s
+${SYNC_SLEEP}=         3s
 
 *** Test Cases ***
 Configure Environment
@@ -36,33 +46,47 @@ Show Interfaces Before Setup
     vpp_term: Show Interfaces    agent_vpp_1
 
 Add Veth1 And Veth2 Interfaces
-    Put Veth Interface With IP    node=agent_vpp_1    name=vpp1_veth1    mac=${VETH1_MAC}    peer=vpp1_veth2    ip=10.10.1.1    prefix=24    mtu=1500
-    Put Veth Interface    node=agent_vpp_1    name=vpp1_veth2    mac=${VETH2_MAC}    peer=vpp1_veth1
+    Put Veth Interface With IP    node=agent_vpp_1
+    ...    name=vpp1_veth1    mac=${VETH1_MAC}    peer=vpp1_veth2
+    ...    ip=${IP_ADR}    prefix=24    mtu=1500
+    Put Veth Interface    node=agent_vpp_1
+    ...    name=vpp1_veth2    mac=${VETH2_MAC}    peer=vpp1_veth1
 
 Add Afpacket1 Interface
     vpp_term: Interface Not Exists    node=agent_vpp_1    mac=${AFP1_MAC}
-    Put Afpacket Interface    node=agent_vpp_1    name=vpp1_afpacket1    mac=${AFP1_MAC}    host_int=vpp1_veth2
+    Put Afpacket Interface    node=agent_vpp_1
+    ...    name=vpp1_afpacket1    mac=${AFP1_MAC}    host_int=vpp1_veth2
 
 Check That Afpacket1 Interface Is Created
     vpp_term: Interface Is Created    node=agent_vpp_1    mac=${AFP1_MAC}
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    vat_term: Check Afpacket Interface State    agent_vpp_1    vpp1_afpacket1    enabled=1    mac=${AFP1_MAC}
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    vpp_api: Check Afpacket Interface State    agent_vpp_1
+    ...    vpp1_afpacket1    enabled=1    mac=${AFP1_MAC}
 
 Check That Veth1 And Veth2 Interfaces Are Created And Not Affected By Afpacket1 Interface
     linux: Interface Is Created    node=agent_vpp_1    mac=${VETH1_MAC}
     linux: Interface Is Created    node=agent_vpp_1    mac=${VETH2_MAC}
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth1    mac=${VETH1_MAC}    ipv4=10.10.1.1/24    mtu=1500    state=up
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth2    mac=${VETH2_MAC}    state=up
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth1    mac=${VETH1_MAC}
+    ...    ipv4=${IP_ADR_MASK}    mtu=1500    state=up
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth2    mac=${VETH2_MAC}    state=up
 
 Add Afpacket2 Interface Before Veth3 And Veth4 Interfaces
     vpp_term: Interface Not Exists    node=agent_vpp_1    mac=${AFP2_MAC}
-    Put Afpacket Interface    node=agent_vpp_1    name=vpp1_afpacket2    mac=${AFP2_MAC}    host_int=vpp1_veth3
+    Put Afpacket Interface    node=agent_vpp_1
+    ...    name=vpp1_afpacket2    mac=${AFP2_MAC}    host_int=vpp1_veth3
 
 Check That Afpacket2 Interface Is Not Created Without Veth3 And Veth4
     vpp_term: Interface Not Exists    node=agent_vpp_1    mac=${AFP2_MAC}
 
 Add Veth3 Interface
     linux: Interface Not Exists    node=agent_vpp_1    mac=${VETH3_MAC}
-    Put Veth Interface With IP    node=agent_vpp_1    name=vpp1_veth3    mac=${VETH3_MAC}    peer=vpp1_veth4    ip=20.20.1.1    prefix=24    mtu=1500
+    Put Veth Interface With IP    node=agent_vpp_1
+    ...    name=vpp1_veth3    mac=${VETH3_MAC}    peer=vpp1_veth4
+    ...    ip=${IP_ADR2}    prefix=24    mtu=1500
     linux: Interface Not Exists    node=agent_vpp_1    mac=${VETH3_MAC}
 
 Check That Afpacket2 Is Not Created Without Veth4
@@ -70,44 +94,69 @@ Check That Afpacket2 Is Not Created Without Veth4
 
 Add Veth4 Interface
     linux: Interface Not Exists    node=agent_vpp_1    mac=${VETH4_MAC}
-    Put Veth Interface    node=agent_vpp_1    name=vpp1_veth4    mac=${VETH4_MAC}    peer=vpp1_veth3    enabled=true
+    Put Veth Interface    node=agent_vpp_1
+    ...    name=vpp1_veth4    mac=${VETH4_MAC}    peer=vpp1_veth3    enabled=true
 
 Check That Afpacket2 Interface Is Created
     vpp_term: Interface Is Created    node=agent_vpp_1    mac=${AFP2_MAC}
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    vat_term: Check Afpacket Interface State    agent_vpp_1    vpp1_afpacket2    enabled=1    mac=${AFP2_MAC}
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    vpp_api: Check Afpacket Interface State    agent_vpp_1
+    ...    vpp1_afpacket2    enabled=1    mac=${AFP2_MAC}
 
 Check That Veth3 And Veth4 Interfaces Are Created And Not Affected By Afpacket2 Interface
     linux: Interface Is Created    node=agent_vpp_1    mac=${VETH3_MAC}
     linux: Interface Is Created    node=agent_vpp_1    mac=${VETH4_MAC}
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth3    mac=${VETH3_MAC}    ipv4=20.20.1.1/24    mtu=1500    state=up
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth4    mac=${VETH4_MAC}    state=up
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth3    mac=${VETH3_MAC}
+    ...    ipv4=${IP_ADR_MASK2}    mtu=1500    state=up
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth4    mac=${VETH4_MAC}    state=up
 
 Check That Afpacket1 Interface Is Still Configured
-    vat_term: Check Afpacket Interface State    agent_vpp_1    vpp1_afpacket1    enabled=1    mac=${AFP1_MAC}
+    vpp_api: Check Afpacket Interface State    agent_vpp_1
+    ...    vpp1_afpacket1    enabled=1    mac=${AFP1_MAC}
 
 Update Afpacket2 Interface
-    Put Afpacket Interface    node=agent_vpp_1    name=vpp1_afpacket2    mac=${AFP2_SEC_MAC}    host_int=vpp1_veth4
+    Put Afpacket Interface    node=agent_vpp_1
+    ...    name=vpp1_afpacket2    mac=${AFP2_SEC_MAC}    host_int=vpp1_veth4
     vpp_term: Interface Is Deleted    node=agent_vpp_1    mac=${AFP2_MAC}
     vpp_term: Interface Is Created    node=agent_vpp_1    mac=${AFP2_SEC_MAC}
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    vat_term: Check Afpacket Interface State    agent_vpp_1    vpp1_afpacket2    enabled=1    mac=${AFP2_SEC_MAC}
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    vpp_api: Check Afpacket Interface State    agent_vpp_1
+    ...    vpp1_afpacket2    enabled=1    mac=${AFP2_SEC_MAC}
 
 Check That Afpacket1 Interface Is Still Configured After Update
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    vat_term: Check Afpacket Interface State    agent_vpp_1    vpp1_afpacket1    enabled=1    mac=${AFP1_MAC}
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    vpp_api: Check Afpacket Interface State    agent_vpp_1
+    ...    vpp1_afpacket1    enabled=1    mac=${AFP1_MAC}
 
 Check That Veth3 And Veth4 Interfaces Are Not Affected By Change Of Afpacket2 Interface
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth3    mac=${VETH3_MAC}    ipv4=20.20.1.1/24    mtu=1500    state=up
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth4    mac=${VETH4_MAC}    state=up
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth3    mac=${VETH3_MAC}
+    ...    ipv4=${IP_ADR_MASK2}    mtu=1500    state=up
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth4    mac=${VETH4_MAC}    state=up
 
 Delete Afpacket1 Interface
     Delete VPP Interface    node=agent_vpp_1    name=vpp1_afpacket1
     vpp_term: Interface Is Deleted    node=agent_vpp_1    mac=${AFP1_MAC}
 
 Check That Afpacket2 Interface Is Still Configured
-    vat_term: Check Afpacket Interface State    agent_vpp_1    vpp1_afpacket2    enabled=1    mac=${AFP2_SEC_MAC}
+    vpp_api: Check Afpacket Interface State    agent_vpp_1
+    ...    vpp1_afpacket2    enabled=1    mac=${AFP2_SEC_MAC}
 
 Check That Veth1 And Veth2 Interfaces Are Not Affected By Delete Of Afpacket1 Interface
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth1    mac=${VETH1_MAC}    ipv4=10.10.1.1/24    mtu=1500    state=up
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth2    mac=${VETH2_MAC}    state=up
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth1    mac=${VETH1_MAC}
+    ...    ipv4=${IP_ADR_MASK}    mtu=1500    state=up
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth2    mac=${VETH2_MAC}    state=up
 
 Delete Veth3 Interface
     Delete Linux Interface    node=agent_vpp_1    name=vpp1_veth3
@@ -132,8 +181,8 @@ Show Interfaces And Other Objects After Setup
     Write To Machine    agent_vpp_2_term    show vxlan tunnel
     Write To Machine    agent_vpp_1_term    show err
     Write To Machine    agent_vpp_2_term    show err
-    vat_term: Interfaces Dump    agent_vpp_1
-    vat_term: Interfaces Dump    agent_vpp_2
+    vpp_api: Interfaces Dump    agent_vpp_1
+    vpp_api: Interfaces Dump    agent_vpp_2
     Execute In Container    agent_vpp_1    ip a
     Execute In Container    agent_vpp_2    ip a
 

--- a/tests/robot/suites/crudIPv6/afpacket_crudIPv6.robot
+++ b/tests/robot/suites/crudIPv6/afpacket_crudIPv6.robot
@@ -1,14 +1,20 @@
 *** Settings ***
 Library      OperatingSystem
-#Library      RequestsLibrary
-#Library      SSHLibrary      timeout=60s
-#Library      String
 
 Resource     ../../variables/${VARIABLES}_variables.robot
 
-Resource     ../../libraries/all_libs.robot
+Resource     ../../libraries/vpp_api.robot
+Resource     ../../libraries/vpp_term.robot
+Resource     ../../libraries/docker.robot
+Resource     ../../libraries/setup-teardown.robot
+Resource     ../../libraries/configurations.robot
+Resource     ../../libraries/etcdctl.robot
+Resource     ../../libraries/linux.robot
 
-Force Tags        crud     IPv6    ExpectedFailure
+Resource     ../../libraries/interface/afpacket.robot
+Resource     ../../libraries/interface/interface_generic.robot
+
+Force Tags        crud     IPv6
 Suite Setup       Testsuite Setup
 Suite Teardown    Testsuite Teardown
 Test Setup        TestSetup
@@ -26,10 +32,10 @@ ${AFP2_MAC}=           a2:02:02:02:02:02
 ${AFP2_SEC_MAC}=       a2:22:22:22:22:22
 ${IP_ADR}=             fd30:0:0:1:e::
 ${IP_ADR_MASK}=        fd30:0:0:1:e::/64
-${IP_ADR2}=             fd30:0:0:2:f::
-${IP_ADR_MASK2}=        fd30:0:0:2:f::/64
-${WAIT_TIMEOUT}=     20s
-${SYNC_SLEEP}=       3s
+${IP_ADR2}=            fd30:0:0:2:f::
+${IP_ADR_MASK2}=       fd30:0:0:2:f::/64
+${WAIT_TIMEOUT}=       20s
+${SYNC_SLEEP}=         3s
 
 *** Test Cases ***
 Configure Environment
@@ -40,85 +46,122 @@ Show Interfaces Before Setup
     vpp_term: Show Interfaces    agent_vpp_1
 
 Add Veth1 And Veth2 Interfaces
-    Put Veth Interface With IP    node=agent_vpp_1    name=vpp1_veth1    mac=${VETH1_MAC}    peer=vpp1_veth2    ip=${IP_ADR}    prefix=64    mtu=1500
-    Put Veth Interface    node=agent_vpp_1    name=vpp1_veth2    mac=${VETH2_MAC}    peer=vpp1_veth1
-    vpp_term: Show Interfaces    agent_vpp_1
+    Put Veth Interface With IP    node=agent_vpp_1
+    ...    name=vpp1_veth1    mac=${VETH1_MAC}    peer=vpp1_veth2
+    ...    ip=${IP_ADR}    prefix=64    mtu=1500
+    Put Veth Interface    node=agent_vpp_1
+    ...    name=vpp1_veth2    mac=${VETH2_MAC}    peer=vpp1_veth1
 
 Add Afpacket1 Interface
     vpp_term: Interface Not Exists    node=agent_vpp_1    mac=${AFP1_MAC}
-    Put Afpacket Interface    node=agent_vpp_1    name=vpp1_afpacket1    mac=${AFP1_MAC}    host_int=vpp1_veth2
-    vpp_term: Show Interfaces    agent_vpp_1
+    Put Afpacket Interface    node=agent_vpp_1
+    ...    name=vpp1_afpacket1    mac=${AFP1_MAC}    host_int=vpp1_veth2
 
 Check That Afpacket1 Interface Is Created
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    vpp_term: Interface Is Created    node=agent_vpp_1    mac=${AFP1_MAC}
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    vat_term: Check Afpacket Interface State    agent_vpp_1    vpp1_afpacket1    enabled=1    mac=${AFP1_MAC}
+    vpp_term: Interface Is Created    node=agent_vpp_1    mac=${AFP1_MAC}
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    vpp_api: Check Afpacket Interface State    agent_vpp_1
+    ...    vpp1_afpacket1    enabled=1    mac=${AFP1_MAC}
 
 Check That Veth1 And Veth2 Interfaces Are Created And Not Affected By Afpacket1 Interface
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Interface Is Created    node=agent_vpp_1    mac=${VETH1_MAC}
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Interface Is Created    node=agent_vpp_1    mac=${VETH2_MAC}
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth1    mac=${VETH1_MAC}    ipv6=${IP_ADR_MASK}    mtu=1500    state=up
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth2    mac=${VETH2_MAC}    state=up
+    linux: Interface Is Created    node=agent_vpp_1    mac=${VETH1_MAC}
+    linux: Interface Is Created    node=agent_vpp_1    mac=${VETH2_MAC}
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth1    mac=${VETH1_MAC}
+    ...    ipv6=${IP_ADR_MASK}    mtu=1500    state=up
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth2    mac=${VETH2_MAC}    state=up
 
 Add Afpacket2 Interface Before Veth3 And Veth4 Interfaces
     vpp_term: Interface Not Exists    node=agent_vpp_1    mac=${AFP2_MAC}
-    Put Afpacket Interface    node=agent_vpp_1    name=vpp1_afpacket2    mac=${AFP2_MAC}    host_int=vpp1_veth3
+    Put Afpacket Interface    node=agent_vpp_1
+    ...    name=vpp1_afpacket2    mac=${AFP2_MAC}    host_int=vpp1_veth3
 
 Check That Afpacket2 Interface Is Not Created Without Veth3 And Veth4
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    vpp_term: Interface Not Exists    node=agent_vpp_1    mac=${AFP2_MAC}
+    vpp_term: Interface Not Exists    node=agent_vpp_1    mac=${AFP2_MAC}
 
 Add Veth3 Interface
     linux: Interface Not Exists    node=agent_vpp_1    mac=${VETH3_MAC}
-    Put Veth Interface With IP    node=agent_vpp_1    name=vpp1_veth3    mac=${VETH3_MAC}    peer=vpp1_veth4    ip=${IP_ADR2}    prefix=64    mtu=1500
+    Put Veth Interface With IP    node=agent_vpp_1
+    ...    name=vpp1_veth3    mac=${VETH3_MAC}    peer=vpp1_veth4
+    ...    ip=${IP_ADR2}    prefix=64    mtu=1500
     linux: Interface Not Exists    node=agent_vpp_1    mac=${VETH3_MAC}
 
 Check That Afpacket2 Is Not Created Without Veth4
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    vpp_term: Interface Not Exists    node=agent_vpp_1    mac=${AFP2_MAC}
+    vpp_term: Interface Not Exists    node=agent_vpp_1    mac=${AFP2_MAC}
 
 Add Veth4 Interface
     linux: Interface Not Exists    node=agent_vpp_1    mac=${VETH4_MAC}
-    Put Veth Interface    node=agent_vpp_1    name=vpp1_veth4    mac=${VETH4_MAC}    peer=vpp1_veth3    enabled=false
+    Put Veth Interface    node=agent_vpp_1
+    ...    name=vpp1_veth4    mac=${VETH4_MAC}    peer=vpp1_veth3    enabled=true
 
 Check That Afpacket2 Interface Is Created
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    vpp_term: Interface Is Created    node=agent_vpp_1    mac=${AFP2_MAC}
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    vat_term: Check Afpacket Interface State    agent_vpp_1    vpp1_afpacket2    enabled=1    mac=${AFP2_MAC}
+    vpp_term: Interface Is Created    node=agent_vpp_1    mac=${AFP2_MAC}
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    vpp_api: Check Afpacket Interface State    agent_vpp_1
+    ...    vpp1_afpacket2    enabled=1    mac=${AFP2_MAC}
 
 Check That Veth3 And Veth4 Interfaces Are Created And Not Affected By Afpacket2 Interface
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Interface Is Created    node=agent_vpp_1    mac=${VETH3_MAC}
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Interface Is Created    node=agent_vpp_1    mac=${VETH4_MAC}
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth3    mac=${VETH3_MAC}    ipv6=${IP_ADR_MASK2}    mtu=1500    state=lowerlayerdown
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth4    mac=${VETH4_MAC}    state=down
+    linux: Interface Is Created    node=agent_vpp_1    mac=${VETH3_MAC}
+    linux: Interface Is Created    node=agent_vpp_1    mac=${VETH4_MAC}
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth3    mac=${VETH3_MAC}
+    ...    ipv6=${IP_ADR_MASK2}    mtu=1500    state=up
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth4    mac=${VETH4_MAC}    state=up
 
 Check That Afpacket1 Interface Is Still Configured
-    vat_term: Check Afpacket Interface State    agent_vpp_1    vpp1_afpacket1    enabled=1    mac=${AFP1_MAC}
+    vpp_api: Check Afpacket Interface State    agent_vpp_1
+    ...    vpp1_afpacket1    enabled=1    mac=${AFP1_MAC}
 
 Update Afpacket2 Interface
-    Put Afpacket Interface    node=agent_vpp_1    name=vpp1_afpacket2    mac=${AFP2_SEC_MAC}    host_int=vpp1_veth4
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    vpp_term: Interface Is Deleted    node=agent_vpp_1    mac=${AFP2_MAC}
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    vpp_term: Interface Is Created    node=agent_vpp_1    mac=${AFP2_SEC_MAC}
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    vat_term: Check Afpacket Interface State    agent_vpp_1    vpp1_afpacket2    enabled=1    mac=${AFP2_SEC_MAC}
+    Put Afpacket Interface    node=agent_vpp_1
+    ...    name=vpp1_afpacket2    mac=${AFP2_SEC_MAC}    host_int=vpp1_veth4
+    vpp_term: Interface Is Deleted    node=agent_vpp_1    mac=${AFP2_MAC}
+    vpp_term: Interface Is Created    node=agent_vpp_1    mac=${AFP2_SEC_MAC}
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    vpp_api: Check Afpacket Interface State    agent_vpp_1
+    ...    vpp1_afpacket2    enabled=1    mac=${AFP2_SEC_MAC}
 
 Check That Afpacket1 Interface Is Still Configured After Update
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    vat_term: Check Afpacket Interface State    agent_vpp_1    vpp1_afpacket1    enabled=1    mac=${AFP1_MAC}
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    vpp_api: Check Afpacket Interface State    agent_vpp_1
+    ...    vpp1_afpacket1    enabled=1    mac=${AFP1_MAC}
 
 Check That Veth3 And Veth4 Interfaces Are Not Affected By Change Of Afpacket2 Interface
-    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth3    mac=${VETH3_MAC}    ipv6=${IP_ADR_MASK2}    mtu=1500    state=lowerlayerdown
-    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth4    mac=${VETH4_MAC}    state=down
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth3    mac=${VETH3_MAC}
+    ...    ipv6=${IP_ADR_MASK2}    mtu=1500    state=up
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth4    mac=${VETH4_MAC}    state=up
 
 Delete Afpacket1 Interface
     Delete VPP Interface    node=agent_vpp_1    name=vpp1_afpacket1
     vpp_term: Interface Is Deleted    node=agent_vpp_1    mac=${AFP1_MAC}
 
 Check That Afpacket2 Interface Is Still Configured
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    vat_term: Check Afpacket Interface State    agent_vpp_1    vpp1_afpacket2    enabled=1    mac=${AFP2_SEC_MAC}
+    vpp_api: Check Afpacket Interface State    agent_vpp_1
+    ...    vpp1_afpacket2    enabled=1    mac=${AFP2_SEC_MAC}
 
 Check That Veth1 And Veth2 Interfaces Are Not Affected By Delete Of Afpacket1 Interface
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth1    mac=${VETH1_MAC}    ipv4=${IP_ADR_MASK}    mtu=1500    state=up
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Check Veth Interface State     agent_vpp_1    vpp1_veth2    mac=${VETH2_MAC}    state=up
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth1    mac=${VETH1_MAC}
+    ...    ipv6=${IP_ADR_MASK}    mtu=1500    state=up
+    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}
+    ...    linux: Check Veth Interface State     agent_vpp_1
+    ...    vpp1_veth2    mac=${VETH2_MAC}    state=up
 
 Delete Veth3 Interface
     Delete Linux Interface    node=agent_vpp_1    name=vpp1_veth3
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Interface Is Deleted    node=agent_vpp_1    mac=${VETH3_MAC}
-    Wait Until Keyword Succeeds   ${WAIT_TIMEOUT}   ${SYNC_SLEEP}    linux: Interface Is Deleted    node=agent_vpp_1    mac=${VETH4_MAC}
+    linux: Interface Is Deleted    node=agent_vpp_1    mac=${VETH3_MAC}
+    linux: Interface Is Deleted    node=agent_vpp_1    mac=${VETH4_MAC}
 
 Check That Afpacket2 Interface Is Deleted After Deleting Veth3 And Veth4
     vpp_term: Interface Is Deleted    node=agent_vpp_1    mac=${AFP2_SEC_MAC}
@@ -138,8 +181,8 @@ Show Interfaces And Other Objects After Setup
     Write To Machine    agent_vpp_2_term    show vxlan tunnel
     Write To Machine    agent_vpp_1_term    show err
     Write To Machine    agent_vpp_2_term    show err
-    vat_term: Interfaces Dump    agent_vpp_1
-    vat_term: Interfaces Dump    agent_vpp_2
+    vpp_api: Interfaces Dump    agent_vpp_1
+    vpp_api: Interfaces Dump    agent_vpp_2
     Execute In Container    agent_vpp_1    ip a
     Execute In Container    agent_vpp_2    ip a
 

--- a/tests/robot/tools/vpp_api_executor.py
+++ b/tests/robot/tools/vpp_api_executor.py
@@ -76,8 +76,11 @@ def _convert_reply(api_r):
                 except ipaddress.AddressValueError:
                     # maybe it's not an IP address after all
                     pass
+            elif len(val) in (6, 8):
+                # Probably a padded MAC address(8) or "Dmac, Smac, etc."??(6)
+                return val.hex()
 
-            # strip null byte padding from some fields, such as acl_dump "tag"
+            # strip null byte padding from some fields, such as tag or name
             while val.endswith(b"\x00"):
                 val = val[:-1]
             return str(val, "ascii")
@@ -92,7 +95,7 @@ def _convert_reply(api_r):
                 return item_dict
             else:
                 # just a simple string
-                return binascii.hexlify(str(val))
+                return str(val)
         # Next handles parameters not supporting preferred integer or string
         # representation to get it logged
         elif hasattr(val, '__repr__'):


### PR DESCRIPTION
 - implement interfaces dump using VPP python API
 - rework afpacket crud tests to use VPP python API instead
 - fix and re-enable afpacket CRUD IPv6

Signed-off-by: samuel.elias <samelias@cisco.com>