### PR TITLE
fix: duplicate linux addr

### DIFF
--- a/plugins/linux/ifplugin/descriptor/interface_address.go
+++ b/plugins/linux/ifplugin/descriptor/interface_address.go
@@ -149,7 +149,7 @@ func (d *InterfaceAddressDescriptor) Create(key string, emptyVal proto.Message) 
 	err = d.ifHandler.AddInterfaceIP(ifMeta.HostIfName, ipAddr)
 
 	// an attempt to add already assigned IP is not considered as error
-	if err == syscall.EEXIST {
+	if errors.Cause(err) == syscall.EEXIST {
 		err = nil
 	}
 	return nil, err

--- a/tests/e2e/020_netalloc_test.go
+++ b/tests/e2e/020_netalloc_test.go
@@ -16,8 +16,6 @@ package e2e
 
 import (
 	"context"
-	"os"
-	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -572,14 +570,6 @@ func TestVPPRoutesWithNetalloc(t *testing.T) {
 	Expect(ctx.pingFromVPP(linuxLoopNet1IP)).To(Succeed())
 	Expect(ctx.pingFromVPP(linuxLoopNet2IP)).To(Succeed())
 	Expect(ctx.agentInSync()).To(BeTrue())
-
-	if strings.HasSuffix(os.Getenv("VPP_IMG"), "19.08") {
-		// TODO: we cannot handle microservice restarts in 19.08 since the TAP interface
-		// attached to the stopped microservice is automatically removed, but not the
-		// associated routes and it is not possible to remove/update them
-		// Waiting for reaction from VPP dev...
-		return
-	}
 
 	// restart microservice
 	ctx.stopMicroservice(msName)


### PR DESCRIPTION
cherry-pick: f0f912e660e474226b1ac5aa418d03b2d93cad16 (#1586)