### PR TITLE
refactor: Retrieve method for descriptor in iptables plugin

### DIFF
--- a/plugins/linux/iptablesplugin/linuxcalls/iptables_api.go
+++ b/plugins/linux/iptablesplugin/linuxcalls/iptables_api.go
@@ -50,8 +50,8 @@ type IPTablesAPIWrite interface {
 	// DeleteRule deletes a rule from the specified chain.
 	DeleteRule(protocol L3Protocol, table, chain string, rule string) error
 
-	// protocol deletes all rules within the specified chain.
-	DeleteAllRules(proto L3Protocol, table, chain string) error
+	// DeleteAllRules deletes all rules within the specified chain.
+	DeleteAllRules(protocol L3Protocol, table, chain string) error
 }
 
 // IPTablesAPIRead interface covers read methods inside linux calls package


### PR DESCRIPTION
Noticed I've forgot to `git add` this changes yesterday. Comments fixing is the most important part in here :)

- Switch back to the default namespace asap. 
  _problem PR fixes:_ 
      if `d.ipTablesHandler.ListRules()` returns error, call `continue` and skip switching to default network ns.
- Return early if no rule chain is present.
  _problem PR fixes:_ 
      check if `if goRoutinesCnt == 0 ` and it could happen only if `correlate` is empty. Set it to 1 and call `retrieveRuleChains` anyway.