### PR TITLE
feat: GRPC retrieve for linux plugins

### DIFF
--- a/plugins/configurator/options.go
+++ b/plugins/configurator/options.go
@@ -16,7 +16,10 @@ package configurator
 
 import (
 	"github.com/ligato/cn-infra/rpc/grpc"
+	"github.com/ligato/cn-infra/servicelabel"
 	"go.ligato.io/vpp-agent/v2/plugins/govppmux"
+	linuxifplugin "go.ligato.io/vpp-agent/v2/plugins/linux/ifplugin"
+	"go.ligato.io/vpp-agent/v2/plugins/linux/nsplugin"
 	"go.ligato.io/vpp-agent/v2/plugins/netalloc"
 	"go.ligato.io/vpp-agent/v2/plugins/orchestrator"
 	"go.ligato.io/vpp-agent/v2/plugins/vpp/aclplugin"
@@ -36,11 +39,14 @@ func NewPlugin(opts ...Option) *Plugin {
 	p.GRPCServer = &grpc.DefaultPlugin
 	p.Dispatch = &orchestrator.DefaultPlugin
 	p.GoVppmux = &govppmux.DefaultPlugin
+	p.ServiceLabel = &servicelabel.DefaultPlugin
 	p.AddrAlloc = &netalloc.DefaultPlugin
 	p.VPPACLPlugin = &aclplugin.DefaultPlugin
 	p.VPPIfPlugin = &ifplugin.DefaultPlugin
 	p.VPPL2Plugin = &l2plugin.DefaultPlugin
 	p.VPPL3Plugin = &l3plugin.DefaultPlugin
+	p.LinuxIfPlugin = &linuxifplugin.DefaultPlugin
+	p.NsPlugin = &nsplugin.DefaultPlugin
 
 	for _, o := range opts {
 		o(p)

--- a/plugins/configurator/plugin.go
+++ b/plugins/configurator/plugin.go
@@ -168,7 +168,7 @@ func (p *Plugin) initHandlers() (err error) {
 	// Linux handlers
 	p.configurator.linuxIfHandler = iflinuxcalls.NewNetLinkHandler(p.NsPlugin, linuxIfIndexes,
 		p.ServiceLabel.GetAgentPrefix(), defaultGoRoutineCount, p.Log)
-	p.configurator.linuxL3Handler = l3linuxcalls.NewNetLinkHandler()
+	p.configurator.linuxL3Handler = l3linuxcalls.NewNetLinkHandler(p.NsPlugin, linuxIfIndexes, defaultGoRoutineCount, p.Log)
 
 	return nil
 }

--- a/plugins/configurator/plugin.go
+++ b/plugins/configurator/plugin.go
@@ -19,11 +19,14 @@ import (
 
 	"github.com/ligato/cn-infra/infra"
 	"github.com/ligato/cn-infra/rpc/grpc"
+	"github.com/ligato/cn-infra/servicelabel"
 	"github.com/ligato/cn-infra/utils/safeclose"
 
 	"go.ligato.io/vpp-agent/v2/plugins/govppmux"
+	iflinuxplugin "go.ligato.io/vpp-agent/v2/plugins/linux/ifplugin"
 	iflinuxcalls "go.ligato.io/vpp-agent/v2/plugins/linux/ifplugin/linuxcalls"
 	l3linuxcalls "go.ligato.io/vpp-agent/v2/plugins/linux/l3plugin/linuxcalls"
+	"go.ligato.io/vpp-agent/v2/plugins/linux/nsplugin"
 	"go.ligato.io/vpp-agent/v2/plugins/netalloc"
 	"go.ligato.io/vpp-agent/v2/plugins/orchestrator"
 	abfvppcalls "go.ligato.io/vpp-agent/v2/plugins/vpp/abfplugin/vppcalls"
@@ -42,6 +45,9 @@ import (
 	"go.ligato.io/vpp-agent/v2/proto/ligato/vpp"
 )
 
+// Default Go routine count for linux configuration retrieval
+const defaultGoRoutineCount = 10
+
 // Plugin registers VPP GRPC services in *grpc.Server.
 type Plugin struct {
 	Deps
@@ -55,14 +61,17 @@ type Plugin struct {
 // Deps - dependencies of Plugin
 type Deps struct {
 	infra.PluginDeps
-	GRPCServer   grpc.Server
-	Dispatch     orchestrator.Dispatcher
-	GoVppmux     govppmux.StatsAPI
-	AddrAlloc    netalloc.AddressAllocator
-	VPPACLPlugin aclplugin.API
-	VPPIfPlugin  ifplugin.API
-	VPPL2Plugin  *l2plugin.L2Plugin
-	VPPL3Plugin  l3plugin.API
+	GRPCServer    grpc.Server
+	Dispatch      orchestrator.Dispatcher
+	GoVppmux      govppmux.StatsAPI
+	ServiceLabel  servicelabel.ReaderAPI
+	AddrAlloc     netalloc.AddressAllocator
+	VPPACLPlugin  aclplugin.API
+	VPPIfPlugin   ifplugin.API
+	VPPL2Plugin   *l2plugin.L2Plugin
+	VPPL3Plugin   l3plugin.API
+	LinuxIfPlugin iflinuxplugin.API
+	NsPlugin      nsplugin.API
 }
 
 // Init sets plugin child loggers
@@ -115,6 +124,9 @@ func (p *Plugin) initHandlers() (err error) {
 	aclIndexes := p.VPPACLPlugin.GetACLIndex() // TODO: make ACL optional
 	vrfIndexes := p.VPPL3Plugin.GetVRFIndex()
 
+	// Linux Indexes
+	linuxIfIndexes := p.LinuxIfPlugin.GetInterfaceIndex()
+
 	// VPP handlers
 
 	// core
@@ -153,8 +165,9 @@ func (p *Plugin) initHandlers() (err error) {
 		p.Log.Info("VPP Punt handler is not available, it will be skipped")
 	}
 
-	// Linux indexes and handlers
-	p.configurator.linuxIfHandler = iflinuxcalls.NewNetLinkHandler()
+	// Linux handlers
+	p.configurator.linuxIfHandler = iflinuxcalls.NewNetLinkHandler(p.NsPlugin, linuxIfIndexes,
+		p.ServiceLabel.GetAgentPrefix(), defaultGoRoutineCount, p.Log)
 	p.configurator.linuxL3Handler = l3linuxcalls.NewNetLinkHandler()
 
 	return nil

--- a/plugins/linux/ifplugin/descriptor/interface.go
+++ b/plugins/linux/ifplugin/descriptor/interface.go
@@ -21,18 +21,19 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/vishvananda/netlink"
+	"go.ligato.io/vpp-agent/v2/pkg/models"
+	"golang.org/x/sys/unix"
+
 	"github.com/golang/protobuf/proto"
 	prototypes "github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
-	"github.com/vishvananda/netlink"
-	"golang.org/x/sys/unix"
 
 	"github.com/ligato/cn-infra/idxmap"
 	"github.com/ligato/cn-infra/logging"
 	"github.com/ligato/cn-infra/logging/logrus"
 	"github.com/ligato/cn-infra/servicelabel"
 
-	"go.ligato.io/vpp-agent/v2/pkg/models"
 	kvs "go.ligato.io/vpp-agent/v2/plugins/kvscheduler/api"
 	"go.ligato.io/vpp-agent/v2/plugins/linux/ifplugin/descriptor/adapter"
 	"go.ligato.io/vpp-agent/v2/plugins/linux/ifplugin/ifaceidx"
@@ -53,10 +54,6 @@ const (
 	// InterfaceDescriptorName is the name of the descriptor for Linux interfaces.
 	InterfaceDescriptorName = "linux-interface"
 
-	// defaultLoopbackName is the name used to access loopback interface in linux
-	// host_if_name field in config is effectively ignored
-	defaultLoopbackName = "lo"
-
 	// default MTU - expected when MTU is not specified in the config.
 	defaultEthernetMTU = 1500
 	defaultLoopbackMTU = 65536
@@ -72,10 +69,6 @@ const (
 
 	// suffix attached to logical names of VETH interfaces with peers not found by Retrieve
 	vethMissingPeerSuffix = "-MISSING_PEER"
-
-	// minimum number of namespaces to be given to a single Go routine for processing
-	// in the Retrieve operation
-	minWorkForGoRoutine = 3
 )
 
 // A list of non-retriable errors:
@@ -129,14 +122,10 @@ type InterfaceDescriptor struct {
 	ifHandler    iflinuxcalls.NetlinkAPI
 	nsPlugin     nsplugin.API
 	vppIfPlugin  VPPIfPluginAPI
-	scheduler    kvs.KVScheduler
 	addrAlloc    netalloc.AddressAllocator
 
 	// runtime
 	intfIndex ifaceidx.LinuxIfMetadataIndex
-
-	// parallelization of the Retrieve operation
-	goRoutinesCnt int
 }
 
 // VPPIfPluginAPI is defined here to avoid import cycles.
@@ -148,20 +137,17 @@ type VPPIfPluginAPI interface {
 
 // NewInterfaceDescriptor creates a new instance of the Interface descriptor.
 func NewInterfaceDescriptor(
-	scheduler kvs.KVScheduler, serviceLabel servicelabel.ReaderAPI, nsPlugin nsplugin.API,
-	vppIfPlugin VPPIfPluginAPI, addrAlloc netalloc.AddressAllocator, ifHandler iflinuxcalls.NetlinkAPI,
-	log logging.PluginLogger, goRoutinesCnt int) (descr *kvs.KVDescriptor, ctx *InterfaceDescriptor) {
+	serviceLabel servicelabel.ReaderAPI, nsPlugin nsplugin.API, vppIfPlugin VPPIfPluginAPI,
+	addrAlloc netalloc.AddressAllocator, log logging.PluginLogger) (descr *kvs.KVDescriptor,
+	ctx *InterfaceDescriptor) {
 
 	// descriptor context
 	ctx = &InterfaceDescriptor{
-		scheduler:     scheduler,
-		ifHandler:     ifHandler,
-		nsPlugin:      nsPlugin,
-		vppIfPlugin:   vppIfPlugin,
-		addrAlloc:     addrAlloc,
-		serviceLabel:  serviceLabel,
-		goRoutinesCnt: goRoutinesCnt,
-		log:           log.NewLogger("if-descriptor"),
+		nsPlugin:     nsPlugin,
+		vppIfPlugin:  vppIfPlugin,
+		addrAlloc:    addrAlloc,
+		serviceLabel: serviceLabel,
+		log:          log.NewLogger("if-descriptor"),
 	}
 
 	typedDescr := &adapter.InterfaceDescriptor{
@@ -195,6 +181,12 @@ func NewInterfaceDescriptor(
 // the descriptor registration.
 func (d *InterfaceDescriptor) SetInterfaceIndex(intfIndex ifaceidx.LinuxIfMetadataIndex) {
 	d.intfIndex = intfIndex
+}
+
+// SetInterfaceHandler provides interface handler to the descriptor immediately after
+// the registration.
+func (d *InterfaceDescriptor) SetInterfaceHandler(ifHandler iflinuxcalls.NetlinkAPI) {
+	d.ifHandler = ifHandler
 }
 
 // EquivalentInterfaces is case-insensitive comparison function for
@@ -336,7 +328,7 @@ func (d *InterfaceDescriptor) Create(key string, linuxIf *interfaces.Interface) 
 				return nil, err
 			}
 			return &ifaceidx.LinuxIfMetadata{
-				Namespace:    linuxIf.Namespace,
+				Namespace:    linuxIf.GetNamespace(),
 				LinuxIfIndex: link.Attrs().Index,
 			}, nil
 		}
@@ -657,72 +649,62 @@ func (d *InterfaceDescriptor) Retrieve(correlate []adapter.InterfaceKVWithMetada
 		}
 	}
 
-	// determine the number of go routines to invoke
-	goRoutinesCnt := len(nsList) / minWorkForGoRoutine
-	if goRoutinesCnt == 0 {
-		goRoutinesCnt = 1
-	}
-	if goRoutinesCnt > d.goRoutinesCnt {
-		goRoutinesCnt = d.goRoutinesCnt
-	}
-	ch := make(chan retrievedIfaces, goRoutinesCnt)
+	// Obtain interface details - all interfaces with metadata
+	ifDetails, err := d.ifHandler.DumpInterfacesWithContext(nsList)
 
-	// invoke multiple go routines for more efficient parallel interface retrieval
-	for idx := 0; idx < goRoutinesCnt; idx++ {
-		if goRoutinesCnt > 1 {
-			go d.retrieveInterfaces(nsList, idx, goRoutinesCnt, ch)
-		} else {
-			d.retrieveInterfaces(nsList, idx, goRoutinesCnt, ch)
+	// interface logical name -> interface data
+	ifaces := make(map[string]adapter.InterfaceKVWithMetadata)
+	// already retrieved interfaces by their Linux indexes
+	indexes := make(map[int]struct{})
+
+	for _, ifDetail := range ifDetails {
+		// Transform linux interface details to the type-safe value with metadata
+		kv := adapter.InterfaceKVWithMetadata{
+			Value: ifDetail.Interface,
+			Metadata: &ifaceidx.LinuxIfMetadata{
+				LinuxIfIndex: ifDetail.Meta.LinuxIfIndex,
+				Namespace:    ifDetail.Interface.GetNamespace(),
+				HostIfName:   ifDetail.Interface.HostIfName,
+			},
+			Key: interfaces.InterfaceKey(ifDetail.Interface.Name),
 		}
-	}
 
-	// receive results from the go routines
-	ifaces := make(map[string]adapter.InterfaceKVWithMetadata) // interface logical name -> interface data
-	indexes := make(map[int]struct{})                          // already retrieved interfaces by their Linux indexes
-
-	for idx := 0; idx < goRoutinesCnt; idx++ {
-		retrieved := <-ch
-		if retrieved.err != nil {
-			return nil, retrieved.err
-		}
-		for _, kv := range retrieved.interfaces {
-			// skip if this interface was already retrieved and this is not the expected
-			// namespace from correlation - remember, the same namespace may have
-			// multiple different references
-			var rewrite bool
-			if _, alreadyRetrieved := indexes[kv.Metadata.LinuxIfIndex]; alreadyRetrieved {
-				if expCfg, hasExpCfg := ifCfg[kv.Value.Name]; hasExpCfg {
-					if proto.Equal(expCfg.Namespace, kv.Value.Namespace) {
-						rewrite = true
-					}
-				}
-				if !rewrite {
-					continue
-				}
-			}
-			indexes[kv.Metadata.LinuxIfIndex] = struct{}{}
-
-			// test for duplicity of VETH logical names
-			if kv.Value.Type == interfaces.Interface_VETH {
-				if _, duplicate := ifaces[kv.Value.Name]; duplicate && !rewrite {
-					// add suffix to the duplicate to make its logical name unique
-					// (and not configured by NB so that it will get removed)
-					dupIndex := 1
-					for intf2 := range ifaces {
-						if strings.HasPrefix(intf2, kv.Value.Name+vethDuplicateSuffix) {
-							dupIndex++
-						}
-					}
-					kv.Value.Name = kv.Value.Name + vethDuplicateSuffix + strconv.Itoa(dupIndex)
-					kv.Key = interfaces.InterfaceKey(kv.Value.Name)
-				}
-			}
-			// correlate link_only attribute
+		// skip if this interface was already retrieved and this is not the expected
+		// namespace from correlation - remember, the same namespace may have
+		// multiple different references
+		var rewrite bool
+		if _, alreadyRetrieved := indexes[kv.Metadata.LinuxIfIndex]; alreadyRetrieved {
 			if expCfg, hasExpCfg := ifCfg[kv.Value.Name]; hasExpCfg {
-				kv.Value.LinkOnly = expCfg.GetLinkOnly()
+				if proto.Equal(expCfg.Namespace, kv.Value.Namespace) {
+					rewrite = true
+				}
 			}
-			ifaces[kv.Value.Name] = kv
+			if !rewrite {
+				continue
+			}
 		}
+		indexes[kv.Metadata.LinuxIfIndex] = struct{}{}
+
+		// test for duplicity of VETH logical names
+		if kv.Value.Type == interfaces.Interface_VETH {
+			if _, duplicate := ifaces[kv.Value.Name]; duplicate && !rewrite {
+				// add suffix to the duplicate to make its logical name unique
+				// (and not configured by NB so that it will get removed)
+				dupIndex := 1
+				for intf2 := range ifaces {
+					if strings.HasPrefix(intf2, kv.Value.Name+vethDuplicateSuffix) {
+						dupIndex++
+					}
+				}
+				kv.Value.Name = kv.Value.Name + vethDuplicateSuffix + strconv.Itoa(dupIndex)
+				kv.Key = interfaces.InterfaceKey(kv.Value.Name)
+			}
+		}
+		// correlate link_only attribute
+		if expCfg, hasExpCfg := ifCfg[kv.Value.Name]; hasExpCfg {
+			kv.Value.LinkOnly = expCfg.GetLinkOnly()
+		}
+		ifaces[kv.Value.Name] = kv
 	}
 
 	// first collect VETHs with duplicate logical names
@@ -789,110 +771,6 @@ func (d *InterfaceDescriptor) Retrieve(correlate []adapter.InterfaceKVWithMetada
 	}
 
 	return values, nil
-}
-
-// retrieveInterfaces is run by a separate go routine to retrieve all interfaces
-// present in every <goRoutineIdx>-th network namespace from the list.
-func (d *InterfaceDescriptor) retrieveInterfaces(nsList []*namespace.NetNamespace, goRoutineIdx, goRoutinesCnt int, ch chan<- retrievedIfaces) {
-	var retrieved retrievedIfaces
-
-	agentPrefix := d.serviceLabel.GetAgentPrefix()
-	nsCtx := nslinuxcalls.NewNamespaceMgmtCtx()
-
-	for i := goRoutineIdx; i < len(nsList); i += goRoutinesCnt {
-		nsRef := nsList[i]
-		// switch to the namespace
-		revert, err := d.nsPlugin.SwitchToNamespace(nsCtx, nsRef)
-		if err != nil {
-			d.log.WithField("namespace", nsRef).
-				Warn("Failed to switch namespace:", err)
-			continue // continue with the next namespace
-		}
-
-		// get all links in the namespace
-		links, err := d.ifHandler.GetLinkList()
-		if err != nil {
-			d.log.Error("Failed to get link list:", err)
-			// switch back to the default namespace before returning error
-			revert()
-			retrieved.err = err
-			break
-		}
-
-		// retrieve every interface managed by this agent
-		for _, link := range links {
-			iface := &interfaces.Interface{
-				Namespace:   nsRef,
-				HostIfName:  link.Attrs().Name,
-				PhysAddress: link.Attrs().HardwareAddr.String(),
-				Mtu:         uint32(link.Attrs().MTU),
-			}
-
-			alias := link.Attrs().Alias
-			if !strings.HasPrefix(alias, agentPrefix) {
-				// skip interface not configured by this agent
-				continue
-			}
-			alias = strings.TrimPrefix(alias, agentPrefix)
-
-			// parse alias to obtain logical references
-			if link.Type() == "veth" {
-				iface.Type = interfaces.Interface_VETH
-				var vethPeerIfName string
-				iface.Name, vethPeerIfName = parseVethAlias(alias)
-				iface.Link = &interfaces.Interface_Veth{
-					Veth: &interfaces.VethLink{
-						PeerIfName: vethPeerIfName,
-					},
-				}
-			} else if link.Type() == "tuntap" || link.Type() == "tun" /* not defined in vishvananda */ {
-				iface.Type = interfaces.Interface_TAP_TO_VPP
-				var vppTapIfName string
-				iface.Name, vppTapIfName, _ = parseTapAlias(alias)
-				iface.Link = &interfaces.Interface_Tap{
-					Tap: &interfaces.TapLink{
-						VppTapIfName: vppTapIfName,
-					},
-				}
-			} else if link.Attrs().Name == defaultLoopbackName {
-				iface.Type = interfaces.Interface_LOOPBACK
-				iface.Name = alias
-			} else {
-				// unsupported interface type supposedly configured by agent => print warning
-				d.log.WithFields(logging.Fields{
-					"if-host-name": link.Attrs().Name,
-					"namespace":    nsRef,
-				}).Warnf("Managed interface of unsupported type: %s", link.Type())
-				continue
-			}
-
-			// skip interfaces with invalid aliases
-			if iface.Name == "" {
-				continue
-			}
-
-			// retrieve addresses, MTU, etc.
-			d.retrieveLinkDetails(link, iface, nsRef)
-
-			// build key-value pair for the retrieved interface
-			retrieved.interfaces = append(retrieved.interfaces, adapter.InterfaceKVWithMetadata{
-				Key:    models.Key(iface),
-				Value:  iface,
-				Origin: kvs.FromNB,
-				Metadata: &ifaceidx.LinuxIfMetadata{
-					LinuxIfIndex: link.Attrs().Index,
-					VPPTapName:   iface.GetTap().GetVppTapIfName(),
-					Namespace:    nsRef,
-					HostIfName:   link.Attrs().Name,
-				},
-			})
-		}
-
-		// switch back to the default namespace
-		revert()
-	}
-
-	ch <- retrieved
 }
 
 // retrieveExistingInterfaces retrieves already created Linux interface - i.e. not created
@@ -1082,7 +960,7 @@ func (d *InterfaceDescriptor) getInterfaceAddresses(ifName string) (addresses []
 // getHostIfName returns the interface host name.
 func getHostIfName(linuxIf *interfaces.Interface) string {
 	if linuxIf.Type == interfaces.Interface_LOOPBACK {
-		return defaultLoopbackName
+		return iflinuxcalls.DefaultLoopbackName
 	}
 	hostIfName := linuxIf.HostIfName
 	if hostIfName == "" {

--- a/plugins/linux/ifplugin/descriptor/interface.go
+++ b/plugins/linux/ifplugin/descriptor/interface.go
@@ -666,6 +666,7 @@ func (d *InterfaceDescriptor) Retrieve(correlate []adapter.InterfaceKVWithMetada
 			Metadata: &ifaceidx.LinuxIfMetadata{
 				LinuxIfIndex: ifDetail.Meta.LinuxIfIndex,
 				Namespace:    ifDetail.Interface.GetNamespace(),
+				VPPTapName:   ifDetail.Interface.GetTap().GetVppTapIfName(),
 				HostIfName:   ifDetail.Interface.HostIfName,
 			},
 			Key: interfaces.InterfaceKey(ifDetail.Interface.Name),

--- a/plugins/linux/ifplugin/descriptor/interface.go
+++ b/plugins/linux/ifplugin/descriptor/interface.go
@@ -411,13 +411,6 @@ func (d *InterfaceDescriptor) Delete(key string, linuxIf *interfaces.Interface, 
 	nsCtx := nslinuxcalls.NewNamespaceMgmtCtx()
 	revert, err := d.nsPlugin.SwitchToNamespace(nsCtx, linuxIf.Namespace)
 	if err != nil {
-		if _, ok := err.(*nsplugin.UnavailableMicroserviceErr); ok {
-			// Assume that the delete was called by scheduler because the namespace
-			// was removed. Do not return error in this case.
-			d.log.Debugf("Interface %s assumed deleted, required namespace %+v does not exist",
-				linuxIf.Name, linuxIf.Namespace)
-			return nil
-		}
 		d.log.Error("switch to namespace failed:", err)
 		return err
 	}
@@ -657,7 +650,7 @@ func (d *InterfaceDescriptor) Retrieve(correlate []adapter.InterfaceKVWithMetada
 	}
 
 	// Obtain interface details - all interfaces with metadata
-	ifDetails, err := d.ifHandler.DumpInterfacesWithContext(nsList)
+	ifDetails, err := d.ifHandler.DumpInterfacesFromNamespaces(nsList)
 	if err != nil {
 		return nil, errors.Errorf("Failed to retrieve linux interfaces: %v", err)
 	}

--- a/plugins/linux/ifplugin/descriptor/interface.go
+++ b/plugins/linux/ifplugin/descriptor/interface.go
@@ -651,7 +651,9 @@ func (d *InterfaceDescriptor) Retrieve(correlate []adapter.InterfaceKVWithMetada
 
 	// Obtain interface details - all interfaces with metadata
 	ifDetails, err := d.ifHandler.DumpInterfacesWithContext(nsList)
-
+	if err != nil {
+		return nil, errors.Errorf("Failed to retrieve linux interfaces: %v", err)
+	}
 	// interface logical name -> interface data
 	ifaces := make(map[string]adapter.InterfaceKVWithMetadata)
 	// already retrieved interfaces by their Linux indexes

--- a/plugins/linux/ifplugin/descriptor/interface_address.go
+++ b/plugins/linux/ifplugin/descriptor/interface_address.go
@@ -176,6 +176,13 @@ func (d *InterfaceAddressDescriptor) Delete(key string, emptyVal proto.Message, 
 	nsCtx := nslinuxcalls.NewNamespaceMgmtCtx()
 	revert, err := d.nsPlugin.SwitchToNamespace(nsCtx, ifMeta.Namespace)
 	if err != nil {
+		if _, ok := err.(*nsplugin.UnavailableMicroserviceErr); ok {
+			// Assume that the delete was called by scheduler because the namespace
+			// was removed. Do not return error in this case.
+			d.log.Debugf("Interface %s IP address %s assumed deleted, required namespace %+v does not exist",
+				iface, ipAddr, ifMeta.Namespace)
+			return nil
+		}
 		d.log.Error(err)
 		return err
 	}

--- a/plugins/linux/ifplugin/descriptor/interface_tap.go
+++ b/plugins/linux/ifplugin/descriptor/interface_tap.go
@@ -110,7 +110,7 @@ func (d *InterfaceDescriptor) deleteAutoTAP(nsCtx nslinuxcalls.NamespaceMgmtCtx,
 	}
 
 	// rename back to the temporary name
-	d.ifHandler.RenameInterface(hostName, origVppTapHostName)
+	err = d.ifHandler.RenameInterface(hostName, origVppTapHostName)
 	if err != nil {
 		d.log.Error(err)
 		return err

--- a/plugins/linux/ifplugin/descriptor/interface_veth.go
+++ b/plugins/linux/ifplugin/descriptor/interface_veth.go
@@ -17,7 +17,6 @@ package descriptor
 import (
 	"fmt"
 	"hash/fnv"
-	"strings"
 
 	"go.ligato.io/vpp-agent/v2/plugins/linux/ifplugin/ifaceidx"
 	nslinuxcalls "go.ligato.io/vpp-agent/v2/plugins/linux/nsplugin/linuxcalls"
@@ -148,16 +147,6 @@ func (d *InterfaceDescriptor) deleteVETH(nsCtx nslinuxcalls.NamespaceMgmtCtx, ke
 // The alias stores the VETH logical name together with the peer (logical) name.
 func getVethAlias(vethName, peerName string) string {
 	return vethName + "/" + peerName
-}
-
-// parseVethAlias parses out VETH logical name together with the peer name from the alias.
-func parseVethAlias(alias string) (vethName, peerName string) {
-	aliasParts := strings.Split(alias, "/")
-	vethName = aliasParts[0]
-	if len(aliasParts) > 0 {
-		peerName = aliasParts[1]
-	}
-	return
 }
 
 // getVethTemporaryHostName (deterministically) generates a temporary host name

--- a/plugins/linux/ifplugin/descriptor/interface_veth.go
+++ b/plugins/linux/ifplugin/descriptor/interface_veth.go
@@ -136,7 +136,7 @@ func (d *InterfaceDescriptor) deleteVETH(nsCtx nslinuxcalls.NamespaceMgmtCtx, ke
 		}
 		if tempPeerHostName != "" {
 			// peer should be automatically removed as well, but just in case...
-			d.ifHandler.DeleteInterface(tempPeerHostName) // ignore errors
+			_ = d.ifHandler.DeleteInterface(tempPeerHostName) // ignore errors
 		}
 	}
 

--- a/plugins/linux/ifplugin/descriptor/interface_veth.go
+++ b/plugins/linux/ifplugin/descriptor/interface_veth.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"hash/fnv"
 
+	"go.ligato.io/vpp-agent/v2/plugins/linux/ifplugin/linuxcalls"
+
 	"go.ligato.io/vpp-agent/v2/plugins/linux/ifplugin/ifaceidx"
 	nslinuxcalls "go.ligato.io/vpp-agent/v2/plugins/linux/nsplugin/linuxcalls"
 	interfaces "go.ligato.io/vpp-agent/v2/proto/ligato/linux/interfaces"
@@ -54,12 +56,12 @@ func (d *InterfaceDescriptor) createVETH(
 		}
 
 		// add alias to both VETH ends
-		err = d.ifHandler.SetInterfaceAlias(tempHostName, agentPrefix+getVethAlias(linuxIf.Name, peerName))
+		err = d.ifHandler.SetInterfaceAlias(tempHostName, agentPrefix+linuxcalls.GetVethAlias(linuxIf.Name, peerName))
 		if err != nil {
 			d.log.Error(err)
 			return nil, err
 		}
-		err = d.ifHandler.SetInterfaceAlias(tempPeerHostName, agentPrefix+getVethAlias(peerName, linuxIf.Name))
+		err = d.ifHandler.SetInterfaceAlias(tempPeerHostName, agentPrefix+linuxcalls.GetVethAlias(peerName, linuxIf.Name))
 		if err != nil {
 			d.log.Error(err)
 			return nil, err
@@ -141,12 +143,6 @@ func (d *InterfaceDescriptor) deleteVETH(nsCtx nslinuxcalls.NamespaceMgmtCtx, ke
 	}
 
 	return nil
-}
-
-// getVethAlias returns alias for Linux VETH interface managed by the agent.
-// The alias stores the VETH logical name together with the peer (logical) name.
-func getVethAlias(vethName, peerName string) string {
-	return vethName + "/" + peerName
 }
 
 // getVethTemporaryHostName (deterministically) generates a temporary host name

--- a/plugins/linux/ifplugin/linuxcalls/dump_interface_linuxcalls.go
+++ b/plugins/linux/ifplugin/linuxcalls/dump_interface_linuxcalls.go
@@ -75,7 +75,7 @@ func (h *NetLinkHandler) DumpInterfaces() ([]*InterfaceDetails, error) {
 // will be retrieved. If no context is provided, interfaces only from the default namespace are retrieved.
 func (h *NetLinkHandler) DumpInterfacesWithContext(nsList []*namespaces.NetNamespace) ([]*InterfaceDetails, error) {
 	// Always retrieve from the default namespace
-	if nsList == nil || len(nsList) == 0 {
+	if len(nsList) == 0 {
 		nsList = []*namespaces.NetNamespace{nil}
 	}
 	// Determine the number of go routines to invoke
@@ -104,9 +104,7 @@ func (h *NetLinkHandler) DumpInterfacesWithContext(nsList []*namespaces.NetNames
 		if retrieved.err != nil {
 			return nil, retrieved.err
 		}
-		for _, linuxIf := range retrieved.interfaces {
-			linuxIfs = append(linuxIfs, linuxIf)
-		}
+		linuxIfs = append(linuxIfs, retrieved.interfaces...)
 	}
 	return linuxIfs, nil
 }

--- a/plugins/linux/ifplugin/linuxcalls/dump_interface_linuxcalls.go
+++ b/plugins/linux/ifplugin/linuxcalls/dump_interface_linuxcalls.go
@@ -1,0 +1,281 @@
+//  Copyright (c) 2018 Cisco and/or its affiliates.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at:
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// +build !windows,!darwin
+
+package linuxcalls
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/ligato/cn-infra/logging"
+	"github.com/vishvananda/netlink"
+	"go.ligato.io/vpp-agent/v2/plugins/linux/nsplugin/linuxcalls"
+	interfaces "go.ligato.io/vpp-agent/v2/proto/ligato/linux/interfaces"
+	namespaces "go.ligato.io/vpp-agent/v2/proto/ligato/linux/namespace"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// defaultLoopbackName is the name used to access loopback interface in linux
+	// host_if_name field in config is effectively ignored
+	DefaultLoopbackName = "lo"
+
+	// minimum number of namespaces to be given to a single Go routine for processing
+	// in the Retrieve operation
+	minWorkForGoRoutine = 3
+)
+
+// retrievedIfaces is used as the return value sent via channel by retrieveInterfaces().
+type retrievedInterfaces struct {
+	interfaces []*InterfaceDetails
+	err        error
+}
+
+// DumpInterfaces retrieves all linux interfaces from default namespace, and from all
+// the other namespaces based on known linux interfaces from the index map.
+func (h *NetLinkHandler) DumpInterfaces() ([]*InterfaceDetails, error) {
+	// Add default namespace
+	nsList := []*namespaces.NetNamespace{nil}
+	for _, ifName := range h.ifIndexes.ListAllInterfaces() {
+		if metadata, exists := h.ifIndexes.LookupByName(ifName); exists {
+			if metadata == nil {
+				h.log.Warnf("metadata for %s are nil", ifName)
+				continue
+			}
+			nsListed := false
+			for _, ns := range nsList {
+				if proto.Equal(ns, metadata.Namespace) {
+					nsListed = true
+					break
+				}
+			}
+			if !nsListed {
+				nsList = append(nsList, metadata.Namespace)
+			}
+		}
+	}
+	return h.DumpInterfacesWithContext(nsList)
+}
+
+// DumpInterfacesWithContext requires context in form of the namespace list of which linux interfaces
+// will be retrieved. If no context is provided, interfaces only from the default namespace are retrieved.
+func (h *NetLinkHandler) DumpInterfacesWithContext(nsList []*namespaces.NetNamespace) ([]*InterfaceDetails, error) {
+	// Always retrieve from the default namespace
+	if nsList == nil || len(nsList) == 0 {
+		nsList = []*namespaces.NetNamespace{nil}
+	}
+	// Determine the number of go routines to invoke
+	goRoutinesCnt := len(nsList) / minWorkForGoRoutine
+	if goRoutinesCnt == 0 {
+		goRoutinesCnt = 1
+	}
+	if goRoutinesCnt > h.goRoutineCount {
+		goRoutinesCnt = h.goRoutineCount
+	}
+	ch := make(chan retrievedInterfaces, goRoutinesCnt)
+
+	// Invoke multiple go routines for more efficient parallel interface retrieval
+	for idx := 0; idx < goRoutinesCnt; idx++ {
+		if goRoutinesCnt > 1 {
+			go h.retrieveInterfaces(nsList, idx, goRoutinesCnt, ch)
+		} else {
+			h.retrieveInterfaces(nsList, idx, goRoutinesCnt, ch)
+		}
+	}
+
+	// receive results from the go routines
+	var linuxIfs []*InterfaceDetails
+	for idx := 0; idx < goRoutinesCnt; idx++ {
+		retrieved := <-ch
+		if retrieved.err != nil {
+			return nil, retrieved.err
+		}
+		for _, linuxIf := range retrieved.interfaces {
+			linuxIfs = append(linuxIfs, linuxIf)
+		}
+	}
+	return linuxIfs, nil
+}
+
+// retrieveInterfaces is run by a separate go routine to retrieve all interfaces
+// present in every <goRoutineIdx>-th network namespace from the list.
+func (h *NetLinkHandler) retrieveInterfaces(nsList []*namespaces.NetNamespace, goRoutineIdx, goRoutinesCnt int, ch chan<- retrievedInterfaces) {
+	var retrieved retrievedInterfaces
+
+	nsCtx := linuxcalls.NewNamespaceMgmtCtx()
+	for i := goRoutineIdx; i < len(nsList); i += goRoutinesCnt {
+		nsRef := nsList[i]
+		// switch to the namespace
+		revert, err := h.nsPlugin.SwitchToNamespace(nsCtx, nsRef)
+		if err != nil {
+			h.log.WithField("namespace", nsRef).Warn("Failed to switch namespace:", err)
+			continue // continue with the next namespace
+		}
+
+		// get all links in the namespace
+		links, err := h.GetLinkList()
+		if err != nil {
+			h.log.Error("Failed to get link list:", err)
+			// switch back to the default namespace before returning error
+			revert()
+			retrieved.err = err
+			break
+		}
+
+		// retrieve every interface managed by this agent
+		for _, link := range links {
+			iface := &interfaces.Interface{
+				Namespace:   nsRef,
+				HostIfName:  link.Attrs().Name,
+				PhysAddress: link.Attrs().HardwareAddr.String(),
+				Mtu:         uint32(link.Attrs().MTU),
+			}
+
+			alias := link.Attrs().Alias
+			if !strings.HasPrefix(alias, h.agentPrefix) {
+				// skip interface not configured by this agent
+				continue
+			}
+			alias = strings.TrimPrefix(alias, h.agentPrefix)
+
+			// parse alias to obtain logical references
+			if link.Type() == "veth" {
+				iface.Type = interfaces.Interface_VETH
+				var vethPeerIfName string
+				iface.Name, vethPeerIfName = parseVethAlias(alias)
+				iface.Link = &interfaces.Interface_Veth{
+					Veth: &interfaces.VethLink{
+						PeerIfName: vethPeerIfName,
+					},
+				}
+			} else if link.Type() == "tuntap" || link.Type() == "tun" /* not defined in vishvananda */ {
+				iface.Type = interfaces.Interface_TAP_TO_VPP
+				var vppTapIfName string
+				iface.Name, vppTapIfName, _ = parseTapAlias(alias)
+				iface.Link = &interfaces.Interface_Tap{
+					Tap: &interfaces.TapLink{
+						VppTapIfName: vppTapIfName,
+					},
+				}
+			} else if link.Attrs().Name == DefaultLoopbackName {
+				iface.Type = interfaces.Interface_LOOPBACK
+				iface.Name = alias
+			} else {
+				// unsupported interface type supposedly configured by agent => print warning
+				h.log.WithFields(logging.Fields{
+					"if-host-name": link.Attrs().Name,
+					"namespace":    nsRef,
+				}).Warnf("Managed interface of unsupported type: %s", link.Type())
+				continue
+			}
+
+			// skip interfaces with invalid aliases
+			if iface.Name == "" {
+				continue
+			}
+
+			// retrieve addresses, MTU, etc.
+			h.retrieveLinkDetails(link, iface, nsRef)
+
+			// build key-value pair for the retrieved interface
+			retrieved.interfaces = append(retrieved.interfaces, &InterfaceDetails{
+				Interface: iface,
+				Meta: &InterfaceMeta{
+					LinuxIfIndex: link.Attrs().Index,
+				},
+			})
+		}
+
+		// switch back to the default namespace
+		revert()
+	}
+
+	ch <- retrieved
+}
+
+// retrieveLinkDetails retrieves link details common to all interface types (e.g. addresses).
+func (h *NetLinkHandler) retrieveLinkDetails(link netlink.Link, iface *interfaces.Interface, nsRef *namespaces.NetNamespace) {
+	var err error
+	// read interface status
+	iface.Enabled, err = h.IsInterfaceUp(link.Attrs().Name)
+	if err != nil {
+		h.log.WithFields(logging.Fields{
+			"if-host-name": link.Attrs().Name,
+			"namespace":    nsRef,
+		}).Warn("Failed to read interface status:", err)
+	}
+
+	// read assigned IP addresses
+	addressList, err := h.GetAddressList(link.Attrs().Name)
+	if err != nil {
+		h.log.WithFields(logging.Fields{
+			"if-host-name": link.Attrs().Name,
+			"namespace":    nsRef,
+		}).Warn("Failed to read address list:", err)
+	}
+	for _, address := range addressList {
+		if address.Scope == unix.RT_SCOPE_LINK {
+			// ignore link-local IPv6 addresses
+			continue
+		}
+		mask, _ := address.Mask.Size()
+		addrStr := address.IP.String() + "/" + strconv.Itoa(mask)
+		iface.IpAddresses = append(iface.IpAddresses, addrStr)
+	}
+
+	// read checksum offloading
+	if iface.Type == interfaces.Interface_VETH {
+		rxOn, txOn, err := h.GetChecksumOffloading(link.Attrs().Name)
+		if err != nil {
+			h.log.WithFields(logging.Fields{
+				"if-host-name": link.Attrs().Name,
+				"namespace":    nsRef,
+			}).Warn("Failed to read checksum offloading:", err)
+		} else {
+			if !rxOn {
+				iface.GetVeth().RxChecksumOffloading = interfaces.VethLink_CHKSM_OFFLOAD_DISABLED
+			}
+			if !txOn {
+				iface.GetVeth().TxChecksumOffloading = interfaces.VethLink_CHKSM_OFFLOAD_DISABLED
+			}
+		}
+	}
+}
+
+// parseVethAlias parses out VETH logical name together with the peer name from the alias.
+func parseVethAlias(alias string) (vethName, peerName string) {
+	aliasParts := strings.Split(alias, "/")
+	vethName = aliasParts[0]
+	if len(aliasParts) > 0 {
+		peerName = aliasParts[1]
+	}
+	return
+}
+
+// parseTapAlias parses out TAP_TO_VPP logical name together with the name of the
+// linked VPP-TAP and the original TAP host interface name.
+func parseTapAlias(alias string) (linuxTapName, vppTapName, origHostIfName string) {
+	aliasParts := strings.Split(alias, "/")
+	linuxTapName = aliasParts[0]
+	if len(aliasParts) > 1 {
+		vppTapName = aliasParts[1]
+	}
+	if len(aliasParts) > 2 {
+		origHostIfName = aliasParts[2]
+	}
+	return
+}

--- a/plugins/linux/ifplugin/linuxcalls/dump_interface_linuxcalls.go
+++ b/plugins/linux/ifplugin/linuxcalls/dump_interface_linuxcalls.go
@@ -49,18 +49,18 @@ type retrievedInterfaces struct {
 // DumpInterfaces retrieves all linux interfaces from default namespace and from all
 // the other namespaces based on known linux interfaces from the index map.
 func (h *NetLinkHandler) DumpInterfaces() ([]*InterfaceDetails, error) {
-	return h.DumpInterfacesWithContext(h.getKnownNamespaces())
+	return h.DumpInterfacesFromNamespaces(h.getKnownNamespaces())
 }
 
 // DumpInterfaceStats retrieves statistics for all linux interfaces from default namespace
 // and from all the other namespaces based on known linux interfaces from the index map.
 func (h *NetLinkHandler) DumpInterfaceStats() ([]*InterfaceStatistics, error) {
-	return h.DumpInterfaceStatsWithContext(h.getKnownNamespaces())
+	return h.DumpInterfaceStatsFromNamespaces(h.getKnownNamespaces())
 }
 
-// DumpInterfacesWithContext requires context in form of the namespace list of which linux interfaces
+// DumpInterfacesFromNamespaces requires context in form of the namespace list of which linux interfaces
 // will be retrieved. If no context is provided, interfaces only from the default namespace are retrieved.
-func (h *NetLinkHandler) DumpInterfacesWithContext(nsList []*namespaces.NetNamespace) ([]*InterfaceDetails, error) {
+func (h *NetLinkHandler) DumpInterfacesFromNamespaces(nsList []*namespaces.NetNamespace) ([]*InterfaceDetails, error) {
 	// Always retrieve from the default namespace
 	if len(nsList) == 0 {
 		nsList = []*namespaces.NetNamespace{nil}
@@ -96,10 +96,10 @@ func (h *NetLinkHandler) DumpInterfacesWithContext(nsList []*namespaces.NetNames
 	return linuxIfs, nil
 }
 
-// DumpInterfaceStatsWithContext requires context in form of the namespace list of which linux interface stats
+// DumpInterfaceStatsFromNamespaces requires context in form of the namespace list of which linux interface stats
 // will be retrieved. If no context is provided, interface stats only from the default namespace interfaces
 // are retrieved.
-func (h *NetLinkHandler) DumpInterfaceStatsWithContext(nsList []*namespaces.NetNamespace) ([]*InterfaceStatistics, error) {
+func (h *NetLinkHandler) DumpInterfaceStatsFromNamespaces(nsList []*namespaces.NetNamespace) ([]*InterfaceStatistics, error) {
 	// Always retrieve from the default namespace
 	if len(nsList) == 0 {
 		nsList = []*namespaces.NetNamespace{nil}

--- a/plugins/linux/ifplugin/linuxcalls/netlink_api.go
+++ b/plugins/linux/ifplugin/linuxcalls/netlink_api.go
@@ -128,15 +128,15 @@ type NetlinkAPIRead interface {
 	// DumpInterfaces uses local cache to gather information about linux
 	// namespaces and retrieves interfaces from them.
 	DumpInterfaces() ([]*InterfaceDetails, error)
-	// DumpInterfacesWithContext retrieves all linux interfaces based
+	// DumpInterfacesFromNamespaces retrieves all linux interfaces based
 	// on provided namespace context.
-	DumpInterfacesWithContext(nsList []*namespaces.NetNamespace) ([]*InterfaceDetails, error)
+	DumpInterfacesFromNamespaces(nsList []*namespaces.NetNamespace) ([]*InterfaceDetails, error)
 	// DumpInterfaceStats uses local cache to gather information about linux
 	// namespaces and retrieves stats for interfaces in that namespace them.
 	DumpInterfaceStats() ([]*InterfaceStatistics, error)
-	// DumpInterfaceStatsWithContext retrieves all linux interface stats based
+	// DumpInterfaceStatsFromNamespaces retrieves all linux interface stats based
 	// on provided namespace context.
-	DumpInterfaceStatsWithContext(nsList []*namespaces.NetNamespace) ([]*InterfaceStatistics, error)
+	DumpInterfaceStatsFromNamespaces(nsList []*namespaces.NetNamespace) ([]*InterfaceStatistics, error)
 }
 
 // NetLinkHandler is accessor for Netlink methods.

--- a/plugins/linux/ifplugin/linuxcalls/netlink_api.go
+++ b/plugins/linux/ifplugin/linuxcalls/netlink_api.go
@@ -35,10 +35,35 @@ type InterfaceDetails struct {
 	Meta      *InterfaceMeta        `json:"interface_meta"`
 }
 
+// Statistics are represented here since
+// there is currently no model
+type InterfaceStatistics struct {
+	Name         string                    `json:"interface_name"`
+	Type         interfaces.Interface_Type `json:"interface_type"`
+	LinuxIfIndex int                       `json:"linux_if_index"`
+
+	// stats data
+	RxPackets uint64 `json:"rx_packets"`
+	TxPackets uint64 `json:"tx_packets"`
+	RxBytes   uint64 `json:"rx_bytes"`
+	TxBytes   uint64 `json:"tx_bytes"`
+	RxErrors  uint64 `json:"rx_errors"`
+	TxErrors  uint64 `json:"tx_errors"`
+	RxDropped uint64 `json:"rx_dropped"`
+	TxDropped uint64 `json:"tx_dropped"`
+}
+
 // InterfaceMeta represents linux interface metadata
 type InterfaceMeta struct {
-	LinuxIfIndex int  `json:"linux_if_index"`
-	IsExisting   bool `json:"is_existing"`
+	LinuxIfIndex  int    `json:"linux_if_index"`
+	ParentIndex   int    `json:"parent_index"`
+	MasterIndex   int    `json:"master_index"`
+	OperState     uint8  `json:"oper_state"`
+	Flags         uint32 `json:"flags"`
+	Encapsulation string `json:"encapsulation"`
+	NumRxQueues   int    `json:"num_rx_queue"`
+	NumTxQueues   int    `json:"num_tx_queue"`
+	TxQueueLen    int    `json:"tx_queue_len"`
 }
 
 // NetlinkAPI interface covers all methods inside linux calls package
@@ -101,11 +126,17 @@ type NetlinkAPIRead interface {
 	// for the given interface.
 	GetChecksumOffloading(ifName string) (rxOn, txOn bool, err error)
 	// DumpInterfaces uses local cache to gather information about linux
-	// namespaces and retrieves them.
+	// namespaces and retrieves interfaces from them.
 	DumpInterfaces() ([]*InterfaceDetails, error)
 	// DumpInterfacesWithContext retrieves all linux interfaces based
 	// on provided namespace context.
 	DumpInterfacesWithContext(nsList []*namespaces.NetNamespace) ([]*InterfaceDetails, error)
+	// DumpInterfaceStats uses local cache to gather information about linux
+	// namespaces and retrieves stats for interfaces in that namespace them.
+	DumpInterfaceStats() ([]*InterfaceStatistics, error)
+	// DumpInterfaceStatsWithContext retrieves all linux interface stats based
+	// on provided namespace context.
+	DumpInterfaceStatsWithContext(nsList []*namespaces.NetNamespace) ([]*InterfaceStatistics, error)
 }
 
 // NetLinkHandler is accessor for Netlink methods.

--- a/plugins/linux/ifplugin/linuxcalls/netlink_api.go
+++ b/plugins/linux/ifplugin/linuxcalls/netlink_api.go
@@ -28,7 +28,7 @@ import (
 	"github.com/vishvananda/netns"
 )
 
-// InterfaceDetails is a object combining linux interface data based on proto
+// InterfaceDetails is an object combining linux interface data based on proto
 // model with additional metadata
 type InterfaceDetails struct {
 	Interface *interfaces.Interface `json:"interface"`

--- a/plugins/linux/l3plugin/descriptor/route.go
+++ b/plugins/linux/l3plugin/descriptor/route.go
@@ -46,10 +46,6 @@ const (
 	// RouteDescriptorName is the name of the descriptor for Linux routes.
 	RouteDescriptorName = "linux-route"
 
-	//// IP addresses matching any destination.
-	//ipv4AddrAny = "0.0.0.0"
-	//ipv6AddrAny = "::"
-
 	// dependency labels
 	routeOutInterfaceDep       = "outgoing-interface-is-up"
 	routeOutInterfaceIPAddrDep = "outgoing-interface-has-ip-address"

--- a/plugins/linux/l3plugin/l3plugin.go
+++ b/plugins/linux/l3plugin/l3plugin.go
@@ -79,7 +79,7 @@ func (p *L3Plugin) Init() error {
 	}
 
 	// init handlers
-	p.l3Handler = linuxcalls.NewNetLinkHandler()
+	p.l3Handler = linuxcalls.NewNetLinkHandler(p.NsPlugin, p.IfPlugin.GetInterfaceIndex(), defaultGoRoutinesCnt, p.Log)
 
 	// init & register descriptors
 	arpDescriptor := descriptor.NewARPDescriptor(

--- a/plugins/linux/l3plugin/linuxcalls/arp_linuxcalls.go
+++ b/plugins/linux/l3plugin/linuxcalls/arp_linuxcalls.go
@@ -29,10 +29,3 @@ func (h *NetLinkHandler) SetARPEntry(arpEntry *netlink.Neigh) error {
 func (h *NetLinkHandler) DelARPEntry(arpEntry *netlink.Neigh) error {
 	return netlink.NeighDel(arpEntry)
 }
-
-// GetARPEntries reads all configured static ARP entries for given interface.
-// <interfaceIdx> works as filter, if set to zero, all arp entries in the namespace
-// are returned
-func (h *NetLinkHandler) GetARPEntries(interfaceIdx int) ([]netlink.Neigh, error) {
-	return netlink.NeighList(interfaceIdx, 0)
-}

--- a/plugins/linux/l3plugin/linuxcalls/dump_arp_linuxcalls.go
+++ b/plugins/linux/l3plugin/linuxcalls/dump_arp_linuxcalls.go
@@ -120,7 +120,11 @@ func (h *NetLinkHandler) retrieveARPs(interfaces []string, goRoutineIdx, goRouti
 					IpAddress: arp.IP.String(),
 					HwAddress: arp.HardwareAddr.String(),
 				},
-				Meta: &ArpMeta{},
+				Meta: &ArpMeta{
+					InterfaceIndex: uint32(arp.LinkIndex),
+					IPFamily:       uint32(arp.Family),
+					VNI:            uint32(arp.VNI),
+				},
 			})
 		}
 	}

--- a/plugins/linux/l3plugin/linuxcalls/dump_arp_linuxcalls.go
+++ b/plugins/linux/l3plugin/linuxcalls/dump_arp_linuxcalls.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2019 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows,!darwin
+
+package linuxcalls
+
+import (
+	"github.com/ligato/cn-infra/logging"
+	"github.com/pkg/errors"
+	"github.com/vishvananda/netlink"
+	"go.ligato.io/vpp-agent/v2/plugins/linux/nsplugin/linuxcalls"
+	linux_l3 "go.ligato.io/vpp-agent/v2/proto/ligato/linux/l3"
+)
+
+// retrievedARPs is used as the return value sent via channel by retrieveARPs().
+type retrievedARPs struct {
+	arps []*ArpDetails
+	err  error
+}
+
+// GetARPEntries reads all configured static ARP entries for given interface.
+// <interfaceIdx> works as filter, if set to zero, all arp entries in the namespace
+// are returned
+func (h *NetLinkHandler) GetARPEntries(interfaceIdx int) ([]netlink.Neigh, error) {
+	return netlink.NeighList(interfaceIdx, 0)
+}
+
+// DumpARPEntries reads all ARP entries and returns them as details
+// with proto-modeled ARP data and additional metadata
+func (h *NetLinkHandler) DumpARPEntries() ([]*ArpDetails, error) {
+	interfaces := h.ifIndexes.ListAllInterfaces()
+	goRoutinesCnt := len(interfaces) / minWorkForGoRoutine
+	if goRoutinesCnt == 0 {
+		goRoutinesCnt = 1
+	}
+	if goRoutinesCnt > h.goRoutineCount {
+		goRoutinesCnt = h.goRoutineCount
+	}
+	ch := make(chan retrievedARPs, goRoutinesCnt)
+
+	// invoke multiple go routines for more efficient parallel ARP retrieval
+	for idx := 0; idx < goRoutinesCnt; idx++ {
+		if goRoutinesCnt > 1 {
+			go h.retrieveARPs(interfaces, idx, goRoutinesCnt, ch)
+		} else {
+			h.retrieveARPs(interfaces, idx, goRoutinesCnt, ch)
+		}
+	}
+
+	// collect results from the go routines
+	var arpDetails []*ArpDetails
+	for idx := 0; idx < goRoutinesCnt; idx++ {
+		retrieved := <-ch
+		if retrieved.err != nil {
+			return nil, retrieved.err
+		}
+		arpDetails = append(arpDetails, retrieved.arps...)
+	}
+
+	return arpDetails, nil
+}
+
+// retrieveARPs is run by a separate go routine to retrieve all ARP entries associated
+// with every <goRoutineIdx>-th interface.
+func (h *NetLinkHandler) retrieveARPs(interfaces []string, goRoutineIdx, goRoutinesCnt int, ch chan<- retrievedARPs) {
+	var retrieved retrievedARPs
+	nsCtx := linuxcalls.NewNamespaceMgmtCtx()
+
+	for i := goRoutineIdx; i < len(interfaces); i += goRoutinesCnt {
+		ifName := interfaces[i]
+		// get interface metadata
+		ifMeta, found := h.ifIndexes.LookupByName(ifName)
+		if !found || ifMeta == nil {
+			retrieved.err = errors.Errorf("failed to obtain metadata for interface %s", ifName)
+			h.log.Error(retrieved.err)
+			break
+		}
+
+		// switch to the namespace of the interface
+		revertNs, err := h.nsPlugin.SwitchToNamespace(nsCtx, ifMeta.Namespace)
+		if err != nil {
+			// namespace and all the ARPs it had contained no longer exist
+			h.log.WithFields(logging.Fields{
+				"err":       err,
+				"namespace": ifMeta.Namespace,
+			}).Warn("Failed to retrieve ARPs from the namespace")
+			continue
+		}
+
+		// get ARPs assigned to this interface
+		arps, err := h.GetARPEntries(ifMeta.LinuxIfIndex)
+		revertNs()
+		if err != nil {
+			retrieved.err = err
+			h.log.Error(retrieved.err)
+			break
+		}
+
+		// convert each ARP from Netlink representation to the ARP details
+		for _, arp := range arps {
+			if arp.IP.IsLinkLocalMulticast() {
+				// skip link-local multi-cast ARPs until there is a requirement to support them as well
+				continue
+			}
+			retrieved.arps = append(retrieved.arps, &ArpDetails{
+				ARP: &linux_l3.ARPEntry{
+					Interface: ifName,
+					IpAddress: arp.IP.String(),
+					HwAddress: arp.HardwareAddr.String(),
+				},
+				Meta: &ArpMeta{},
+			})
+		}
+	}
+
+	ch <- retrieved
+}

--- a/plugins/linux/l3plugin/linuxcalls/dump_l3_linuxcalls.go
+++ b/plugins/linux/l3plugin/linuxcalls/dump_l3_linuxcalls.go
@@ -1,0 +1,276 @@
+// Copyright (c) 2017 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows,!darwin
+
+package linuxcalls
+
+import (
+	"github.com/ligato/cn-infra/logging"
+	"github.com/pkg/errors"
+	"github.com/vishvananda/netlink"
+	"go.ligato.io/vpp-agent/v2/plugins/linux/nsplugin/linuxcalls"
+	linux_l3 "go.ligato.io/vpp-agent/v2/proto/ligato/linux/l3"
+)
+
+const (
+	// IP addresses matching any destination.
+	IPv4AddrAny = "0.0.0.0"
+	IPv6AddrAny = "::"
+
+	// minimum number of interfaces to be given to a single Go routine for processing
+	// in the Retrieve operation
+	minWorkForGoRoutine = 3
+)
+
+// retrievedARPs is used as the return value sent via channel by retrieveARPs().
+type retrievedARPs struct {
+	arps []*ArpDetails
+	err  error
+}
+
+// retrievedRoutes is used as the return value sent via channel by retrieveRoutes().
+type retrievedRoutes struct {
+	routes []*RouteDetails
+	err    error
+}
+
+// GetARPEntries reads all configured static ARP entries for given interface.
+// <interfaceIdx> works as filter, if set to zero, all arp entries in the namespace
+// are returned
+func (h *NetLinkHandler) GetARPEntries(interfaceIdx int) ([]netlink.Neigh, error) {
+	return netlink.NeighList(interfaceIdx, 0)
+}
+
+// DumpARPEntries reads all ARP entries and returns them as details
+// with proto-modeled ARP data and additional metadata
+func (h *NetLinkHandler) DumpARPEntries() ([]*ArpDetails, error) {
+	interfaces := h.ifIndexes.ListAllInterfaces()
+	goRoutinesCnt := len(interfaces) / minWorkForGoRoutine
+	if goRoutinesCnt == 0 {
+		goRoutinesCnt = 1
+	}
+	if goRoutinesCnt > h.goRoutineCount {
+		goRoutinesCnt = h.goRoutineCount
+	}
+	ch := make(chan retrievedARPs, goRoutinesCnt)
+
+	// invoke multiple go routines for more efficient parallel ARP retrieval
+	for idx := 0; idx < goRoutinesCnt; idx++ {
+		if goRoutinesCnt > 1 {
+			go h.retrieveARPs(interfaces, idx, goRoutinesCnt, ch)
+		} else {
+			h.retrieveARPs(interfaces, idx, goRoutinesCnt, ch)
+		}
+	}
+
+	// collect results from the go routines
+	var arpDetails []*ArpDetails
+	for idx := 0; idx < goRoutinesCnt; idx++ {
+		retrieved := <-ch
+		if retrieved.err != nil {
+			return nil, retrieved.err
+		}
+		for _, linuxArp := range retrieved.arps {
+			arpDetails = append(arpDetails, linuxArp)
+		}
+	}
+
+	return arpDetails, nil
+}
+
+// GetRoutes reads all configured static routes with the given outgoing
+// interface.
+// <interfaceIdx> works as filter, if set to zero, all routes in the namespace
+// are returned.
+func (h *NetLinkHandler) GetRoutes(interfaceIdx int) (v4Routes, v6Routes []netlink.Route, err error) {
+	var link netlink.Link
+	if interfaceIdx != 0 {
+		// netlink.RouteList reads only link index
+		link = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Index: interfaceIdx}}
+	}
+
+	v4Routes, err = netlink.RouteList(link, netlink.FAMILY_V4)
+	if err != nil {
+		return
+	}
+	v6Routes, err = netlink.RouteList(link, netlink.FAMILY_V6)
+	return
+}
+
+// DumpRoutes reads all route entries and returns them as details
+// with proto-modeled route data and additional metadata
+func (h *NetLinkHandler) DumpRoutes() ([]*RouteDetails, error) {
+	interfaces := h.ifIndexes.ListAllInterfaces()
+	goRoutinesCnt := len(interfaces) / minWorkForGoRoutine
+	if goRoutinesCnt == 0 {
+		goRoutinesCnt = 1
+	}
+	if goRoutinesCnt > h.goRoutineCount {
+		goRoutinesCnt = h.goRoutineCount
+	}
+	ch := make(chan retrievedRoutes, goRoutinesCnt)
+
+	// invoke multiple go routines for more efficient parallel route retrieval
+	for idx := 0; idx < goRoutinesCnt; idx++ {
+		if goRoutinesCnt > 1 {
+			go h.retrieveRoutes(interfaces, idx, goRoutinesCnt, ch)
+		} else {
+			h.retrieveRoutes(interfaces, idx, goRoutinesCnt, ch)
+		}
+	}
+
+	// collect results from the go routines
+	var routeDetails []*RouteDetails
+	for idx := 0; idx < goRoutinesCnt; idx++ {
+		retrieved := <-ch
+		if retrieved.err != nil {
+			return nil, retrieved.err
+		}
+		// correlate with the expected configuration
+		for _, routeDetail := range retrieved.routes {
+			routeDetails = append(routeDetails, routeDetail)
+		}
+	}
+
+	return routeDetails, nil
+}
+
+// retrieveARPs is run by a separate go routine to retrieve all ARP entries associated
+// with every <goRoutineIdx>-th interface.
+func (h *NetLinkHandler) retrieveARPs(interfaces []string, goRoutineIdx, goRoutinesCnt int, ch chan<- retrievedARPs) {
+	var retrieved retrievedARPs
+	nsCtx := linuxcalls.NewNamespaceMgmtCtx()
+
+	for i := goRoutineIdx; i < len(interfaces); i += goRoutinesCnt {
+		ifName := interfaces[i]
+		// get interface metadata
+		ifMeta, found := h.ifIndexes.LookupByName(ifName)
+		if !found || ifMeta == nil {
+			retrieved.err = errors.Errorf("failed to obtain metadata for interface %s", ifName)
+			h.log.Error(retrieved.err)
+			break
+		}
+
+		// switch to the namespace of the interface
+		revertNs, err := h.nsPlugin.SwitchToNamespace(nsCtx, ifMeta.Namespace)
+		if err != nil {
+			// namespace and all the ARPs it had contained no longer exist
+			h.log.WithFields(logging.Fields{
+				"err":       err,
+				"namespace": ifMeta.Namespace,
+			}).Warn("Failed to retrieve ARPs from the namespace")
+			continue
+		}
+
+		// get ARPs assigned to this interface
+		arps, err := h.GetARPEntries(ifMeta.LinuxIfIndex)
+		revertNs()
+		if err != nil {
+			retrieved.err = err
+			h.log.Error(retrieved.err)
+			break
+		}
+
+		// convert each ARP from Netlink representation to the ARP details
+		for _, arp := range arps {
+			if arp.IP.IsLinkLocalMulticast() {
+				// skip link-local multi-cast ARPs until there is a requirement to support them as well
+				continue
+			}
+			retrieved.arps = append(retrieved.arps, &ArpDetails{
+				ARP: &linux_l3.ARPEntry{
+					Interface: ifName,
+					IpAddress: arp.IP.String(),
+					HwAddress: arp.HardwareAddr.String(),
+				},
+				Meta: &ArpMeta{},
+			})
+		}
+	}
+
+	ch <- retrieved
+}
+
+// retrieveRoutes is run by a separate go routine to retrieve all routes entries
+// associated with every <goRoutineIdx>-th interface.
+func (h *NetLinkHandler) retrieveRoutes(interfaces []string, goRoutineIdx, goRoutinesCnt int, ch chan<- retrievedRoutes) {
+	var retrieved retrievedRoutes
+	nsCtx := linuxcalls.NewNamespaceMgmtCtx()
+
+	for i := goRoutineIdx; i < len(interfaces); i += goRoutinesCnt {
+		ifName := interfaces[i]
+		// get interface metadata
+		ifMeta, found := h.ifIndexes.LookupByName(ifName)
+		if !found || ifMeta == nil {
+			retrieved.err = errors.Errorf("failed to obtain metadata for interface %s", ifName)
+			h.log.Error(retrieved.err)
+			break
+		}
+
+		// switch to the namespace of the interface
+		revertNs, err := h.nsPlugin.SwitchToNamespace(nsCtx, ifMeta.Namespace)
+		if err != nil {
+			// namespace and all the routes it had contained no longer exist
+			h.log.WithFields(logging.Fields{
+				"err":       err,
+				"namespace": ifMeta.Namespace,
+			}).Warn("Failed to retrieve routes from the namespace")
+			continue
+		}
+
+		// get routes assigned to this interface
+		v4Routes, v6Routes, err := h.GetRoutes(ifMeta.LinuxIfIndex)
+		revertNs()
+		if err != nil {
+			retrieved.err = err
+			h.log.Error(retrieved.err)
+			break
+		}
+
+		// convert each route from Netlink representation to the NB representation
+		for idx, route := range append(v4Routes, v6Routes...) {
+			var dstNet, gwAddr string
+			if route.Dst == nil {
+				if idx < len(v4Routes) {
+					dstNet = IPv4AddrAny + "/0"
+				} else {
+					dstNet = IPv6AddrAny + "/0"
+				}
+			} else {
+				if route.Dst.IP.To4() == nil && route.Dst.IP.IsLinkLocalUnicast() {
+					// skip link-local IPv6 destinations until there is a requirement to support them
+					continue
+				}
+				dstNet = route.Dst.String()
+			}
+			if len(route.Gw) != 0 {
+				gwAddr = route.Gw.String()
+			}
+			retrieved.routes = append(retrieved.routes, &RouteDetails{
+				Route: &linux_l3.Route{
+					OutgoingInterface: ifName,
+					DstNetwork:        dstNet,
+					GwAddr:            gwAddr,
+					Metric:            uint32(route.Priority),
+				},
+				Meta: &RouteMeta{
+					NetlinkScope: route.Scope,
+				},
+			})
+		}
+	}
+
+	ch <- retrieved
+}

--- a/plugins/linux/l3plugin/linuxcalls/dump_route_linuxcalls.go
+++ b/plugins/linux/l3plugin/linuxcalls/dump_route_linuxcalls.go
@@ -158,7 +158,10 @@ func (h *NetLinkHandler) retrieveRoutes(interfaces []string, goRoutineIdx, goRou
 					Metric:            uint32(route.Priority),
 				},
 				Meta: &RouteMeta{
-					NetlinkScope: route.Scope,
+					InterfaceIndex: uint32(route.LinkIndex),
+					NetlinkScope:   route.Scope,
+					Protocol:       uint32(route.Protocol),
+					MTU:            uint32(route.MTU),
 				},
 			})
 		}

--- a/plugins/linux/l3plugin/linuxcalls/netlink_api.go
+++ b/plugins/linux/l3plugin/linuxcalls/netlink_api.go
@@ -25,12 +25,15 @@ import (
 // ArpDetails is an object combining linux ARP data based on proto
 // model with additional metadata
 type ArpDetails struct {
-	ARP  *linux.ARPEntry
-	Meta *ArpMeta
+	ARP  *linux.ARPEntry `json:"linux_arp"`
+	Meta *ArpMeta        `json:"linux_arp_meta"`
 }
 
 // ArpMeta represents linux ARP metadata
 type ArpMeta struct {
+	InterfaceIndex uint32 `json:"interface_index"`
+	IPFamily       uint32 `json:"ip_family"`
+	VNI            uint32 `json:"vni"`
 }
 
 // RouteDetails is an object combining linux route data based on proto
@@ -42,7 +45,10 @@ type RouteDetails struct {
 
 // RouteMeta represents linux Route metadata
 type RouteMeta struct {
-	NetlinkScope netlink.Scope
+	InterfaceIndex uint32        `json:"interface_index"`
+	NetlinkScope   netlink.Scope `json:"link_scope"`
+	Protocol       uint32        `json:"protocol"`
+	MTU            uint32        `json:"mtu"`
 }
 
 // NetlinkAPI interface covers all methods inside linux calls package needed

--- a/plugins/linux/l3plugin/linuxcalls/route_linuxcalls.go
+++ b/plugins/linux/l3plugin/linuxcalls/route_linuxcalls.go
@@ -34,22 +34,3 @@ func (h *NetLinkHandler) ReplaceRoute(route *netlink.Route) error {
 func (h *NetLinkHandler) DelRoute(route *netlink.Route) error {
 	return netlink.RouteDel(route)
 }
-
-// GetRoutes reads all configured static routes with the given outgoing
-// interface.
-// <interfaceIdx> works as filter, if set to zero, all routes in the namespace
-// are returned.
-func (h *NetLinkHandler) GetRoutes(interfaceIdx int) (v4Routes, v6Routes []netlink.Route, err error) {
-	var link netlink.Link
-	if interfaceIdx != 0 {
-		// netlink.RouteList reads only link index
-		link = &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Index: interfaceIdx}}
-	}
-
-	v4Routes, err = netlink.RouteList(link, netlink.FAMILY_V4)
-	if err != nil {
-		return
-	}
-	v6Routes, err = netlink.RouteList(link, netlink.FAMILY_V6)
-	return
-}

--- a/plugins/linux/nsplugin/ns_plugin.go
+++ b/plugins/linux/nsplugin/ns_plugin.go
@@ -62,12 +62,12 @@ type Config struct {
 	Disabled bool `json:"disabled"`
 }
 
-// unavailableMicroserviceErr is error implementation used when a given microservice is not deployed.
-type unavailableMicroserviceErr struct {
+// UnavailableMicroserviceErr is error implementation used when a given microservice is not deployed.
+type UnavailableMicroserviceErr struct {
 	label string
 }
 
-func (e *unavailableMicroserviceErr) Error() string {
+func (e *UnavailableMicroserviceErr) Error() string {
 	return fmt.Sprintf("Microservice '%s' is not available", e.label)
 }
 
@@ -135,7 +135,7 @@ func (p *NsPlugin) GetNamespaceHandle(ctx nsLinuxcalls.NamespaceMgmtCtx, namespa
 		reference := namespace.Reference
 		namespace = p.convertMicroserviceNsToPidNs(reference)
 		if namespace == nil {
-			return 0, &unavailableMicroserviceErr{label: reference}
+			return 0, &UnavailableMicroserviceErr{label: reference}
 		}
 	}
 

--- a/plugins/restapi/handlers.go
+++ b/plugins/restapi/handlers.go
@@ -213,27 +213,23 @@ func (p *Plugin) registerPuntHandlers() {
 func (p *Plugin) registerLinuxInterfaceHandlers() {
 	// GET linux interfaces
 	p.registerHTTPHandler(resturl.LinuxInterface, GET, func() (interface{}, error) {
-		return p.linuxIfHandler.GetLinkList()
+		return p.linuxIfHandler.DumpInterfaces()
 	})
 	// GET linux interface stats
-	/*p.registerHTTPHandler(resturl.LinuxInterfaceStats, GET, func() (interface{}, error) {
-		return p.linuxIfHandler.DumpInterfaceStatistics()
-	})*/
+	p.registerHTTPHandler(resturl.LinuxInterfaceStats, GET, func() (interface{}, error) {
+		return p.linuxIfHandler.DumpInterfaceStats()
+	})
 }
 
 // Registers linux L3 plugin REST handlers
 func (p *Plugin) registerLinuxL3Handlers() {
 	// GET linux routes
 	p.registerHTTPHandler(resturl.LinuxRoutes, GET, func() (interface{}, error) {
-		routes4, routes6, err := p.linuxL3Handler.GetRoutes(0)
-		if err != nil {
-			return nil, err
-		}
-		return append(routes4, routes6...), nil
+		return p.linuxL3Handler.DumpRoutes()
 	})
 	// GET linux ARPs
 	p.registerHTTPHandler(resturl.LinuxArps, GET, func() (interface{}, error) {
-		return p.linuxL3Handler.GetARPEntries(0)
+		return p.linuxL3Handler.DumpARPEntries()
 	})
 }
 

--- a/plugins/restapi/options.go
+++ b/plugins/restapi/options.go
@@ -16,13 +16,16 @@ package restapi
 
 import (
 	"github.com/ligato/cn-infra/rpc/rest"
-	"go.ligato.io/vpp-agent/v2/plugins/vpp/l3plugin"
+	"github.com/ligato/cn-infra/servicelabel"
 
 	"go.ligato.io/vpp-agent/v2/plugins/govppmux"
+	linuxifplugin "go.ligato.io/vpp-agent/v2/plugins/linux/ifplugin"
+	"go.ligato.io/vpp-agent/v2/plugins/linux/nsplugin"
 	"go.ligato.io/vpp-agent/v2/plugins/netalloc"
 	"go.ligato.io/vpp-agent/v2/plugins/vpp/aclplugin"
 	"go.ligato.io/vpp-agent/v2/plugins/vpp/ifplugin"
 	"go.ligato.io/vpp-agent/v2/plugins/vpp/l2plugin"
+	"go.ligato.io/vpp-agent/v2/plugins/vpp/l3plugin"
 )
 
 // DefaultPlugin is a default instance of Plugin.
@@ -35,11 +38,14 @@ func NewPlugin(opts ...Option) *Plugin {
 	p.PluginName = "restpapi"
 	p.HTTPHandlers = &rest.DefaultPlugin
 	p.GoVppmux = &govppmux.DefaultPlugin
+	p.ServiceLabel = &servicelabel.DefaultPlugin
 	p.AddrAlloc = &netalloc.DefaultPlugin
 	p.VPPACLPlugin = &aclplugin.DefaultPlugin
 	p.VPPIfPlugin = &ifplugin.DefaultPlugin
 	p.VPPL2Plugin = &l2plugin.DefaultPlugin
 	p.VPPL3Plugin = &l3plugin.DefaultPlugin
+	p.LinuxIfPlugin = &linuxifplugin.DefaultPlugin
+	p.NsPlugin = &nsplugin.DefaultPlugin
 
 	for _, o := range opts {
 		o(p)

--- a/plugins/restapi/plugin_restapi.go
+++ b/plugins/restapi/plugin_restapi.go
@@ -179,7 +179,7 @@ func (p *Plugin) Init() (err error) {
 	// Linux handlers
 	p.linuxIfHandler = iflinuxcalls.NewNetLinkHandler(p.NsPlugin, linuxIfIndexes, p.ServiceLabel.GetAgentPrefix(),
 		defaultGoRoutineCount, p.Log)
-	p.linuxL3Handler = l3linuxcalls.NewNetLinkHandler()
+	p.linuxL3Handler = l3linuxcalls.NewNetLinkHandler(p.NsPlugin, linuxIfIndexes, defaultGoRoutineCount, p.Log)
 
 	p.index = &index{
 		ItemMap: getIndexPageItems(),

--- a/plugins/restapi/plugin_restapi.go
+++ b/plugins/restapi/plugin_restapi.go
@@ -18,6 +18,9 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/ligato/cn-infra/servicelabel"
+	"go.ligato.io/vpp-agent/v2/plugins/linux/nsplugin"
+
 	"git.fd.io/govpp.git/api"
 	"github.com/ligato/cn-infra/infra"
 	"github.com/ligato/cn-infra/rpc/rest"
@@ -26,6 +29,7 @@ import (
 
 	"go.ligato.io/vpp-agent/v2/plugins/govppmux"
 	vpevppcalls "go.ligato.io/vpp-agent/v2/plugins/govppmux/vppcalls"
+	linuxifplugin "go.ligato.io/vpp-agent/v2/plugins/linux/ifplugin"
 	iflinuxcalls "go.ligato.io/vpp-agent/v2/plugins/linux/ifplugin/linuxcalls"
 	l3linuxcalls "go.ligato.io/vpp-agent/v2/plugins/linux/l3plugin/linuxcalls"
 	"go.ligato.io/vpp-agent/v2/plugins/netalloc"
@@ -50,6 +54,9 @@ const (
 	GET  = http.MethodGet
 	POST = http.MethodPost
 )
+
+// Default Go routine count used to retrieve linux configuration
+const defaultGoRoutineCount = 10
 
 // Plugin registers Rest Plugin
 type Plugin struct {
@@ -83,13 +90,16 @@ type Plugin struct {
 // Deps represents dependencies of Rest Plugin
 type Deps struct {
 	infra.PluginDeps
-	HTTPHandlers rest.HTTPHandlers
-	GoVppmux     govppmux.StatsAPI
-	AddrAlloc    netalloc.AddressAllocator
-	VPPACLPlugin aclplugin.API
-	VPPIfPlugin  ifplugin.API
-	VPPL2Plugin  *l2plugin.L2Plugin
-	VPPL3Plugin  *l3plugin.L3Plugin
+	HTTPHandlers  rest.HTTPHandlers
+	GoVppmux      govppmux.StatsAPI
+	ServiceLabel  servicelabel.ReaderAPI
+	AddrAlloc     netalloc.AddressAllocator
+	VPPACLPlugin  aclplugin.API
+	VPPIfPlugin   ifplugin.API
+	VPPL2Plugin   *l2plugin.L2Plugin
+	VPPL3Plugin   *l3plugin.L3Plugin
+	LinuxIfPlugin linuxifplugin.API
+	NsPlugin      nsplugin.API
 }
 
 // index defines map of main index page entries
@@ -116,6 +126,9 @@ func (p *Plugin) Init() (err error) {
 	dhcpIndexes := p.VPPIfPlugin.GetDHCPIndex()
 	aclIndexes := p.VPPACLPlugin.GetACLIndex() // TODO: make ACL optional
 	vrfIndexes := p.VPPL3Plugin.GetVRFIndex()
+
+	// Linux Indexes
+	linuxIfIndexes := p.LinuxIfPlugin.GetInterfaceIndex()
 
 	// Initialize VPP handlers
 	p.vpeHandler = vpevppcalls.CompatibleVpeHandler(p.vppChan)
@@ -164,7 +177,8 @@ func (p *Plugin) Init() (err error) {
 	}
 
 	// Linux handlers
-	p.linuxIfHandler = iflinuxcalls.NewNetLinkHandler()
+	p.linuxIfHandler = iflinuxcalls.NewNetLinkHandler(p.NsPlugin, linuxIfIndexes, p.ServiceLabel.GetAgentPrefix(),
+		defaultGoRoutineCount, p.Log)
 	p.linuxL3Handler = l3linuxcalls.NewNetLinkHandler()
 
 	p.index = &index{

--- a/plugins/restapi/resturl/urls.go
+++ b/plugins/restapi/resturl/urls.go
@@ -128,6 +128,8 @@ const (
 	Tracer = "/vpp/binapitrace"
 	// Configurator stats
 	ConfiguratorStats = "/stats/configurator"
+	// Linux interface stats
+	LinuxInterfaceStats = "/stats/linux/interfaces"
 )
 
 // Index

--- a/plugins/vpp/ifplugin/descriptor/interface_crud.go
+++ b/plugins/vpp/ifplugin/descriptor/interface_crud.go
@@ -433,6 +433,11 @@ func (d *InterfaceDescriptor) Retrieve(correlate []adapter.InterfaceKVWithMetada
 				// that the retrieved value was generated before and the original host name
 				// was empty.
 				intf.Interface.GetTap().HostIfName = ""
+				// VPP 1904 BUG - host name is sometimes not properly dumped, use generated
+				// value for metadata
+				// TODO remove with VPP 1904 support drop
+			} else if tapHostIfName == "" {
+				tapHostIfName = generateTAPHostName(intf.Interface.Name)
 			}
 		}
 

--- a/plugins/vpp/ifplugin/descriptor/interface_crud.go
+++ b/plugins/vpp/ifplugin/descriptor/interface_crud.go
@@ -14,7 +14,6 @@ import (
 
 // Create creates a VPP interface.
 func (d *InterfaceDescriptor) Create(key string, intf *interfaces.Interface) (metadata *ifaceidx.IfaceMetadata, err error) {
-	d.log.Warnf(">>>>>>>>>>>>>>> Create name: %v, type: %v, metadata: %v", intf.Name, intf.Type, metadata)
 	var ifIdx uint32
 	var tapHostIfName string
 

--- a/plugins/vpp/ifplugin/descriptor/interface_crud.go
+++ b/plugins/vpp/ifplugin/descriptor/interface_crud.go
@@ -14,6 +14,7 @@ import (
 
 // Create creates a VPP interface.
 func (d *InterfaceDescriptor) Create(key string, intf *interfaces.Interface) (metadata *ifaceidx.IfaceMetadata, err error) {
+	d.log.Warnf(">>>>>>>>>>>>>>> Create name: %v, type: %v, metadata: %v", intf.Name, intf.Type, metadata)
 	var ifIdx uint32
 	var tapHostIfName string
 
@@ -429,7 +430,9 @@ func (d *InterfaceDescriptor) Retrieve(correlate []adapter.InterfaceKVWithMetada
 		if intf.Interface.Type == interfaces.Interface_TAP {
 			tapHostIfName = intf.Interface.GetTap().GetHostIfName()
 			if generateTAPHostName(intf.Interface.Name) == tapHostIfName {
-				// interface host name was unset
+				// if a generated TAP host name matches the dumped one, there is a premise
+				// that the retrieved value was generated before and the original host name
+				// was empty.
 				intf.Interface.GetTap().HostIfName = ""
 			}
 		}
@@ -440,13 +443,14 @@ func (d *InterfaceDescriptor) Retrieve(correlate []adapter.InterfaceKVWithMetada
 				intf.Interface.GetTap().ToMicroservice = expCfg.GetTap().GetToMicroservice()
 				intf.Interface.GetTap().RxRingSize = expCfg.GetTap().GetRxRingSize()
 				intf.Interface.GetTap().TxRingSize = expCfg.GetTap().GetTxRingSize()
-				// FIXME: VPP BUG - TAPv2 host name is sometimes not properly dumped
 				// (seemingly uninitialized section of memory is returned)
 				if intf.Interface.GetTap().GetVersion() == 2 {
 					intf.Interface.GetTap().HostIfName = expCfg.GetTap().GetHostIfName()
-					tapHostIfName = expCfg.GetTap().GetHostIfName()
+					// set host name in metadata from NB data if defined
+					if intf.Interface.GetTap().HostIfName != "" {
+						tapHostIfName = expCfg.GetTap().GetHostIfName()
+					}
 				}
-
 			}
 			if expCfg.Type == interfaces.Interface_MEMIF && intf.Interface.GetMemif() != nil {
 				intf.Interface.GetMemif().Secret = expCfg.GetMemif().GetSecret()

--- a/plugins/vpp/ifplugin/ifplugin.go
+++ b/plugins/vpp/ifplugin/ifplugin.go
@@ -26,6 +26,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ligato/cn-infra/servicelabel"
+
 	govppapi "git.fd.io/govpp.git/api"
 	"github.com/ligato/cn-infra/datasync"
 	"github.com/ligato/cn-infra/health/statuscheck"
@@ -50,6 +52,9 @@ import (
 	_ "go.ligato.io/vpp-agent/v2/plugins/vpp/ifplugin/vppcalls/vpp2001"
 	_ "go.ligato.io/vpp-agent/v2/plugins/vpp/ifplugin/vppcalls/vpp2001_324"
 )
+
+// Default Go routine count used while retrieving linux configuration
+const goRoutineCount = 10
 
 // IfPlugin configures VPP interfaces using GoVPP.
 type IfPlugin struct {
@@ -92,9 +97,10 @@ type IfPlugin struct {
 // Deps lists dependencies of the interface plugin.
 type Deps struct {
 	infra.PluginDeps
-	KVScheduler kvs.KVScheduler
-	GoVppmux    govppmux.StatsAPI
-	AddrAlloc   netalloc.AddressAllocator
+	KVScheduler  kvs.KVScheduler
+	GoVppmux     govppmux.StatsAPI
+	ServiceLabel servicelabel.ReaderAPI
+	AddrAlloc    netalloc.AddressAllocator
 
 	/*	LinuxIfPlugin and NsPlugin deps are optional,
 		but they are required if AFPacket or TAP+TAP_TO_VPP interfaces are used. */
@@ -133,7 +139,8 @@ func (p *IfPlugin) Init() (err error) {
 	// init handlers
 	p.ifHandler = vppcalls.CompatibleInterfaceVppHandler(p.vppCh, p.Log)
 	if p.LinuxIfPlugin != nil {
-		p.linuxIfHandler = linux_ifcalls.NewNetLinkHandler()
+		p.linuxIfHandler = linux_ifcalls.NewNetLinkHandler(p.NsPlugin, p.LinuxIfPlugin.GetInterfaceIndex(),
+			p.ServiceLabel.GetAgentPrefix(), goRoutineCount, p.Log)
 	}
 
 	// init & register descriptors

--- a/plugins/vpp/ifplugin/options.go
+++ b/plugins/vpp/ifplugin/options.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ligato/cn-infra/config"
 	"github.com/ligato/cn-infra/health/statuscheck"
 	"github.com/ligato/cn-infra/logging"
+	"github.com/ligato/cn-infra/servicelabel"
 	"go.ligato.io/vpp-agent/v2/plugins/govppmux"
 	"go.ligato.io/vpp-agent/v2/plugins/kvscheduler"
 	"go.ligato.io/vpp-agent/v2/plugins/netalloc"
@@ -34,6 +35,7 @@ func NewPlugin(opts ...Option) *IfPlugin {
 	p.StatusCheck = &statuscheck.DefaultPlugin
 	p.KVScheduler = &kvscheduler.DefaultPlugin
 	p.GoVppmux = &govppmux.DefaultPlugin
+	p.ServiceLabel = &servicelabel.DefaultPlugin
 	p.AddrAlloc = &netalloc.DefaultPlugin
 
 	for _, o := range opts {

--- a/tests/e2e/010_interfaces_test.go
+++ b/tests/e2e/010_interfaces_test.go
@@ -26,8 +26,6 @@ import (
 	vpp_interfaces "go.ligato.io/vpp-agent/v2/proto/ligato/vpp/interfaces"
 )
 
-// TODO: running downstream resync in-between restarts/re-creates seems to break stuff (for now commented out)
-
 // connect VPP with a microservice via TAP interface
 func TestTapInterfaceConn(t *testing.T) {
 	ctx := setupE2E(t)
@@ -91,16 +89,14 @@ func TestTapInterfaceConn(t *testing.T) {
 		Eventually(ctx.getValueStateClb(vppTap)).Should(Equal(kvscheduler.ValueState_PENDING))
 		Eventually(ctx.getValueStateClb(linuxTap)).Should(Equal(kvscheduler.ValueState_PENDING))
 		Expect(ctx.pingFromVPP(linuxTapIP)).NotTo(Succeed())
-
-		//Expect(ctx.agentInSync()).To(BeTrue())
+		Expect(ctx.agentInSync()).To(BeTrue())
 
 		ctx.startMicroservice(msName)
 		Eventually(ctx.getValueStateClb(vppTap)).Should(Equal(kvscheduler.ValueState_CONFIGURED))
 		Expect(ctx.getValueState(linuxTap)).To(Equal(kvscheduler.ValueState_CONFIGURED))
 		Expect(ctx.pingFromVPP(linuxTapIP)).To(Succeed())
 		Expect(ctx.pingFromMs(msName, vppTapIP)).To(Succeed())
-
-		//Expect(ctx.agentInSync()).To(BeTrue())
+		Expect(ctx.agentInSync()).To(BeTrue())
 	}
 
 	// re-create VPP TAP
@@ -121,7 +117,7 @@ func TestTapInterfaceConn(t *testing.T) {
 
 	Eventually(ctx.pingFromVPPClb(linuxTapIP)).Should(Succeed())
 	Expect(ctx.pingFromMs(msName, vppTapIP)).To(Succeed())
-	//Expect(ctx.agentInSync()).To(BeTrue())
+	Expect(ctx.agentInSync()).To(BeTrue())
 
 	// re-create Linux TAP
 	req = ctx.grpcClient.ChangeRequest()
@@ -141,7 +137,7 @@ func TestTapInterfaceConn(t *testing.T) {
 
 	Eventually(ctx.pingFromVPPClb(linuxTapIP)).Should(Succeed())
 	Expect(ctx.pingFromMs(msName, vppTapIP)).To(Succeed())
-	//Expect(ctx.agentInSync()).To(BeTrue())
+	Expect(ctx.agentInSync()).To(BeTrue())
 }
 
 // connect VPP with a microservice via AF-PACKET + VETH interfaces
@@ -222,8 +218,7 @@ func TestAfPacketInterfaceConn(t *testing.T) {
 		Eventually(ctx.getValueStateClb(veth1)).Should(Equal(kvscheduler.ValueState_PENDING))
 		Eventually(ctx.getValueStateClb(veth2)).Should(Equal(kvscheduler.ValueState_PENDING))
 		Expect(ctx.pingFromVPP(veth2IP)).NotTo(Succeed())
-
-		//Expect(ctx.agentInSync()).To(BeTrue())
+		Expect(ctx.agentInSync()).To(BeTrue())
 
 		ctx.startMicroservice(msName)
 		Eventually(ctx.getValueStateClb(afPacket)).Should(Equal(kvscheduler.ValueState_CONFIGURED))
@@ -231,8 +226,7 @@ func TestAfPacketInterfaceConn(t *testing.T) {
 		Expect(ctx.getValueState(veth2)).To(Equal(kvscheduler.ValueState_CONFIGURED))
 		Expect(ctx.pingFromVPP(veth2IP)).To(Succeed())
 		Expect(ctx.pingFromMs(msName, afPacketIP)).To(Succeed())
-
-		//Expect(ctx.agentInSync()).To(BeTrue())
+		Expect(ctx.agentInSync()).To(BeTrue())
 	}
 
 	// re-create AF-PACKET
@@ -253,7 +247,7 @@ func TestAfPacketInterfaceConn(t *testing.T) {
 
 	Eventually(ctx.pingFromVPPClb(veth2IP)).Should(Succeed())
 	Expect(ctx.pingFromMs(msName, afPacketIP)).To(Succeed())
-	//Expect(ctx.agentInSync()).To(BeTrue())
+	Expect(ctx.agentInSync()).To(BeTrue())
 
 	// re-create VETH
 	req = ctx.grpcClient.ChangeRequest()
@@ -273,5 +267,5 @@ func TestAfPacketInterfaceConn(t *testing.T) {
 
 	Eventually(ctx.pingFromVPPClb(veth2IP)).Should(Succeed())
 	Expect(ctx.pingFromMs(msName, afPacketIP)).To(Succeed())
-	//Expect(ctx.agentInSync()).To(BeTrue())
+	Expect(ctx.agentInSync()).To(BeTrue())
 }


### PR DESCRIPTION
* Linux interface, ARP and route descriptor have dedicated `dump` method in the linuxcalls. The simple `get` (calling netlink API) was kept untouched. 
* Linux interface API offers methods to dump Linux interfaces from namespaces provided in the form of a parameter `nsList`, or call simple `DumpInterfaces()` to obtain all known interfaces from the default namespace and also from other namespaces known to the agent (via local cache).
* Method `DumpInterfaceStats()` retrieves interface statistics (in the similar manner as for VPP). Since there is currently no protobuf model for these data, they are not available for the GRPC.
* GRPC and HTTP handlers are using new methods to retrieve data (which means that the respective HTTP call does not read all the Linux interfaces from the default namespace, but all Linux interfaces configured by the agent from all namespaces).

Signed-off-by: Vladimir Lavor <vlavor@cisco.com>