### PR TITLE
test: added basic integration tests for SRv6 Localsids

### DIFF
--- a/plugins/vpp/srplugin/vppcalls/api_vppcalls.go
+++ b/plugins/vpp/srplugin/vppcalls/api_vppcalls.go
@@ -55,6 +55,9 @@ type SRv6VPPWrite interface {
 type SRv6VPPRead interface {
 	// TODO: implement other dump methods
 
+	// DumpLocalSids retrieves all localsids
+	DumpLocalSids() (localsids []*srv6.LocalSID, err error)
+
 	// RetrievePolicyIndexInfo retrieves index of policy <policy> and its segment lists
 	RetrievePolicyIndexInfo(policy *srv6.Policy) (policyIndex uint32, segmentListIndexes map[*srv6.Policy_SegmentList]uint32, err error)
 }

--- a/plugins/vpp/srplugin/vppcalls/vpp1904/srv6_dump.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp1904/srv6_dump.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2019 Pantheon.tech
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vpp1904
+
+import (
+	"net"
+
+	"github.com/go-errors/errors"
+	"go.ligato.io/vpp-agent/v2/plugins/vpp/binapi/vpp1904/sr"
+	srv6 "go.ligato.io/vpp-agent/v2/proto/ligato/vpp/srv6"
+)
+
+// DumpLocalSids retrieves all localsids
+func (h *SRv6VppHandler) DumpLocalSids() (localsids []*srv6.LocalSID, err error) {
+	h.log.Debug("Dumping LocalSIDs")
+
+	reqCtx := h.callsChannel.SendMultiRequest(&sr.SrLocalsidsDump{})
+	for {
+		// retrieve dump for another localsid
+		dumpReply := &sr.SrLocalsidsDetails{}
+		stop, err := reqCtx.ReceiveReply(dumpReply)
+		if stop {
+			break
+		}
+		if err != nil {
+			return nil, errors.Errorf("error while retrieving localsid details:%v", err)
+		}
+
+		// convert dumped localsid details into modeled Localsid struct
+		sid, error := h.convertDumpedSid(&dumpReply.Addr)
+		if error != nil {
+			return localsids, errors.Errorf("can't properly handle sid address "+
+				"of dumped localsid %v due to: %v", dumpReply, err)
+		}
+		localsid := &srv6.LocalSID{
+			InstallationVrfId: dumpReply.FibTable,
+			Sid:               sid.String(),
+		}
+		if err := h.fillEndFunction(localsid, dumpReply); err != nil {
+			return localsids, errors.Errorf("can't properly handle end function "+
+				"of dumped localsid %v due to: %v", dumpReply, err)
+		}
+
+		// collect all dumped localsids
+		localsids = append(localsids, localsid)
+	}
+
+	return localsids, nil
+}
+
+// convertDumpedSid extract from dumped structure SID value and converts it to IPv6 (net.IP)
+func (h *SRv6VppHandler) convertDumpedSid(srv6Sid *sr.Srv6Sid) (net.IP, error) {
+	if srv6Sid == nil || srv6Sid.Addr == nil {
+		return nil, errors.New("can't convert sid from nil dumped address (or nil srv6sid)")
+	}
+	sid := net.IP(srv6Sid.Addr).To16()
+	if sid == nil {
+		return nil, errors.Errorf("can't convert dumped SID bytes(%v) to net.IP", srv6Sid.Addr)
+	}
+	return sid, nil
+}
+
+// fillEndFunction create end function part of NB-modeled localsid from SB-dumped structure
+func (h *SRv6VppHandler) fillEndFunction(localSID *srv6.LocalSID, dumpReply *sr.SrLocalsidsDetails) error {
+	switch uint8(dumpReply.Behavior) {
+	case BehaviorEnd:
+		localSID.EndFunction = &srv6.LocalSID_BaseEndFunction{
+			BaseEndFunction: &srv6.LocalSID_End{
+				Psp: uintToBool(dumpReply.EndPsp),
+			},
+		}
+	case BehaviorX:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionX{
+			EndFunctionX: &srv6.LocalSID_EndX{
+				Psp:               uintToBool(dumpReply.EndPsp),
+				OutgoingInterface: ifName,
+				NextHop:           h.nextHop(dumpReply),
+			},
+		}
+	case BehaviorT:
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionT{
+			EndFunctionT: &srv6.LocalSID_EndT{
+				Psp:   uintToBool(dumpReply.EndPsp),
+				VrfId: dumpReply.XconnectIfaceOrVrfTable,
+			},
+		}
+	case BehaviorDX2:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDx2{
+			EndFunctionDx2: &srv6.LocalSID_EndDX2{
+				VlanTag:           dumpReply.VlanIndex,
+				OutgoingInterface: ifName,
+			},
+		}
+	case BehaviorDX4:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDx4{
+			EndFunctionDx4: &srv6.LocalSID_EndDX4{
+				OutgoingInterface: ifName,
+				NextHop:           h.nextHop(dumpReply),
+			},
+		}
+	case BehaviorDX6:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDx6{
+			EndFunctionDx6: &srv6.LocalSID_EndDX6{
+				OutgoingInterface: ifName,
+				NextHop:           h.nextHop(dumpReply),
+			},
+		}
+	case BehaviorDT4:
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDt4{
+			EndFunctionDt4: &srv6.LocalSID_EndDT4{
+				VrfId: dumpReply.XconnectIfaceOrVrfTable,
+			},
+		}
+	case BehaviorDT6:
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDt6{
+			EndFunctionDt6: &srv6.LocalSID_EndDT6{
+				VrfId: dumpReply.XconnectIfaceOrVrfTable,
+			},
+		}
+	default:
+		return errors.Errorf("localsid with unknown or unsupported behavior (%v)", dumpReply.Behavior)
+	}
+
+	return nil
+}
+
+// nextHop transforms SB dump data about next hop to NB modeled structure
+func (h *SRv6VppHandler) nextHop(dumpReply *sr.SrLocalsidsDetails) string {
+	nh4 := net.IP(dumpReply.XconnectNhAddr4)
+	nh6 := net.IP(dumpReply.XconnectNhAddr6)
+	nhStr := ""
+	// default is no next hop address (i.e. L2 xconnect)
+	if nh4 != nil && !nh4.Equal(net.IPv4zero) {
+		nhStr = nh4.String()
+	} else if nh6 != nil && !nh6.Equal(net.IPv6zero) {
+		nhStr = nh6.String()
+	}
+	return nhStr
+}
+
+func uintToBool(input uint8) bool {
+	return input != 0
+}

--- a/plugins/vpp/srplugin/vppcalls/vpp1908/srv6_dump.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp1908/srv6_dump.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2019 Pantheon.tech
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vpp1908
+
+import (
+	"net"
+
+	"github.com/go-errors/errors"
+	"go.ligato.io/vpp-agent/v2/plugins/vpp/binapi/vpp1908/sr"
+	srv6 "go.ligato.io/vpp-agent/v2/proto/ligato/vpp/srv6"
+)
+
+// DumpLocalSids retrieves all localsids
+func (h *SRv6VppHandler) DumpLocalSids() (localsids []*srv6.LocalSID, err error) {
+	h.log.Debug("Dumping LocalSIDs")
+
+	reqCtx := h.callsChannel.SendMultiRequest(&sr.SrLocalsidsDump{})
+	for {
+		// retrieve dump for another localsid
+		dumpReply := &sr.SrLocalsidsDetails{}
+		stop, err := reqCtx.ReceiveReply(dumpReply)
+		if stop {
+			break
+		}
+		if err != nil {
+			return nil, errors.Errorf("error while retrieving localsid details:%v", err)
+		}
+
+		// convert dumped localsid details into modeled Localsid struct
+		sid, error := h.convertDumpedSid(&dumpReply.Addr)
+		if error != nil {
+			return localsids, errors.Errorf("can't properly handle sid address "+
+				"of dumped localsid %v due to: %v", dumpReply, err)
+		}
+		localsid := &srv6.LocalSID{
+			InstallationVrfId: dumpReply.FibTable,
+			Sid:               sid.String(),
+		}
+		if err := h.fillEndFunction(localsid, dumpReply); err != nil {
+			return localsids, errors.Errorf("can't properly handle end function "+
+				"of dumped localsid %v due to: %v", dumpReply, err)
+		}
+
+		// collect all dumped localsids
+		localsids = append(localsids, localsid)
+	}
+
+	return localsids, nil
+}
+
+// convertDumpedSid extract from dumped structure SID value and converts it to IPv6 (net.IP)
+func (h *SRv6VppHandler) convertDumpedSid(srv6Sid *sr.Srv6Sid) (net.IP, error) {
+	if srv6Sid == nil || srv6Sid.Addr == nil {
+		return nil, errors.New("can't convert sid from nil dumped address (or nil srv6sid)")
+	}
+	sid := net.IP(srv6Sid.Addr).To16()
+	if sid == nil {
+		return nil, errors.Errorf("can't convert dumped SID bytes(%v) to net.IP", srv6Sid.Addr)
+	}
+	return sid, nil
+}
+
+// fillEndFunction create end function part of NB-modeled localsid from SB-dumped structure
+func (h *SRv6VppHandler) fillEndFunction(localSID *srv6.LocalSID, dumpReply *sr.SrLocalsidsDetails) error {
+	switch uint8(dumpReply.Behavior) {
+	case BehaviorEnd:
+		localSID.EndFunction = &srv6.LocalSID_BaseEndFunction{
+			BaseEndFunction: &srv6.LocalSID_End{
+				Psp: uintToBool(dumpReply.EndPsp),
+			},
+		}
+	case BehaviorX:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionX{
+			EndFunctionX: &srv6.LocalSID_EndX{
+				Psp:               uintToBool(dumpReply.EndPsp),
+				OutgoingInterface: ifName,
+				NextHop:           h.nextHop(dumpReply),
+			},
+		}
+	case BehaviorT:
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionT{
+			EndFunctionT: &srv6.LocalSID_EndT{
+				Psp:   uintToBool(dumpReply.EndPsp),
+				VrfId: dumpReply.XconnectIfaceOrVrfTable,
+			},
+		}
+	case BehaviorDX2:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDx2{
+			EndFunctionDx2: &srv6.LocalSID_EndDX2{
+				VlanTag:           dumpReply.VlanIndex,
+				OutgoingInterface: ifName,
+			},
+		}
+	case BehaviorDX4:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDx4{
+			EndFunctionDx4: &srv6.LocalSID_EndDX4{
+				OutgoingInterface: ifName,
+				NextHop:           h.nextHop(dumpReply),
+			},
+		}
+	case BehaviorDX6:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDx6{
+			EndFunctionDx6: &srv6.LocalSID_EndDX6{
+				OutgoingInterface: ifName,
+				NextHop:           h.nextHop(dumpReply),
+			},
+		}
+	case BehaviorDT4:
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDt4{
+			EndFunctionDt4: &srv6.LocalSID_EndDT4{
+				VrfId: dumpReply.XconnectIfaceOrVrfTable,
+			},
+		}
+	case BehaviorDT6:
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDt6{
+			EndFunctionDt6: &srv6.LocalSID_EndDT6{
+				VrfId: dumpReply.XconnectIfaceOrVrfTable,
+			},
+		}
+	default:
+		return errors.Errorf("localsid with unknown or unsupported behavior (%v)", dumpReply.Behavior)
+	}
+
+	return nil
+}
+
+// nextHop transforms SB dump data about next hop to NB modeled structure
+func (h *SRv6VppHandler) nextHop(dumpReply *sr.SrLocalsidsDetails) string {
+	nh4 := net.IP(dumpReply.XconnectNhAddr4)
+	nh6 := net.IP(dumpReply.XconnectNhAddr6)
+	nhStr := ""
+	// default is no next hop address (i.e. L2 xconnect)
+	if nh4 != nil && !nh4.Equal(net.IPv4zero) {
+		nhStr = nh4.String()
+	} else if nh6 != nil && !nh6.Equal(net.IPv6zero) {
+		nhStr = nh6.String()
+	}
+	return nhStr
+}
+
+func uintToBool(input uint8) bool {
+	return input != 0
+}

--- a/plugins/vpp/srplugin/vppcalls/vpp2001/srv6_dump.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp2001/srv6_dump.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2019 Pantheon.tech
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vpp2001
+
+import (
+	"net"
+
+	"github.com/go-errors/errors"
+	"go.ligato.io/vpp-agent/v2/plugins/vpp/binapi/vpp2001/sr"
+	srv6 "go.ligato.io/vpp-agent/v2/proto/ligato/vpp/srv6"
+)
+
+// DumpLocalSids retrieves all localsids
+func (h *SRv6VppHandler) DumpLocalSids() (localsids []*srv6.LocalSID, err error) {
+	h.log.Debug("Dumping LocalSIDs")
+
+	reqCtx := h.callsChannel.SendMultiRequest(&sr.SrLocalsidsDump{})
+	for {
+		// retrieve dump for another localsid
+		dumpReply := &sr.SrLocalsidsDetails{}
+		stop, err := reqCtx.ReceiveReply(dumpReply)
+		if stop {
+			break
+		}
+		if err != nil {
+			return nil, errors.Errorf("error while retrieving localsid details:%v", err)
+		}
+
+		// convert dumped localsid details into modeled Localsid struct
+		sid, error := h.convertDumpedSid(&dumpReply.Addr)
+		if error != nil {
+			return localsids, errors.Errorf("can't properly handle sid address "+
+				"of dumped localsid %v due to: %v", dumpReply, err)
+		}
+		localsid := &srv6.LocalSID{
+			InstallationVrfId: dumpReply.FibTable,
+			Sid:               sid.String(),
+		}
+		if err := h.fillEndFunction(localsid, dumpReply); err != nil {
+			return localsids, errors.Errorf("can't properly handle end function "+
+				"of dumped localsid %v due to: %v", dumpReply, err)
+		}
+
+		// collect all dumped localsids
+		localsids = append(localsids, localsid)
+	}
+
+	return localsids, nil
+}
+
+// convertDumpedSid extract from dumped structure SID value and converts it to IPv6 (net.IP)
+func (h *SRv6VppHandler) convertDumpedSid(srv6Sid *sr.Srv6Sid) (net.IP, error) {
+	if srv6Sid == nil || srv6Sid.Addr == nil {
+		return nil, errors.New("can't convert sid from nil dumped address (or nil srv6sid)")
+	}
+	sid := net.IP(srv6Sid.Addr).To16()
+	if sid == nil {
+		return nil, errors.Errorf("can't convert dumped SID bytes(%v) to net.IP", srv6Sid.Addr)
+	}
+	return sid, nil
+}
+
+// fillEndFunction create end function part of NB-modeled localsid from SB-dumped structure
+func (h *SRv6VppHandler) fillEndFunction(localSID *srv6.LocalSID, dumpReply *sr.SrLocalsidsDetails) error {
+	switch uint8(dumpReply.Behavior) {
+	case BehaviorEnd:
+		localSID.EndFunction = &srv6.LocalSID_BaseEndFunction{
+			BaseEndFunction: &srv6.LocalSID_End{
+				Psp: uintToBool(dumpReply.EndPsp),
+			},
+		}
+	case BehaviorX:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionX{
+			EndFunctionX: &srv6.LocalSID_EndX{
+				Psp:               uintToBool(dumpReply.EndPsp),
+				OutgoingInterface: ifName,
+				NextHop:           h.nextHop(dumpReply),
+			},
+		}
+	case BehaviorT:
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionT{
+			EndFunctionT: &srv6.LocalSID_EndT{
+				Psp:   uintToBool(dumpReply.EndPsp),
+				VrfId: dumpReply.XconnectIfaceOrVrfTable,
+			},
+		}
+	case BehaviorDX2:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDx2{
+			EndFunctionDx2: &srv6.LocalSID_EndDX2{
+				VlanTag:           dumpReply.VlanIndex,
+				OutgoingInterface: ifName,
+			},
+		}
+	case BehaviorDX4:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDx4{
+			EndFunctionDx4: &srv6.LocalSID_EndDX4{
+				OutgoingInterface: ifName,
+				NextHop:           h.nextHop(dumpReply),
+			},
+		}
+	case BehaviorDX6:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDx6{
+			EndFunctionDx6: &srv6.LocalSID_EndDX6{
+				OutgoingInterface: ifName,
+				NextHop:           h.nextHop(dumpReply),
+			},
+		}
+	case BehaviorDT4:
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDt4{
+			EndFunctionDt4: &srv6.LocalSID_EndDT4{
+				VrfId: dumpReply.XconnectIfaceOrVrfTable,
+			},
+		}
+	case BehaviorDT6:
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDt6{
+			EndFunctionDt6: &srv6.LocalSID_EndDT6{
+				VrfId: dumpReply.XconnectIfaceOrVrfTable,
+			},
+		}
+	default:
+		return errors.Errorf("localsid with unknown or unsupported behavior (%v)", dumpReply.Behavior)
+	}
+
+	return nil
+}
+
+// nextHop transforms SB dump data about next hop to NB modeled structure
+func (h *SRv6VppHandler) nextHop(dumpReply *sr.SrLocalsidsDetails) string {
+	nh4 := net.IP(dumpReply.XconnectNhAddr4)
+	nh6 := net.IP(dumpReply.XconnectNhAddr6)
+	nhStr := ""
+	// default is no next hop address (i.e. L2 xconnect)
+	if nh4 != nil && !nh4.Equal(net.IPv4zero) {
+		nhStr = nh4.String()
+	} else if nh6 != nil && !nh6.Equal(net.IPv6zero) {
+		nhStr = nh6.String()
+	}
+	return nhStr
+}
+
+func uintToBool(input uint8) bool {
+	return input != 0
+}

--- a/plugins/vpp/srplugin/vppcalls/vpp2001_324/srv6_dump.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp2001_324/srv6_dump.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2019 Pantheon.tech
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vpp2001_324
+
+import (
+	"net"
+
+	"github.com/go-errors/errors"
+	"go.ligato.io/vpp-agent/v2/plugins/vpp/binapi/vpp2001_324/sr"
+	srv6 "go.ligato.io/vpp-agent/v2/proto/ligato/vpp/srv6"
+)
+
+// DumpLocalSids retrieves all localsids
+func (h *SRv6VppHandler) DumpLocalSids() (localsids []*srv6.LocalSID, err error) {
+	h.log.Debug("Dumping LocalSIDs")
+
+	reqCtx := h.callsChannel.SendMultiRequest(&sr.SrLocalsidsDump{})
+	for {
+		// retrieve dump for another localsid
+		dumpReply := &sr.SrLocalsidsDetails{}
+		stop, err := reqCtx.ReceiveReply(dumpReply)
+		if stop {
+			break
+		}
+		if err != nil {
+			return nil, errors.Errorf("error while retrieving localsid details:%v", err)
+		}
+
+		// convert dumped localsid details into modeled Localsid struct
+		sid, error := h.convertDumpedSid(&dumpReply.Addr)
+		if error != nil {
+			return localsids, errors.Errorf("can't properly handle sid address "+
+				"of dumped localsid %v due to: %v", dumpReply, err)
+		}
+		localsid := &srv6.LocalSID{
+			InstallationVrfId: dumpReply.FibTable,
+			Sid:               sid.String(),
+		}
+		if err := h.fillEndFunction(localsid, dumpReply); err != nil {
+			return localsids, errors.Errorf("can't properly handle end function "+
+				"of dumped localsid %v due to: %v", dumpReply, err)
+		}
+
+		// collect all dumped localsids
+		localsids = append(localsids, localsid)
+	}
+
+	return localsids, nil
+}
+
+// convertDumpedSid extract from dumped structure SID value and converts it to IPv6 (net.IP)
+func (h *SRv6VppHandler) convertDumpedSid(srv6Sid *sr.Srv6Sid) (net.IP, error) {
+	if srv6Sid == nil || srv6Sid.Addr == nil {
+		return nil, errors.New("can't convert sid from nil dumped address (or nil srv6sid)")
+	}
+	sid := net.IP(srv6Sid.Addr).To16()
+	if sid == nil {
+		return nil, errors.Errorf("can't convert dumped SID bytes(%v) to net.IP", srv6Sid.Addr)
+	}
+	return sid, nil
+}
+
+// fillEndFunction create end function part of NB-modeled localsid from SB-dumped structure
+func (h *SRv6VppHandler) fillEndFunction(localSID *srv6.LocalSID, dumpReply *sr.SrLocalsidsDetails) error {
+	switch uint8(dumpReply.Behavior) {
+	case BehaviorEnd:
+		localSID.EndFunction = &srv6.LocalSID_BaseEndFunction{
+			BaseEndFunction: &srv6.LocalSID_End{
+				Psp: uintToBool(dumpReply.EndPsp),
+			},
+		}
+	case BehaviorX:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionX{
+			EndFunctionX: &srv6.LocalSID_EndX{
+				Psp:               uintToBool(dumpReply.EndPsp),
+				OutgoingInterface: ifName,
+				NextHop:           h.nextHop(dumpReply),
+			},
+		}
+	case BehaviorT:
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionT{
+			EndFunctionT: &srv6.LocalSID_EndT{
+				Psp:   uintToBool(dumpReply.EndPsp),
+				VrfId: dumpReply.XconnectIfaceOrVrfTable,
+			},
+		}
+	case BehaviorDX2:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDx2{
+			EndFunctionDx2: &srv6.LocalSID_EndDX2{
+				VlanTag:           dumpReply.VlanIndex,
+				OutgoingInterface: ifName,
+			},
+		}
+	case BehaviorDX4:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDx4{
+			EndFunctionDx4: &srv6.LocalSID_EndDX4{
+				OutgoingInterface: ifName,
+				NextHop:           h.nextHop(dumpReply),
+			},
+		}
+	case BehaviorDX6:
+		ifName, _, exists := h.ifIndexes.LookupBySwIfIndex(dumpReply.XconnectIfaceOrVrfTable)
+		if !exists {
+			return errors.Errorf("there is no interface with sw index %v", dumpReply.XconnectIfaceOrVrfTable)
+		}
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDx6{
+			EndFunctionDx6: &srv6.LocalSID_EndDX6{
+				OutgoingInterface: ifName,
+				NextHop:           h.nextHop(dumpReply),
+			},
+		}
+	case BehaviorDT4:
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDt4{
+			EndFunctionDt4: &srv6.LocalSID_EndDT4{
+				VrfId: dumpReply.XconnectIfaceOrVrfTable,
+			},
+		}
+	case BehaviorDT6:
+		localSID.EndFunction = &srv6.LocalSID_EndFunctionDt6{
+			EndFunctionDt6: &srv6.LocalSID_EndDT6{
+				VrfId: dumpReply.XconnectIfaceOrVrfTable,
+			},
+		}
+	default:
+		return errors.Errorf("localsid with unknown or unsupported behavior (%v)", dumpReply.Behavior)
+	}
+
+	return nil
+}
+
+// nextHop transforms SB dump data about next hop to NB modeled structure
+func (h *SRv6VppHandler) nextHop(dumpReply *sr.SrLocalsidsDetails) string {
+	nh4 := net.IP(dumpReply.XconnectNhAddr4)
+	nh6 := net.IP(dumpReply.XconnectNhAddr6)
+	nhStr := ""
+	// default is no next hop address (i.e. L2 xconnect)
+	if nh4 != nil && !nh4.Equal(net.IPv4zero) {
+		nhStr = nh4.String()
+	} else if nh6 != nil && !nh6.Equal(net.IPv6zero) {
+		nhStr = nh6.String()
+	}
+	return nhStr
+}
+
+func uintToBool(input uint8) bool {
+	return input != 0
+}

--- a/tests/integration/vpp/110_srv6_test.go
+++ b/tests/integration/vpp/110_srv6_test.go
@@ -1,0 +1,421 @@
+// Copyright (c) 2019 Pantheon.tech
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vpp
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/ligato/cn-infra/logging/logrus"
+	. "github.com/onsi/gomega"
+	netalloc_mock "go.ligato.io/vpp-agent/v2/plugins/netalloc/mock"
+	"go.ligato.io/vpp-agent/v2/plugins/vpp/ifplugin/ifaceidx"
+	ifplugin_vppcalls "go.ligato.io/vpp-agent/v2/plugins/vpp/ifplugin/vppcalls"
+	l3plugin_vppcalls "go.ligato.io/vpp-agent/v2/plugins/vpp/l3plugin/vppcalls"
+	"go.ligato.io/vpp-agent/v2/plugins/vpp/l3plugin/vrfidx"
+	_ "go.ligato.io/vpp-agent/v2/plugins/vpp/srplugin"
+	srv6_vppcalls "go.ligato.io/vpp-agent/v2/plugins/vpp/srplugin/vppcalls"
+	vpp_l3 "go.ligato.io/vpp-agent/v2/proto/ligato/vpp/l3"
+	srv6 "go.ligato.io/vpp-agent/v2/proto/ligato/vpp/srv6"
+)
+
+const (
+	vrfID1 = 11
+	vrfID2 = 12
+)
+
+var (
+	sidA         = sid("A::")
+	nextHop      = net.ParseIP("B::").To16()
+	nextHop2     = net.ParseIP("C::").To16()
+	nextHopIPv4  = net.ParseIP("1.2.3.4").To4()
+	nextHop2IPv4 = net.ParseIP("1.2.3.5").To4()
+	vrfTables    = []*vpp_l3.VrfTable{
+		{
+			Id:       11,
+			Protocol: vpp_l3.VrfTable_IPV6,
+			Label:    "testIpv6Table1",
+		},
+		{
+			Id:       12,
+			Protocol: vpp_l3.VrfTable_IPV6,
+			Label:    "testIpv6Table2",
+		},
+		{
+			Id:       13,
+			Protocol: vpp_l3.VrfTable_IPV4,
+			Label:    "testIpv4Table1",
+		},
+		{
+			Id:       14,
+			Protocol: vpp_l3.VrfTable_IPV4,
+			Label:    "testIpv4Table2",
+		},
+	}
+)
+
+//TODO add CRUD tests for SR-proxy (there is no binary API for it -> dump for SR-proxy needs 1. CLI localsid dump
+// and 2. CLI fib table dump because CLI localsid dump does not include installation vrf for SR-proxy localsid)
+
+// TestLocalsidCRUD tests CRUD operations for Localsids
+func TestLocalsidCRUD(t *testing.T) {
+	ctx := setupVPP(t)
+	defer ctx.teardownVPP()
+
+	// create interfaces (for referencing from localsids)
+	ih := ifplugin_vppcalls.CompatibleInterfaceVppHandler(ctx.vppBinapi, logrus.NewLogger("test"))
+	const ifName = "loop1"
+	ifIdx, err := ih.AddLoopbackInterface(ifName)
+	Expect(err).To(BeNil(), fmt.Sprintf("fixture setup failed in creating of interface %v: %v", ifName, err))
+	t.Logf("interface created %v", ifIdx)
+	const ifName2 = "loop2"
+	ifIdx2, err := ih.AddLoopbackInterface(ifName2)
+	Expect(err).To(BeNil(), fmt.Sprintf("fixture setup failed in creating of interface %v: %v", ifName2, err))
+	t.Logf("interface created %v", ifIdx2)
+	ifIndexes := ifaceidx.NewIfaceIndex(logrus.NewLogger("test-idx"), "test-idx")
+	ifIndexes.Put(ifName, &ifaceidx.IfaceMetadata{SwIfIndex: ifIdx})
+	ifIndexes.Put(ifName2, &ifaceidx.IfaceMetadata{SwIfIndex: ifIdx2})
+
+	// create vrf tables (for referencing from localsids)
+	vrfIndexes := vrfidx.NewVRFIndex(logrus.NewLogger("test-vrf"), "test-vrf")
+	vrfIndexes.Put("vrf1-ipv4", &vrfidx.VRFMetadata{Index: 0, Protocol: vpp_l3.VrfTable_IPV4})
+	vrfIndexes.Put("vrf1-ipv6", &vrfidx.VRFMetadata{Index: 0, Protocol: vpp_l3.VrfTable_IPV6})
+	l3h := l3plugin_vppcalls.CompatibleL3VppHandler(ctx.vppBinapi, ifIndexes, vrfIndexes,
+		netalloc_mock.NewMockNetAlloc(), logrus.NewLogger("test-l3"))
+	for _, vrfTable := range vrfTables[:4] {
+		Expect(l3h.AddVrfTable(vrfTable)).Should(Succeed(), fmt.Sprintf("fixture setup failed "+
+			"in creating of vrf table with name %v due to: %v", vrfTable.Label, err))
+	}
+
+	// SRv6 handler
+	srh := srv6_vppcalls.CompatibleSRv6VppHandler(ctx.vppBinapi, ifIndexes, logrus.NewLogger("test"))
+
+	tests := []struct {
+		name                string
+		input               *srv6.LocalSID
+		expectedDump        *srv6.LocalSID
+		updatedInput        *srv6.LocalSID
+		updatedExpectedDump *srv6.LocalSID
+	}{
+		{
+			name: "base end",
+			input: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_BaseEndFunction{
+					BaseEndFunction: &srv6.LocalSID_End{
+						Psp: true,
+					},
+				},
+			},
+			updatedInput: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_BaseEndFunction{
+					BaseEndFunction: &srv6.LocalSID_End{
+						Psp: false,
+					},
+				},
+			},
+		},
+		{
+			name: "end.X",
+			input: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionX{
+					EndFunctionX: &srv6.LocalSID_EndX{
+						Psp:               true,
+						NextHop:           nextHop.String(),
+						OutgoingInterface: ifName,
+					},
+				},
+			},
+			updatedInput: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionX{
+					EndFunctionX: &srv6.LocalSID_EndX{
+						Psp:               true,
+						NextHop:           nextHop2.String(), // updated
+						OutgoingInterface: ifName,
+					},
+				},
+			},
+		},
+		{
+			name: "end.T",
+			input: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionT{
+					EndFunctionT: &srv6.LocalSID_EndT{
+						Psp:   true,
+						VrfId: vrfTables[0].Id,
+					},
+				},
+			},
+			expectedDump: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionT{
+					EndFunctionT: &srv6.LocalSID_EndT{
+						Psp:   true,
+						VrfId: 1, // bug in VPP, it should return client Table ID but it returns vpp-inner Table ID
+					},
+				},
+			},
+			updatedInput: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionT{
+					EndFunctionT: &srv6.LocalSID_EndT{
+						Psp:   true,
+						VrfId: vrfTables[1].Id, // updated
+					},
+				},
+			},
+			updatedExpectedDump: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionT{
+					EndFunctionT: &srv6.LocalSID_EndT{
+						Psp:   true,
+						VrfId: 2, // bug in VPP, it should return client Table ID but it returns vpp-inner Table ID
+					},
+				},
+			},
+		},
+		{
+			name: "end.DT4",
+			input: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionDt4{
+					EndFunctionDt4: &srv6.LocalSID_EndDT4{
+						VrfId: vrfTables[2].Id,
+					},
+				},
+			},
+			expectedDump: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionDt4{
+					EndFunctionDt4: &srv6.LocalSID_EndDT4{
+						VrfId: 1, // bug in VPP, it should return client Table ID but it returns vpp-inner Table ID
+					},
+				},
+			},
+			updatedInput: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionDt4{
+					EndFunctionDt4: &srv6.LocalSID_EndDT4{
+						VrfId: vrfTables[3].Id, // updated
+					},
+				},
+			},
+			updatedExpectedDump: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionDt4{
+					EndFunctionDt4: &srv6.LocalSID_EndDT4{
+						VrfId: 2, // bug in VPP, it should return client Table ID but it returns vpp-inner Table ID
+					},
+				},
+			},
+		},
+		{
+			name: "end.DT6",
+			input: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionDt6{
+					EndFunctionDt6: &srv6.LocalSID_EndDT6{
+						VrfId: vrfTables[0].Id,
+					},
+				},
+			},
+			expectedDump: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionDt6{
+					EndFunctionDt6: &srv6.LocalSID_EndDT6{
+						VrfId: 1, // bug in VPP, it should return client Table ID but it returns vpp-inner Table ID
+					},
+				},
+			},
+			updatedInput: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionDt6{
+					EndFunctionDt6: &srv6.LocalSID_EndDT6{
+						VrfId: vrfTables[1].Id, // updated
+					},
+				},
+			},
+			updatedExpectedDump: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionDt6{
+					EndFunctionDt6: &srv6.LocalSID_EndDT6{
+						VrfId: 2, // bug in VPP, it should return client Table ID but it returns vpp-inner Table ID
+					},
+				},
+			},
+		},
+		{
+			name: "end.DX2",
+			input: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionDx2{
+					EndFunctionDx2: &srv6.LocalSID_EndDX2{
+						VlanTag:           0,
+						OutgoingInterface: ifName,
+					},
+				},
+			},
+			updatedInput: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionDx2{
+					EndFunctionDx2: &srv6.LocalSID_EndDX2{
+						VlanTag:           0,
+						OutgoingInterface: ifName2,
+					},
+				},
+			},
+		},
+		{
+			name: "end.DX4",
+			input: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionDx4{
+					EndFunctionDx4: &srv6.LocalSID_EndDX4{
+						NextHop:           nextHopIPv4.String(),
+						OutgoingInterface: ifName,
+					},
+				},
+			},
+			updatedInput: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionDx4{
+					EndFunctionDx4: &srv6.LocalSID_EndDX4{
+						NextHop:           nextHop2IPv4.String(), // updated
+						OutgoingInterface: ifName,
+					},
+				},
+			},
+		},
+		{
+			name: "end.DX6",
+			input: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionDx6{
+					EndFunctionDx6: &srv6.LocalSID_EndDX6{
+						NextHop:           nextHop.String(),
+						OutgoingInterface: ifName,
+					},
+				},
+			},
+			updatedInput: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: 0,
+				EndFunction: &srv6.LocalSID_EndFunctionDx6{
+					EndFunctionDx6: &srv6.LocalSID_EndDX6{
+						NextHop:           nextHop2.String(), // updated
+						OutgoingInterface: ifName,
+					},
+				},
+			},
+		},
+		{
+			name: "nondefault installation vrf table",
+			input: &srv6.LocalSID{
+				Sid:               sidA.String(),
+				InstallationVrfId: vrfTables[0].Id,
+				EndFunction: &srv6.LocalSID_BaseEndFunction{
+					BaseEndFunction: &srv6.LocalSID_End{
+						Psp: true,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create
+			Expect(srh.AddLocalSid(test.input)).Should(Succeed())
+
+			// Read
+			localsids, err := srh.DumpLocalSids()
+			t.Logf("received this localsids from dump: %v", localsids)
+			Expect(err).ShouldNot(HaveOccurred())
+			expected := test.input
+			if test.expectedDump != nil {
+				expected = test.expectedDump
+			}
+			Expect(localsids).Should(ConsistOf(expected))
+
+			// Update (for localsids it means delete + create)
+			if test.updatedInput != nil {
+				Expect(srh.DeleteLocalSid(test.input)).Should(Succeed())
+				Expect(srh.AddLocalSid(test.updatedInput)).Should(Succeed())
+				localsids, err = srh.DumpLocalSids()
+				t.Logf("received this localsids from dump: %v", localsids)
+				Expect(err).ShouldNot(HaveOccurred())
+				expected := test.updatedInput
+				if test.updatedExpectedDump != nil {
+					expected = test.updatedExpectedDump
+				}
+				Expect(localsids).Should(ConsistOf(expected))
+			}
+			// Delete
+			if test.updatedInput != nil {
+				Expect(srh.DeleteLocalSid(test.updatedInput)).Should(Succeed())
+			} else {
+				Expect(srh.DeleteLocalSid(test.input)).Should(Succeed())
+			}
+		})
+	}
+}
+
+// sid creates segment ID(=net.IP) from string
+func sid(str string) net.IP {
+	sid, err := parseIPv6(str)
+	if err != nil {
+		panic(fmt.Sprintf("can't parse %q into SRv6 SID (IPv6 address)", str))
+	}
+	return sid
+}
+
+// parseIPv6 parses string <str> to IPv6 address (including IPv4 address converted to IPv6 address)
+func parseIPv6(str string) (net.IP, error) {
+	ip := net.ParseIP(str)
+	if ip == nil {
+		return nil, fmt.Errorf(" %q is not ip address", str)
+	}
+	ipv6 := ip.To16()
+	if ipv6 == nil {
+		return nil, fmt.Errorf(" %q is not ipv6 address", str)
+	}
+	return ipv6, nil
+}

--- a/tests/integration/vpp/110_srv6_test.go
+++ b/tests/integration/vpp/110_srv6_test.go
@@ -32,11 +32,6 @@ import (
 	srv6 "go.ligato.io/vpp-agent/v2/proto/ligato/vpp/srv6"
 )
 
-const (
-	vrfID1 = 11
-	vrfID2 = 12
-)
-
 var (
 	sidA         = sid("A::")
 	nextHop      = net.ParseIP("B::").To16()


### PR DESCRIPTION
Rewritten some CRUD robot test for SRv6 localsids (except of SR-proxy localsid due to more complicated approach for dumping data for SR-proxy localsids). This includes some localsid dump support on vppcalls level (tests needed verification of data written to VPP)