### PR TITLE
fix: added GTPU to the interface type guessing function

### DIFF
--- a/plugins/vpp/ifplugin/vppcalls/vpp1904/dump_interface_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp1904/dump_interface_vppcalls.go
@@ -1063,6 +1063,9 @@ func guessInterfaceType(ifName string) interfaces.Interface_Type {
 	case strings.HasPrefix(ifName, "gre"):
 		return interfaces.Interface_GRE_TUNNEL
 
+	case strings.HasPrefix(ifName, "gtpu"):
+		return interfaces.Interface_GTPU_TUNNEL
+
 	default:
 		return interfaces.Interface_DPDK
 	}

--- a/plugins/vpp/ifplugin/vppcalls/vpp1904/gtpu_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp1904/gtpu_vppcalls.go
@@ -84,6 +84,9 @@ func (h *InterfaceVppHandler) gtpuAddDelTunnel(isAdd uint8, gtpuLink *ifs.GtpuLi
 
 // AddGtpuTunnel adds new GTPU interface.
 func (h *InterfaceVppHandler) AddGtpuTunnel(ifName string, gtpuLink *ifs.GtpuLink, multicastIf uint32) (uint32, error) {
+	if gtpuLink == nil {
+		return 0, errors.New("Missing GTPU tunnel information")
+	}
 	swIfIndex, err := h.gtpuAddDelTunnel(1, gtpuLink, multicastIf)
 	if err != nil {
 		return 0, err
@@ -93,6 +96,9 @@ func (h *InterfaceVppHandler) AddGtpuTunnel(ifName string, gtpuLink *ifs.GtpuLin
 
 // DelGtpuTunnel removes GTPU interface.
 func (h *InterfaceVppHandler) DelGtpuTunnel(ifName string, gtpuLink *ifs.GtpuLink) error {
+	if gtpuLink == nil {
+		return errors.New("Missing GTPU tunnel information")
+	}
 	swIfIndex, err := h.gtpuAddDelTunnel(0, gtpuLink, 0)
 	if err != nil {
 		return err

--- a/plugins/vpp/ifplugin/vppcalls/vpp1904/gtpu_vppcalls_test.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp1904/gtpu_vppcalls_test.go
@@ -227,3 +227,25 @@ func TestDelGtpuTunnelRetval(t *testing.T) {
 	})
 	Expect(err).ToNot(BeNil())
 }
+
+func TestAddNilGtpuTunnel(t *testing.T) {
+	ctx, ifHandler := ifTestSetup(t)
+	defer ctx.TeardownTestCtx()
+
+	ctx.MockVpp.MockReply(&vpp_gtpu.GtpuAddDelTunnel{})
+	ctx.MockVpp.MockReply(&vpp_ifs.SwInterfaceTagAddDelReply{})
+
+	_, err := ifHandler.AddGtpuTunnel("ifName", nil, 0xFFFFFFFF)
+	Expect(err).ToNot(BeNil())
+}
+
+func TestDelNilGtpuTunnel(t *testing.T) {
+	ctx, ifHandler := ifTestSetup(t)
+	defer ctx.TeardownTestCtx()
+
+	ctx.MockVpp.MockReply(&vpp_gtpu.GtpuAddDelTunnel{})
+	ctx.MockVpp.MockReply(&vpp_ifs.SwInterfaceTagAddDelReply{})
+
+	err := ifHandler.DelGtpuTunnel("ifName", nil)
+	Expect(err).ToNot(BeNil())
+}

--- a/plugins/vpp/ifplugin/vppcalls/vpp1908/dump_interface_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp1908/dump_interface_vppcalls.go
@@ -1085,6 +1085,9 @@ func guessInterfaceType(ifName string) interfaces.Interface_Type {
 	case strings.HasPrefix(ifName, "gre"):
 		return interfaces.Interface_GRE_TUNNEL
 
+	case strings.HasPrefix(ifName, "gtpu"):
+		return interfaces.Interface_GTPU_TUNNEL
+
 	default:
 		return interfaces.Interface_DPDK
 	}

--- a/plugins/vpp/ifplugin/vppcalls/vpp1908/gtpu_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp1908/gtpu_vppcalls.go
@@ -84,6 +84,9 @@ func (h *InterfaceVppHandler) gtpuAddDelTunnel(isAdd uint8, gtpuLink *ifs.GtpuLi
 
 // AddGtpuTunnel adds new GTPU interface.
 func (h *InterfaceVppHandler) AddGtpuTunnel(ifName string, gtpuLink *ifs.GtpuLink, multicastIf uint32) (uint32, error) {
+	if gtpuLink == nil {
+		return 0, errors.New("Missing GTPU tunnel information")
+	}
 	swIfIndex, err := h.gtpuAddDelTunnel(1, gtpuLink, multicastIf)
 	if err != nil {
 		return 0, err
@@ -93,6 +96,9 @@ func (h *InterfaceVppHandler) AddGtpuTunnel(ifName string, gtpuLink *ifs.GtpuLin
 
 // DelGtpuTunnel removes GTPU interface.
 func (h *InterfaceVppHandler) DelGtpuTunnel(ifName string, gtpuLink *ifs.GtpuLink) error {
+	if gtpuLink == nil {
+		return errors.New("Missing GTPU tunnel information")
+	}
 	swIfIndex, err := h.gtpuAddDelTunnel(0, gtpuLink, 0)
 	if err != nil {
 		return err

--- a/plugins/vpp/ifplugin/vppcalls/vpp1908/gtpu_vppcalls_test.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp1908/gtpu_vppcalls_test.go
@@ -227,3 +227,25 @@ func TestDelGtpuTunnelRetval(t *testing.T) {
 	})
 	Expect(err).ToNot(BeNil())
 }
+
+func TestAddNilGtpuTunnel(t *testing.T) {
+	ctx, ifHandler := ifTestSetup(t)
+	defer ctx.TeardownTestCtx()
+
+	ctx.MockVpp.MockReply(&vpp_gtpu.GtpuAddDelTunnel{})
+	ctx.MockVpp.MockReply(&vpp_ifs.SwInterfaceTagAddDelReply{})
+
+	_, err := ifHandler.AddGtpuTunnel("ifName", nil, 0xFFFFFFFF)
+	Expect(err).ToNot(BeNil())
+}
+
+func TestDelNilGtpuTunnel(t *testing.T) {
+	ctx, ifHandler := ifTestSetup(t)
+	defer ctx.TeardownTestCtx()
+
+	ctx.MockVpp.MockReply(&vpp_gtpu.GtpuAddDelTunnel{})
+	ctx.MockVpp.MockReply(&vpp_ifs.SwInterfaceTagAddDelReply{})
+
+	err := ifHandler.DelGtpuTunnel("ifName", nil)
+	Expect(err).ToNot(BeNil())
+}

--- a/plugins/vpp/ifplugin/vppcalls/vpp2001/dump_interface_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp2001/dump_interface_vppcalls.go
@@ -1076,6 +1076,9 @@ func guessInterfaceType(ifName string) ifs.Interface_Type {
 	case strings.HasPrefix(ifName, "Bond"):
 		return ifs.Interface_BOND_INTERFACE
 
+	case strings.HasPrefix(ifName, "gtpu"):
+		return ifs.Interface_GTPU_TUNNEL
+
 	default:
 		return ifs.Interface_DPDK
 	}

--- a/plugins/vpp/ifplugin/vppcalls/vpp2001/gtpu_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp2001/gtpu_vppcalls.go
@@ -84,6 +84,9 @@ func (h *InterfaceVppHandler) gtpuAddDelTunnel(isAdd uint8, gtpuLink *ifs.GtpuLi
 
 // AddGtpuTunnel adds new GTPU interface.
 func (h *InterfaceVppHandler) AddGtpuTunnel(ifName string, gtpuLink *ifs.GtpuLink, multicastIf uint32) (uint32, error) {
+	if gtpuLink == nil {
+		return 0, errors.New("Missing GTPU tunnel information")
+	}
 	swIfIndex, err := h.gtpuAddDelTunnel(1, gtpuLink, multicastIf)
 	if err != nil {
 		return 0, err
@@ -93,6 +96,9 @@ func (h *InterfaceVppHandler) AddGtpuTunnel(ifName string, gtpuLink *ifs.GtpuLin
 
 // DelGtpuTunnel removes GTPU interface.
 func (h *InterfaceVppHandler) DelGtpuTunnel(ifName string, gtpuLink *ifs.GtpuLink) error {
+	if gtpuLink == nil {
+		return errors.New("Missing GTPU tunnel information")
+	}
 	swIfIndex, err := h.gtpuAddDelTunnel(0, gtpuLink, 0)
 	if err != nil {
 		return err

--- a/plugins/vpp/ifplugin/vppcalls/vpp2001/gtpu_vppcalls_test.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp2001/gtpu_vppcalls_test.go
@@ -227,3 +227,25 @@ func TestDelGtpuTunnelRetval(t *testing.T) {
 	})
 	Expect(err).ToNot(BeNil())
 }
+
+func TestAddNilGtpuTunnel(t *testing.T) {
+	ctx, ifHandler := ifTestSetup(t)
+	defer ctx.TeardownTestCtx()
+
+	ctx.MockVpp.MockReply(&vpp_gtpu.GtpuAddDelTunnel{})
+	ctx.MockVpp.MockReply(&vpp_ifs.SwInterfaceTagAddDelReply{})
+
+	_, err := ifHandler.AddGtpuTunnel("ifName", nil, 0xFFFFFFFF)
+	Expect(err).ToNot(BeNil())
+}
+
+func TestDelNilGtpuTunnel(t *testing.T) {
+	ctx, ifHandler := ifTestSetup(t)
+	defer ctx.TeardownTestCtx()
+
+	ctx.MockVpp.MockReply(&vpp_gtpu.GtpuAddDelTunnel{})
+	ctx.MockVpp.MockReply(&vpp_ifs.SwInterfaceTagAddDelReply{})
+
+	err := ifHandler.DelGtpuTunnel("ifName", nil)
+	Expect(err).ToNot(BeNil())
+}

--- a/plugins/vpp/ifplugin/vppcalls/vpp2001_324/dump_interface_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp2001_324/dump_interface_vppcalls.go
@@ -1076,6 +1076,9 @@ func guessInterfaceType(ifName string) ifs.Interface_Type {
 	case strings.HasPrefix(ifName, "Bond"):
 		return ifs.Interface_BOND_INTERFACE
 
+	case strings.HasPrefix(ifName, "gtpu"):
+		return ifs.Interface_GTPU_TUNNEL
+
 	default:
 		return ifs.Interface_DPDK
 	}

--- a/plugins/vpp/ifplugin/vppcalls/vpp2001_324/gtpu_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp2001_324/gtpu_vppcalls.go
@@ -84,6 +84,9 @@ func (h *InterfaceVppHandler) gtpuAddDelTunnel(isAdd uint8, gtpuLink *ifs.GtpuLi
 
 // AddGtpuTunnel adds new GTPU interface.
 func (h *InterfaceVppHandler) AddGtpuTunnel(ifName string, gtpuLink *ifs.GtpuLink, multicastIf uint32) (uint32, error) {
+	if gtpuLink == nil {
+		return 0, errors.New("Missing GTPU tunnel information")
+	}
 	swIfIndex, err := h.gtpuAddDelTunnel(1, gtpuLink, multicastIf)
 	if err != nil {
 		return 0, err
@@ -93,6 +96,9 @@ func (h *InterfaceVppHandler) AddGtpuTunnel(ifName string, gtpuLink *ifs.GtpuLin
 
 // DelGtpuTunnel removes GTPU interface.
 func (h *InterfaceVppHandler) DelGtpuTunnel(ifName string, gtpuLink *ifs.GtpuLink) error {
+	if gtpuLink == nil {
+		return errors.New("Missing GTPU tunnel information")
+	}
 	swIfIndex, err := h.gtpuAddDelTunnel(0, gtpuLink, 0)
 	if err != nil {
 		return err

--- a/plugins/vpp/ifplugin/vppcalls/vpp2001_324/gtpu_vppcalls_test.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp2001_324/gtpu_vppcalls_test.go
@@ -227,3 +227,25 @@ func TestDelGtpuTunnelRetval(t *testing.T) {
 	})
 	Expect(err).ToNot(BeNil())
 }
+
+func TestAddNilGtpuTunnel(t *testing.T) {
+	ctx, ifHandler := ifTestSetup(t)
+	defer ctx.TeardownTestCtx()
+
+	ctx.MockVpp.MockReply(&vpp_gtpu.GtpuAddDelTunnel{})
+	ctx.MockVpp.MockReply(&vpp_ifs.SwInterfaceTagAddDelReply{})
+
+	_, err := ifHandler.AddGtpuTunnel("ifName", nil, 0xFFFFFFFF)
+	Expect(err).ToNot(BeNil())
+}
+
+func TestDelNilGtpuTunnel(t *testing.T) {
+	ctx, ifHandler := ifTestSetup(t)
+	defer ctx.TeardownTestCtx()
+
+	ctx.MockVpp.MockReply(&vpp_gtpu.GtpuAddDelTunnel{})
+	ctx.MockVpp.MockReply(&vpp_ifs.SwInterfaceTagAddDelReply{})
+
+	err := ifHandler.DelGtpuTunnel("ifName", nil)
+	Expect(err).ToNot(BeNil())
+}


### PR DESCRIPTION
- Fixed the type guessing for GTPU tunnels.
- Added an extra nil check to the GTPU tunnel add and del functions
to avoid problems with older VPP releases that still have a broken get
api.