### PR TITLE
fix: Wait for interfaces after microservice restart in the bridge domain E2E tests

### DIFF
--- a/tests/e2e/040_bridge_domain_test.go
+++ b/tests/e2e/040_bridge_domain_test.go
@@ -232,7 +232,9 @@ func TestBridgeDomainWithTAPs(t *testing.T) {
 	Expect(ctx.getValueState(linuxTap1)).To(Equal(kvs.ValueState_CONFIGURED),
 		"Linux-TAP attached to a re-started microservice1 is not configured")
 
-	Expect(ctx.pingFromMs(ms2Name, linuxTap1IP)).To(Succeed())
+	// Waiting for TAP interface after restart
+	// See: https://github.com/ligato/vpp-agent/issues/1489
+	Eventually(ctx.pingFromMsClb(ms2Name, linuxTap1IP), "18s", "2s").Should(Succeed())
 	Expect(ctx.pingFromMs(ms1Name, linuxTap2IP)).To(Succeed())
 	Expect(ctx.pingFromMs(ms1Name, vppLoopbackIP)).To(Succeed())
 	Expect(ctx.pingFromMs(ms2Name, vppLoopbackIP)).To(Succeed())
@@ -471,18 +473,9 @@ func TestBridgeDomainWithAfPackets(t *testing.T) {
 	Expect(ctx.getValueState(veth1b)).To(Equal(kvs.ValueState_CONFIGURED),
 		"VETH attached to re-started microservice1 is not configured")
 
-	// After restart of the microservice`ms1Name`,
-	// AF-PACKET interface needs more time for
-	// recreation. Giving at most three ping
-	// attempts and one more which will be tested.
-	//
+	// Waiting for AF-PACKET interface after restart
 	// See: https://github.com/ligato/vpp-agent/issues/1489
-	for attempts := 0; attempts < 3; attempts++ {
-		if err := ctx.pingFromMs(ms2Name, veth1IP); err == nil {
-			break
-		}
-	}
-	Expect(ctx.pingFromMs(ms2Name, veth1IP)).To(Succeed())
+	Eventually(ctx.pingFromMsClb(ms2Name, veth1IP), "18s", "2s").Should(Succeed())
 	Expect(ctx.pingFromMs(ms1Name, veth2IP)).To(Succeed())
 	Expect(ctx.pingFromMs(ms1Name, vppLoopbackIP)).To(Succeed())
 	Expect(ctx.pingFromMs(ms2Name, vppLoopbackIP)).To(Succeed())


### PR DESCRIPTION
Issue: #1489 

Wait a little bit longer for recreation of af-packet interface
**EDIT**: and for TAP interface too