### PR TITLE
fix: Unnumbered interface name

### DIFF
--- a/plugins/vpp/ifplugin/descriptor/interface.go
+++ b/plugins/vpp/ifplugin/descriptor/interface.go
@@ -60,10 +60,6 @@ const (
 	//  - determined by much fits into the VPP interface tag (64 null-terminated character string)
 	logicalNameLengthLimit = 63
 
-	// prefix prepended to internal names of untagged interfaces to construct unique
-	// logical names
-	untaggedIfPreffix = "UNTAGGED-"
-
 	// suffix attached to logical names of dumped TAP interfaces with Linux side
 	// not found by Retrieve of Linux-ifplugin
 	tapMissingLinuxSideSuffix = "-MISSING_LINUX_SIDE"

--- a/plugins/vpp/ifplugin/descriptor/interface_crud.go
+++ b/plugins/vpp/ifplugin/descriptor/interface_crud.go
@@ -415,11 +415,6 @@ func (d *InterfaceDescriptor) Retrieve(correlate []adapter.InterfaceKVWithMetada
 				continue
 			}
 		}
-		if intf.Interface.Name == "" {
-			// untagged interface - generate a logical name for it
-			// (apart from local0 it will get removed by resync)
-			intf.Interface.Name = untaggedIfPreffix + intf.Meta.InternalName
-		}
 		if intf.Interface.Type == interfaces.Interface_BOND_INTERFACE {
 			d.bondIDs[intf.Interface.GetBond().GetId()] = intf.Interface.Name
 		}

--- a/plugins/vpp/ifplugin/descriptor/interface_crud.go
+++ b/plugins/vpp/ifplugin/descriptor/interface_crud.go
@@ -74,6 +74,9 @@ func (d *InterfaceDescriptor) Create(key string, intf *interfaces.Interface) (me
 				return nil, err
 			}
 			multicastIfIdx = multicastMeta.SwIfIndex
+		} else {
+			// not a multicast tunnel
+			multicastIfIdx = 0xFFFFFFFF
 		}
 
 		if intf.GetVxlan().Gpe == nil {
@@ -166,6 +169,9 @@ func (d *InterfaceDescriptor) Create(key string, intf *interfaces.Interface) (me
 				return nil, err
 			}
 			multicastIfIdx = multicastMeta.SwIfIndex
+		} else {
+			// not a multicast tunnel
+			multicastIfIdx = 0xFFFFFFFF
 		}
 
 		ifIdx, err = d.ifHandler.AddGtpuTunnel(intf.Name, intf.GetGtpu(), multicastIfIdx)

--- a/plugins/vpp/ifplugin/vppcalls/vpp1904/dump_interface_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp1904/dump_interface_vppcalls.go
@@ -38,8 +38,14 @@ import (
 	vpp_ipsec "go.ligato.io/vpp-agent/v2/proto/ligato/vpp/ipsec"
 )
 
-// Default VPP MTU value
-const defaultVPPMtu = 9216
+const (
+	// Default VPP MTU value
+	defaultVPPMtu = 9216
+
+	// prefix prepended to internal names of untagged interfaces to construct unique
+	// logical names
+	untaggedIfPreffix = "UNTAGGED-"
+)
 
 func getMtu(vppMtu uint16) uint32 {
 	// If default VPP MTU value is set, return 0 (it means MTU was not set in the NB config)
@@ -133,6 +139,11 @@ func (h *InterfaceVppHandler) dumpInterfaces() (map[uint32]*vppcalls.InterfaceDe
 					HostIfName: strings.TrimPrefix(ifaceName, "host-"),
 				},
 			}
+		}
+		if details.Interface.Name == "" {
+			// untagged interface - generate a logical name for it
+			// (apart from local0 it will get removed by resync)
+			details.Interface.Name = untaggedIfPreffix + ifaceName
 		}
 		ifs[ifDetails.SwIfIndex] = details
 	}

--- a/plugins/vpp/ifplugin/vppcalls/vpp1908/dump_interface_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp1908/dump_interface_vppcalls.go
@@ -41,6 +41,10 @@ import (
 const (
 	// allInterfaces defines unspecified interface index
 	allInterfaces = ^uint32(0)
+
+	// prefix prepended to internal names of untagged interfaces to construct unique
+	// logical names
+	untaggedIfPreffix = "UNTAGGED-"
 )
 
 // Default VPP MTU value
@@ -145,6 +149,11 @@ func (h *InterfaceVppHandler) dumpInterfaces(ifIdxs ...uint32) (map[uint32]*vppc
 					HostIfName: strings.TrimPrefix(ifaceName, "host-"),
 				},
 			}
+		}
+		if details.Interface.Name == "" {
+			// untagged interface - generate a logical name for it
+			// (apart from local0 it will get removed by resync)
+			details.Interface.Name = untaggedIfPreffix + ifaceName
 		}
 		ifs[ifDetails.SwIfIndex] = details
 	}

--- a/plugins/vpp/ifplugin/vppcalls/vpp2001/dump_interface_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp2001/dump_interface_vppcalls.go
@@ -41,6 +41,10 @@ import (
 const (
 	// allInterfaces defines unspecified interface index
 	allInterfaces = ^uint32(0)
+
+	// prefix prepended to internal names of untagged interfaces to construct unique
+	// logical names
+	untaggedIfPreffix = "UNTAGGED-"
 )
 
 const (
@@ -150,6 +154,11 @@ func (h *InterfaceVppHandler) dumpInterfaces(ifIdxs ...uint32) (map[uint32]*vppc
 					HostIfName: strings.TrimPrefix(ifaceName, "host-"),
 				},
 			}
+		}
+		if details.Interface.Name == "" {
+			// untagged interface - generate a logical name for it
+			// (apart from local0 it will get removed by resync)
+			details.Interface.Name = untaggedIfPreffix + ifaceName
 		}
 		interfaces[uint32(ifDetails.SwIfIndex)] = details
 	}

--- a/plugins/vpp/ifplugin/vppcalls/vpp2001_324/dump_interface_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp2001_324/dump_interface_vppcalls.go
@@ -41,6 +41,10 @@ import (
 const (
 	// allInterfaces defines unspecified interface index
 	allInterfaces = ^uint32(0)
+
+	// prefix prepended to internal names of untagged interfaces to construct unique
+	// logical names
+	untaggedIfPreffix = "UNTAGGED-"
 )
 
 const (
@@ -150,6 +154,11 @@ func (h *InterfaceVppHandler) dumpInterfaces(ifIdxs ...uint32) (map[uint32]*vppc
 					HostIfName: strings.TrimPrefix(ifaceName, "host-"),
 				},
 			}
+		}
+		if details.Interface.Name == "" {
+			// untagged interface - generate a logical name for it
+			// (apart from local0 it will get removed by resync)
+			details.Interface.Name = untaggedIfPreffix + ifaceName
 		}
 		interfaces[uint32(ifDetails.SwIfIndex)] = details
 	}

--- a/tests/integration/vpp/090_vxlan_gpe_test.go
+++ b/tests/integration/vpp/090_vxlan_gpe_test.go
@@ -31,7 +31,8 @@ func TestVxlanGpe(t *testing.T) {
 					Protocol: interfaces.VxlanLink_Gpe_IP4,
 				},
 			},
-			isFail: false,
+			mcastSwIfIndex: 0xFFFFFFFF,
+			isFail:         false,
 		},
 		{
 			name: "Create VxLAN-GPE tunnel (IP6)",
@@ -42,7 +43,8 @@ func TestVxlanGpe(t *testing.T) {
 					Protocol: interfaces.VxlanLink_Gpe_IP6,
 				},
 			},
-			isFail: false,
+			mcastSwIfIndex: 0xFFFFFFFF,
+			isFail:         false,
 		},
 		{
 			name: "Create VxLAN-GPE tunnel (Ethernet)",
@@ -53,7 +55,8 @@ func TestVxlanGpe(t *testing.T) {
 					Protocol: interfaces.VxlanLink_Gpe_ETHERNET,
 				},
 			},
-			isFail: false,
+			mcastSwIfIndex: 0xFFFFFFFF,
+			isFail:         false,
 		},
 		{
 			name: "Create VxLAN-GPE tunnel (NSH)",
@@ -64,7 +67,8 @@ func TestVxlanGpe(t *testing.T) {
 					Protocol: interfaces.VxlanLink_Gpe_NSH,
 				},
 			},
-			isFail: false,
+			mcastSwIfIndex: 0xFFFFFFFF,
+			isFail:         false,
 		},
 		{
 			name: "Create VxLAN-GPE tunnel with same source and destination",
@@ -75,7 +79,8 @@ func TestVxlanGpe(t *testing.T) {
 					Protocol: interfaces.VxlanLink_Gpe_IP4,
 				},
 			},
-			isFail: true,
+			mcastSwIfIndex: 0xFFFFFFFF,
+			isFail:         true,
 		},
 		{
 			name: "Create VxLAN-GPE tunnel with src and dst ip versions mismatch",
@@ -86,7 +91,8 @@ func TestVxlanGpe(t *testing.T) {
 					Protocol: interfaces.VxlanLink_Gpe_IP4,
 				},
 			},
-			isFail: true,
+			mcastSwIfIndex: 0xFFFFFFFF,
+			isFail:         true,
 		},
 	}
 	for i, test := range tests {

--- a/tests/integration/vpp/100_gtpu_test.go
+++ b/tests/integration/vpp/100_gtpu_test.go
@@ -59,7 +59,8 @@ func TestGtpu(t *testing.T) {
 				Teid:       101,
 				EncapVrfId: 0,
 			},
-			isFail: false,
+			mcastSwIfIndex: 0xFFFFFFFF,
+			isFail:         false,
 		},
 		{
 			name: "Create GTP-U tunnel (IP6)",
@@ -69,7 +70,8 @@ func TestGtpu(t *testing.T) {
 				Teid:       102,
 				EncapVrfId: 0,
 			},
-			isFail: false,
+			mcastSwIfIndex: 0xFFFFFFFF,
+			isFail:         false,
 		},
 		{
 			name: "Create GTP-U tunnel (DecapNext: L2)",
@@ -80,7 +82,8 @@ func TestGtpu(t *testing.T) {
 				EncapVrfId: 0,
 				DecapNext:  interfaces.GtpuLink_L2,
 			},
-			isFail: false,
+			mcastSwIfIndex: 0xFFFFFFFF,
+			isFail:         false,
 		},
 		{
 			name: "Create GTP-U tunnel (DecapNext: IP4)",
@@ -91,7 +94,8 @@ func TestGtpu(t *testing.T) {
 				EncapVrfId: 0,
 				DecapNext:  interfaces.GtpuLink_IP4,
 			},
-			isFail: false,
+			mcastSwIfIndex: 0xFFFFFFFF,
+			isFail:         false,
 		},
 		{
 			name: "Create GTP-U tunnel (DecapNext: IP6)",
@@ -102,7 +106,8 @@ func TestGtpu(t *testing.T) {
 				EncapVrfId: 0,
 				DecapNext:  interfaces.GtpuLink_IP6,
 			},
-			isFail: false,
+			mcastSwIfIndex: 0xFFFFFFFF,
+			isFail:         false,
 		},
 		{
 			name: "Create GTP-U tunnel with same source and destination",
@@ -112,7 +117,8 @@ func TestGtpu(t *testing.T) {
 				Teid:       301,
 				EncapVrfId: 0,
 			},
-			isFail: true,
+			mcastSwIfIndex: 0xFFFFFFFF,
+			isFail:         true,
 		},
 		{
 			name: "Create GTP-U tunnel with src and dst ip versions mismatch",
@@ -122,7 +128,8 @@ func TestGtpu(t *testing.T) {
 				Teid:       302,
 				EncapVrfId: 0,
 			},
-			isFail: true,
+			mcastSwIfIndex: 0xFFFFFFFF,
+			isFail:         true,
 		},
 	}
 	for i, test := range tests {
@@ -164,6 +171,9 @@ func TestGtpu(t *testing.T) {
 				}
 				if test.gtpu.Teid != gtpu.Teid {
 					t.Fatalf("expected TEID <%d>, got: <%d>", test.gtpu.Teid, gtpu.Teid)
+				}
+				if test.gtpu.Multicast != gtpu.Multicast {
+					t.Fatalf("expected multicast interface name <%s>, got: <%s>", test.gtpu.Multicast, gtpu.Multicast)
 				}
 				if test.gtpu.EncapVrfId != gtpu.EncapVrfId {
 					t.Fatalf("expected GTP-U EncapVrfId <%d>, got: <%d>", test.gtpu.EncapVrfId, gtpu.EncapVrfId)


### PR DESCRIPTION
- During interface discovery, when any unnumbered interface referenced another interface without a tag, the VRF and IP address values could not be resolved and the delete operation failed.
This resolution was performed in the interface implementation but the name was only set later in the descriptor. This change moves the setting of the interface name earlier so that it is available already in the dump interfaces function.

- The above change uncovered a bug: 0 is a valid interface index (local0), but it was used as the multicast interface index for vxlan and gtpu tunnels when no multicast should be set. The integration tests were working only because the dump interfaces function returned an empty name for local0.

In my setup, gtpu_tunnel0 is an unnumbered interface using loop0. The unnumbered struct and and derived values were empty. The values were configured via vppctl and vpp-agent was unable to delete them:

```
      4. DELETE [DISCOVERED]:
          - key: config/vpp/v2/interfaces/UNTAGGED-loop0
          - value: { name:"UNTAGGED-loop0" type:SOFTWARE_LOOPBACK enabled:true phys_address:"de:ad:00:00:00:00" ip_addresses:"127.0.0.1/32"  } 
      5. DELETE [DERIVED DISCOVERED]:
          - key: vpp/interface/unnumbered/gtpu_tunnel0
          - value: {  } 
      6. DELETE [DERIVED DISCOVERED]:
          - key: vpp/interface/gtpu_tunnel0/vrf/from-interface/<invalid>
          - value: <EMPTY> 
      7. DELETE [DISCOVERED]:
          - key: config/vpp/v2/interfaces/gtpu_tunnel0
          - value: { name:"gtpu_tunnel0" type:GTPU_TUNNEL enabled:true unnumbered:<> gtpu:<src_addr:"172.16.16.2" dst_addr:"172.16.16.1" teid:100 decap_next:IP4 >  } 
...

ERRO[0000] failed to find interface gtpu_tunnel0         loc="descriptor/interface_vrf.go(173)" logger=vpp-ifplugin.interface-vrf-descriptor

```