### PR TITLE
fix: shellcheck almost happy

### DIFF
--- a/docker/dev/build.sh
+++ b/docker/dev/build.sh
@@ -35,6 +35,6 @@ docker build -f Dockerfile \
     --build-arg SKIP_CHECK="${SKIP_CHECK:-}" \
     --tag ${IMAGE_TAG} \
     --pull \
- "${DOCKER_BUILD_ARGS-}" ../..
+ ${DOCKER_BUILD_ARGS-} ../..
 
 docker run --rm "${IMAGE_TAG}" vpp-agent -h || true

--- a/docker/dev/build.sh
+++ b/docker/dev/build.sh
@@ -27,14 +27,14 @@ echo "==============================================="
 set -x
 
 docker build -f Dockerfile \
-    --build-arg VPP_IMG=${VPP_IMG} \
-    --build-arg VPP_BINAPI=${VPP_BINAPI} \
-    --build-arg VERSION=${VERSION} \
-    --build-arg COMMIT=${COMMIT} \
-    --build-arg DATE=${DATE} \
-    --build-arg SKIP_CHECK=${SKIP_CHECK:-} \
+    --build-arg VPP_IMG="${VPP_IMG}" \
+    --build-arg VPP_BINAPI="${VPP_BINAPI}" \
+    --build-arg VERSION="${VERSION}" \
+    --build-arg COMMIT="${COMMIT}" \
+    --build-arg DATE="${DATE}" \
+    --build-arg SKIP_CHECK="${SKIP_CHECK:-}" \
     --tag ${IMAGE_TAG} \
     --pull \
- ${DOCKER_BUILD_ARGS-} ../..
+ "${DOCKER_BUILD_ARGS-}" ../..
 
 docker run --rm "${IMAGE_TAG}" vpp-agent -h || true

--- a/docker/dev/init_hook.sh
+++ b/docker/dev/init_hook.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 terminate_process () {
-    PID=$(pidof $1)
+    PID=$(pidof "$1")
     if [[ ${PID} != "" ]]; then
-        kill ${PID}
+        kill "${PID}"
         echo "process $1 terminated"
     fi
 }

--- a/docker/dev/push_image.sh
+++ b/docker/dev/push_image.sh
@@ -14,7 +14,7 @@ set -e
 # detect branch name
 BRANCH_NAME="$(git symbolic-ref HEAD 2>/dev/null)" || BRANCH_NAME="(unnamed branch)"     # detached HEAD
 BRANCH_NAME=${BRANCH_NAME##refs/heads/}
-BRANCH_HEAD_TAG=${BRANCH_HEAD_TAG:-"`git name-rev --name-only --tags HEAD`"}
+BRANCH_HEAD_TAG=${BRANCH_HEAD_TAG:-"$(git name-rev --name-only --tags HEAD)"}
 VERSION=$(git describe --always --tags --dirty)
 
 LOCAL_IMAGE=${LOCAL_IMAGE:-'dev_vpp_agent:latest'}
@@ -26,7 +26,7 @@ IMAGE_NAME=${IMAGE_NAME:-'dev-vpp-agent'}
 #For fat manifest, please refer
 #https://docs.docker.com/registry/spec/manifest-v2-2/#example-manifest-list
 
-BUILDARCH=`uname -m`
+BUILDARCH=$(uname -m)
 
 case "$BUILDARCH" in
   "aarch64" )
@@ -50,29 +50,29 @@ echo "=============================="
 
 case "${BRANCH_NAME}" in
   "master" )
-    if [ ${BRANCH_HEAD_TAG} != "undefined" ] ; then
-      if [ ${BUILDARCH} = "x86_64" ] ; then
+    if [ "${BRANCH_HEAD_TAG}" != "undefined" ] ; then
+      if [ "${BUILDARCH}" = "x86_64" ] ; then
         # for AMD64 platform is used also the default image (without suffix -amd64)
-        docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_HEAD_TAG}
-        docker push ${REPO_OWNER}/${IMAGE_NAME}:${BRANCH_HEAD_TAG}
-        docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${IMAGE_NAME}:latest
-        docker push ${REPO_OWNER}/${IMAGE_NAME}:latest
+        docker tag "${LOCAL_IMAGE}" "${REPO_OWNER}"/"${IMAGE_NAME}":"${BRANCH_HEAD_TAG}"
+        docker push "${REPO_OWNER}"/"${IMAGE_NAME}":"${BRANCH_HEAD_TAG}"
+        docker tag "${LOCAL_IMAGE}" "${REPO_OWNER}"/"${IMAGE_NAME}":latest
+        docker push "${REPO_OWNER}"/"${IMAGE_NAME}":latest
       fi
-      docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_HEAD_TAG}
-      docker push ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_HEAD_TAG}
-      docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:latest
-      docker push ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:latest
+      docker tag "${LOCAL_IMAGE}" "${REPO_OWNER}"/"${IMAGE_NAME}"-${ARCH_SUFFIX}:"${BRANCH_HEAD_TAG}"
+      docker push "${REPO_OWNER}"/"${IMAGE_NAME}"-${ARCH_SUFFIX}:"${BRANCH_HEAD_TAG}"
+      docker tag "${LOCAL_IMAGE}" "${REPO_OWNER}"/"${IMAGE_NAME}"-${ARCH_SUFFIX}:latest
+      docker push "${REPO_OWNER}"/"${IMAGE_NAME}"-${ARCH_SUFFIX}:latest
     else
       echo "For branch ${BRANCH_NAME} is no setup for tagging and pushing docker images because HEAD has no tag."
     fi
     ;;
   "(unnamed branch)" )
-    docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:${VERSION}
+    docker tag "${LOCAL_IMAGE}" "${REPO_OWNER}"/"${IMAGE_NAME}"-${ARCH_SUFFIX}:"${VERSION}"
     echo "Repository is in detached HEAD state - please push manually:"
-    echo docker push ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:${VERSION}
+    echo docker push "${REPO_OWNER}"/"${IMAGE_NAME}"-${ARCH_SUFFIX}:"${VERSION}"
     ;;
   * )
-    docker tag ${LOCAL_IMAGE} ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_NAME}
-    docker push ${REPO_OWNER}/${IMAGE_NAME}-${ARCH_SUFFIX}:${BRANCH_NAME}
+    docker tag "${LOCAL_IMAGE}" "${REPO_OWNER}"/"${IMAGE_NAME}"-${ARCH_SUFFIX}:"${BRANCH_NAME}"
+    docker push "${REPO_OWNER}"/"${IMAGE_NAME}"-${ARCH_SUFFIX}:"${BRANCH_NAME}"
     ;;
 esac

--- a/docker/prod/build.sh
+++ b/docker/prod/build.sh
@@ -22,6 +22,6 @@ set -x
 docker build -f Dockerfile \
     --build-arg DEV_IMG=${DEV_IMG} \
 	  --tag ${IMAGE_TAG} \
- "${DOCKER_BUILD_ARGS-}" .
+ ${DOCKER_BUILD_ARGS-} .
 
 docker run --rm "${IMAGE_TAG}" vpp-agent -h || true

--- a/docker/prod/build.sh
+++ b/docker/prod/build.sh
@@ -4,7 +4,7 @@ cd "$(dirname "$0")"
 
 set -euo pipefail
 
-buildArch=`uname -m`
+buildArch=$(uname -m)
 case "${buildArch##*-}" in
 	  aarch64) ;;
   	x86_64) ;;
@@ -22,6 +22,6 @@ set -x
 docker build -f Dockerfile \
     --build-arg DEV_IMG=${DEV_IMG} \
 	  --tag ${IMAGE_TAG} \
- ${DOCKER_BUILD_ARGS-} .
+ "${DOCKER_BUILD_ARGS-}" .
 
 docker run --rm "${IMAGE_TAG}" vpp-agent -h || true

--- a/docker/prod/init_hook.sh
+++ b/docker/prod/init_hook.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 terminate_process () {
-    PID=$(pidof $1)
+    PID=$(pidof "$1")
     if [[ ${PID} != "" ]]; then
-        kill ${PID}
+        kill "${PID}"
         echo "process $1 terminated"
     fi
 }

--- a/k8s/perf-demo/etcdimport.sh
+++ b/k8s/perf-demo/etcdimport.sh
@@ -4,7 +4,7 @@ etcdKey=""
 while read line || [[ -n "$line" ]]; do
     if [ "${line:0:1}" != "/" ] ; then
         value="$(echo "$line"|tr -d '\r\n')"
-        kubectl exec etcd-server etcdctl -- put --endpoints=[127.0.0.1:22379] $etcdKey "$value"
+        kubectl exec etcd-server etcdctl -- put --endpoints=[127.0.0.1:22379] "$etcdKey" "$value"
     else
         etcdKey="$(echo "$line"|tr -d '\r\n')"
     fi

--- a/k8s/tests/startK8.sh
+++ b/k8s/tests/startK8.sh
@@ -1,10 +1,10 @@
 #starts k8s with flannel networking
 sudo kubeadm reset
-sudo rm -rf $HOME/.kube
+sudo rm -rf "$HOME"/.kube
 sudo kubeadm init --pod-network-cidr=10.244.0.0/16
-mkdir -p $HOME/.kube
-sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
-sudo chown $(id -u):$(id -g) $HOME/.kube/config
+mkdir -p "$HOME"/.kube
+sudo cp -i /etc/kubernetes/admin.conf "$HOME"/.kube/config
+sudo chown $(id -u):$(id -g) "$HOME"/.kube/config
 kubectl taint nodes --all node-role.kubernetes.io/master-
 kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
 kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel-rbac.yml

--- a/k8s/tests/timemeasure.sh
+++ b/k8s/tests/timemeasure.sh
@@ -11,15 +11,15 @@ calcTimeFormat(){
     dt3=$(echo "$dt2-3600*$dh" | bc)
     dm=$(echo "$dt3/60" | bc)
     ds=$(echo "$dt3-60*$dm" | bc)
-    retstr=LC_NUMERIC="en_US.UTF-8" printf "%02d:%02d:%02.5f\n" $dh $dm $ds
-    echo $retstr
+    retstr=LC_NUMERIC="en_US.UTF-8" printf "%02d:%02d:%02.5f\n" "$dh" "$dm" "$ds"
+    echo "$retstr"
 }
 
 # takes timemstamp format value and calculates nanoseconds
 calcNanoTime(){
-    a=(`echo $1 | sed -e 's/[:]/ /g'`)
+    a=($(echo "$1" | sed -e 's/[:]/ /g'))
     seconds= echo "${a[2]}+60*${a[1]}+3600*${a[0]}" | bc
-    echo $seconds
+    echo "$seconds"
 }
 
 # takes ns time value and returns HH:MM:SS:ms time format
@@ -30,8 +30,8 @@ showTime(){
     dt3=$(echo "$dt2-3600*$dh" | bc)
     dm=$(echo "$dt3/60" | bc)
     ds=$(echo "$dt3-60*$dm" | bc)
-    retstr=LC_NUMERIC="en_US.UTF-8" printf "%02d:%02d:%02.5f\n" $dh $dm $ds
-    echo $retstr
+    retstr=LC_NUMERIC="en_US.UTF-8" printf "%02d:%02d:%02.5f\n" "$dh" "$dm" "$ds"
+    echo "$retstr"
 }
 
 # proccess intermediate file log/out.csv
@@ -66,7 +66,7 @@ while IFS="," read -r val1 val2 val3;do
     line_id=$((line_id+1))  
   elif [[ "$val2" == ' Started measuring' ]]
   then
-    start=$(calcNanoTime $val1)
+    start=$(calcNanoTime "$val1")
     echo "$line_id,$run,Measuring started,$val1,00:00:00.0,0" >> log/measuring_exp.csv
     echo "$line_id,$run,Measuring started,$val1,00:00:00.0,0"
     rel_item=$line_id
@@ -75,207 +75,207 @@ while IFS="," read -r val1 val2 val3;do
   elif [[ "$val2" == ' Starting the agent...' ]]
   then
     vppKilled=0
-    startAgent=$(calcNanoTime $val1)
+    startAgent=$(calcNanoTime "$val1")
     diff=$(echo "$startAgent-$start" | bc)
     if [ $(bc <<< "$diff > 0") -eq 1 ]
     then
-        time=$(showTime $diff)
+        time=$(showTime "$diff")
         echo "$line_id,$run,Starting Agent,$val1,$time,$rel_item" >> log/measuring_exp.csv
         echo "$line_id,$run,Starting Agent,$val1,$time,$rel_item"
         rel_item=$line_id
         line_id=$((line_id+1))
     else
-      time=$(showTime $start)
+      time=$(showTime "$start")
       echo "$line_id,$run,Kill failed,$time,00:00:00.0,0" >> log/measuring_exp.csv
       echo "$line_id,$run,Kill failed,$time,00:00:00.0,0"
       line_id=$((line_id+1))
     fi
   elif [[ "$val2" =~ ' Connecting to etcd took' ]]
   then
-    etcdTime=$(calcNanoTime $val1)
+    etcdTime=$(calcNanoTime "$val1")
     etcdStamp=$val1
     #etcdTookTime=$(bc <<< "scale = 10; $val3 / 1000000 ")
-    a=(`echo $val3 | sed -e 's/[:]/ /g'`)
+    a=($(echo "$val3" | sed -e 's/[:]/ /g'))
     etcdTookTimge=$(bc <<< "scale = 10; ${a[0]} / 1000000 ")
 
   elif [[ "$val2" =~ ' Resync took' ]]
   then
-    resyncTime=$(calcNanoTime $val1)
+    resyncTime=$(calcNanoTime "$val1")
     resyncStamp=$val1
     #resyncTookTime=$(bc <<< "scale = 10; $val3 / 1000000 ")
-    a=(`echo $val3 | sed -e 's/[:]/ /g'`)
+    a=($(echo "$val3" | sed -e 's/[:]/ /g'))
     resyncTookTime=$(bc <<< "scale = 10; ${a[0]} / 1000000 ")
 
   elif [[ "$val2" == ' VPP Killed' ]]
   then
-    vppKilled=$(calcNanoTime $val1)
+    vppKilled=$(calcNanoTime "$val1")
     vppItem=$line_id
     diff=$(echo "$vppKilled-$start" | bc)
-    time=$(showTime $diff)
+    time=$(showTime "$diff")
     echo "$line_id,$run,VPP Killed,$val1,$time,$rel_item" >> log/measuring_exp.csv
     echo "$line_id,$run,VPP Killed,$val1,$time,$rel_item"
     line_id=$((line_id+1)) 
     
   elif [[ "$val2" == ' VPP-Agent Killed' ]]
   then
-    vppKilled=$(calcNanoTime $val1)
+    vppKilled=$(calcNanoTime "$val1")
     vppItem=$line_id
     diff=$(echo "$vppKilled-$start" | bc)
-    time=$(showTime $diff)
+    time=$(showTime "$diff")
     echo "$line_id,$run,VPP Agent Killed,$val1,$time,$rel_item" >> log/measuring_exp.csv
     echo "$line_id,$run,VPP Agent Killed,$val1,$time,$rel_item"
     line_id=$((line_id+1))   
   elif [[ "$val2" =~ ' Loading topology' ]]
   then
     diff=$(echo "$vppKilled-0" | bc)
-    time=$(showTime $diff)
+    time=$(showTime "$diff")
     echo "$line_id,$run,$val2,$val1,$time,0" >> log/measuring_exp.csv
     echo "$line_id,$run,$val2,$val1,$time,0"
     line_id=$((line_id+1))
   elif [[ "$val2" =~ ' Container cooled down for' ]]
   then
-    coreDone=$(calcNanoTime $val1)
+    coreDone=$(calcNanoTime "$val1")
     diff=$(echo "$coreDone - $startAgent" | bc)
-    time=$(showTime $diff)
+    time=$(showTime "$diff")
     echo "$line_id,$run,$val2,$val1,$time,$rel_item" >> log/measuring_exp.csv
     echo "$line_id,$run,$val2,$val1,$time,$vppItem"    
     line_id=$((line_id+1))    
   elif [[ "$val2" =~ ' Core dump of size' ]]
   then
-    coreDone=$(calcNanoTime $val1)
+    coreDone=$(calcNanoTime "$val1")
     diff=$(echo "$coreDone - $vppKilled" | bc)
-    time=$(showTime $diff)
+    time=$(showTime "$diff")
     echo "$line_id,$run,$val2,$val1,$time,$vppItem" >> log/measuring_exp.csv
     echo "$line_id,$run,$val2,$val1,$time,$vppItem"    
     line_id=$((line_id+1))
   elif [[ "$val2" = ' Core dump not created' ]]
   then
-    coreDone=$(calcNanoTime $val1)
+    coreDone=$(calcNanoTime "$val1")
     diff=$(echo "$coreDone - $vppKilled" | bc)
-    time=$(showTime $diff)
+    time=$(showTime "$diff")
     echo "$line_id,$run,$val2,$val1,$time,$vppItem" >> log/measuring_exp.csv
     echo "$line_id,$run,$val2,$val1,$time,$vppItem"    
     line_id=$((line_id+1))
   elif [[ "$val2" =~ ' call took' ]]
   then
-    coreDone=$(calcNanoTime $val1)
+    coreDone=$(calcNanoTime "$val1")
     diff=$(echo "$coreDone - $resyncBeginTime" | bc)
-    time=$(showTime $diff)
-    a=(`echo $val3 | sed -e 's/[:]/ /g'`)
+    time=$(showTime "$diff")
+    a=($(echo "$val3" | sed -e 's/[:]/ /g'))
     vppTookTime=$(bc <<< "scale = 10; ${a[0]} / 1000000 ")
     echo "$line_id,$run,$val2,$val1,$time,$resyncBeginItem,$vppTookTime" >> log/measuring_exp.csv
     echo "$line_id,$run,$val2,$val1,$time,$resyncBeginItem,$vppTookTime"    
     line_id=$((line_id+1)) 
   elif [[ "$val2" =~ ' stopwatch has no entries' ]]
   then
-    coreDone=$(calcNanoTime $val1)
+    coreDone=$(calcNanoTime "$val1")
     diff=$(echo "$coreDone - $resyncBeginTime" | bc)
-    time=$(showTime $diff)
+    time=$(showTime "$diff")
     echo "$line_id,$run,$val2,$val1,$time,$resyncBeginItem" >> log/measuring_exp.csv
     echo "$line_id,$run,$val2,$val1,$time,$resyncBeginItem"    
     line_id=$((line_id+1)) 
   elif [[ "$val2" =~ ' partial resync time is' ]]
   then
-    coreDone=$(calcNanoTime $val1)
+    coreDone=$(calcNanoTime "$val1")
     diff=$(echo "$coreDone - $resyncBeginTime" | bc)
-    time=$(showTime $diff)
-    a=(`echo $val3 | sed -e 's/[:]/ /g'`)
+    time=$(showTime "$diff")
+    a=($(echo "$val3" | sed -e 's/[:]/ /g'))
     vppTookTime=$(bc <<< "scale = 10; ${a[0]} / 1000000 ")
     echo "$line_id,$run,$val2,$val1,$time,$resyncBeginItem,$vppTookTime" >> log/measuring_exp.csv
     echo "$line_id,$run,$val2,$val1,$time,$resyncBeginItem,$vppTookTime"    
     line_id=$((line_id+1))  
   elif [[ "$val2" = ' Sleeping while VPP will be ready' ]]
   then
-    coreDone=$(calcNanoTime $val1)
+    coreDone=$(calcNanoTime "$val1")
     diff=$(echo "$coreDone - $startAgent" | bc)
-    time=$(showTime $diff)
+    time=$(showTime "$diff")
     echo "$line_id,$run,$val2,$val1,$time,$rel_item" >> log/measuring_exp.csv
     echo "$line_id,$run,$val2,$val1,$time,$rel_item"    
     line_id=$((line_id+1)) 
   elif [[ "$val2" = ' VPP is ready to connect' ]]
   then
-    coreDone=$(calcNanoTime $val1)
+    coreDone=$(calcNanoTime "$val1")
     diff=$(echo "$coreDone - $startAgent" | bc)
-    time=$(showTime $diff)
+    time=$(showTime "$diff")
     echo "$line_id,$run,$val2,$val1,$time,$rel_item" >> log/measuring_exp.csv
     echo "$line_id,$run,$val2,$val1,$time,$rel_item"    
     line_id=$((line_id+1))   
   elif [[ "$val2" =~ ' Connecting to VPP took' ]]
   then
-    vppTime=$(calcNanoTime $val1)
+    vppTime=$(calcNanoTime "$val1")
     vppStamp=$val1
     #vppTookTime=$(bc <<< "scale = 10; $val3 / 1000000 ")
-    a=(`echo $val3 | sed -e 's/[:]/ /g'`)
+    a=($(echo "$val3" | sed -e 's/[:]/ /g'))
     vppTookTime=$(bc <<< "scale = 10; ${a[0]} / 1000000 ")
   elif [[ "$val2" =~ ' resync the VPP Configuration begin' ]]
   then
-    resyncBeginTime=$(calcNanoTime $val1)
+    resyncBeginTime=$(calcNanoTime "$val1")
     resyncBeginTimeStamp=$val1
     resyncBeginItem=$line_id 
     diff=$(echo "$resyncBeginTime - $startAgent" | bc)
-    time=$(showTime $diff)
+    time=$(showTime "$diff")
     echo "$line_id,$run,$val2,$val1,$time,$rel_item" >> log/measuring_exp.csv
     echo "$line_id,$run,$val2,$val1,$time,$rel_item"    
     line_id=$((line_id+1))       
   elif [[ "$val2" =~ ' resync the Linux Configuration' ]]
   then
-    resyncBeginTime=$(calcNanoTime $val1)
+    resyncBeginTime=$(calcNanoTime "$val1")
     resyncBeginTimeStamp=$val1
     resyncBeginItem=$line_id 
     diff=$(echo "$resyncBeginTime - $startAgent" | bc)
-    time=$(showTime $diff)
+    time=$(showTime "$diff")
     echo "$line_id,$run,$val2,$val1,$time,$rel_item" >> log/measuring_exp.csv
     echo "$line_id,$run,$val2,$val1,$time,$rel_item"    
     line_id=$((line_id+1))       
 
   elif [[ "$val2" =~ ' Connecting to kafka took' ]]
   then
-    kafkaTime=$(calcNanoTime $val1)
+    kafkaTime=$(calcNanoTime "$val1")
     kafkaStamp=$val1
     #kafkaTookTime=$(bc <<< "scale = 10; $val3 / 1000000 ")
-    a=(`echo $val3 | sed -e 's/[:]/ /g'`)
+    a=($(echo "$val3" | sed -e 's/[:]/ /g'))
     kafkaTookTime=$(bc <<< "scale = 10; ${a[0]} / 1000000 ")
   elif [[ "$val2" =~ ' plugin GoVPP: Init' ]]
   then
-    GoVPPInitTime=$(calcNanoTime $val1)
+    GoVPPInitTime=$(calcNanoTime "$val1")
     GoVPPInitStamp=$val1
-    a=(`echo $val3 | sed -e 's/[:]/ /g'`)
+    a=($(echo "$val3" | sed -e 's/[:]/ /g'))
     GoVPPInitTookTime=$(bc <<< "scale = 10; ${a[0]} / 1000000 ")
   elif [[ "$val2" =~ ' plugin Linux: Init' ]]
   then
-    LinuxInitTime=$(calcNanoTime $val1)
+    LinuxInitTime=$(calcNanoTime "$val1")
     LinuxInitStamp=$val1
-    a=(`echo $val3 | sed -e 's/[:]/ /g'`)
+    a=($(echo "$val3" | sed -e 's/[:]/ /g'))
     LinuxInitTookTime=$(bc <<< "scale = 10; ${a[0]} / 1000000 ")
   elif [[ "$val2" =~ ' plugin VPP: Init' ]]
   then
-    PluginVPPInitTime=$(calcNanoTime $val1)
+    PluginVPPInitTime=$(calcNanoTime "$val1")
     PluginVPPInitStamp=$val1
-    a=(`echo $val3 | sed -e 's/[:]/ /g'`)
+    a=($(echo "$val3" | sed -e 's/[:]/ /g'))
     PluginVPPInitTookTime=$(bc <<< "scale = 10; ${a[0]} / 1000000 ")
   elif [[ "$val2" =~ ' resync the VPP Configuration end' ]]
   then
-    PluginVPPResyncTime=$(calcNanoTime $val1)
+    PluginVPPResyncTime=$(calcNanoTime "$val1")
     PluginVPPResyncStamp=$val1
-    a=(`echo $val3 | sed -e 's/[:]/ /g'`)
+    a=($(echo "$val3" | sed -e 's/[:]/ /g'))
     PluginVPPResyncTookTime=$(bc <<< "scale = 10; ${a[0]} / 1000000 ")
   elif [[ "$val2" =~ ' Agent Init' ]]
   then
-    AgentInitTime=$(calcNanoTime $val1)
+    AgentInitTime=$(calcNanoTime "$val1")
     AgentInitStamp=$val1
-    a=(`echo $val3 | sed -e 's/[:]/ /g'`)
+    a=($(echo "$val3" | sed -e 's/[:]/ /g'))
     AgentInitTookTime=$(bc <<< "scale = 10; ${a[0]} / 1000000 ")
   elif [[ "$val2" =~ ' Agent AfterInit' ]]
   then
-    AgentAfterInitTime=$(calcNanoTime $val1)
+    AgentAfterInitTime=$(calcNanoTime "$val1")
     AgentAfterInitStamp=$val1
-    a=(`echo $val3 | sed -e 's/[:]/ /g'`)
+    a=($(echo "$val3" | sed -e 's/[:]/ /g'))
     AgentAfterInitTookTime=$(bc <<< "scale = 10; ${a[0]} / 1000000 ")
   elif [ "$val2" == ' Killed' ]
   then
-    start1=$(calcNanoTime $val1)
+    start1=$(calcNanoTime "$val1")
     diff=$(echo "$start1-$start" | bc)
-    time=$(showTime $diff)
+    time=$(showTime "$diff")
     if [ $(bc <<< "$diff < 0") -eq 1 ]
     then
       echo "$line_id,$run,Kill failed,$val1,$time,$rel_item" >> log/measuring_exp.csv
@@ -330,76 +330,76 @@ while IFS="," read -r val1 val2 val3;do
     if [ $(bc <<< "$diff > 0") -eq 1 ]
     then
       diff=$(echo "$etcdTime-$startAgent" | bc)
-      time=$(showTime $diff)
+      time=$(showTime "$diff")
       echo "$line_id,$run,ETCD connected,$etcdStamp,$time,$rel_item,$etcdTookTime" >> log/measuring_exp.csv
       echo "$line_id,$run,ETCD connected,$etcdStamp,$time,$rel_item,$etcdTookTime"
       line_id=$((line_id+1))
       diff=$(echo "$kafkaTime-$startAgent" | bc)
-      time=$(showTime $diff)
+      time=$(showTime "$diff")
       echo "$line_id,$run,Kafka connected,$kafkaStamp,$time,$rel_item,$kafkaTookTime" >> log/measuring_exp.csv
       echo "$line_id,$run,Kafka connected,$kafkaStamp,$time,$rel_item,$kafkaTookTime"
       line_id=$((line_id+1))
       diff=$(echo "$vppTime-$startAgent" | bc)
-      time=$(showTime $diff)
+      time=$(showTime "$diff")
       echo "$line_id,$run,VPP connected,$vppStamp,$time,$rel_item,$vppTookTime" >> log/measuring_exp.csv
       echo "$line_id,$run,VPP connected,$vppStamp,$time,$rel_item,$vppTookTime"
       line_id=$((line_id+1))
       diff=$(echo "$GoVPPInitTime-$startAgent" | bc)
-      time=$(showTime $diff)
+      time=$(showTime "$diff")
       echo "$line_id,$run,GoVPP Init,$GoVPPInitStamp,$time,$rel_item,$GoVPPInitTookTime" >> log/measuring_exp.csv
       echo "$line_id,$run,GoVPP Init,$GoVPPInitStamp,$time,$rel_item,$GoVPPInitTookTime"
 
       line_id=$((line_id+1))
       diff=$(echo "$LinuxInitTime-$startAgent" | bc)
-      time=$(showTime $diff)
+      time=$(showTime "$diff")
       echo "$line_id,$run,Linux plugin Init,$LinuxInitStamp,$time,$rel_item,$LinuxInitTookTime" >> log/measuring_exp.csv
       echo "$line_id,$run,Linux plugin Init,$LinuxInitStamp,$time,$rel_item,$LinuxInitTookTime"
 
       line_id=$((line_id+1))
       diff=$(echo "$PluginVPPInitTime-$startAgent" | bc)
-      time=$(showTime $diff)
+      time=$(showTime "$diff")
       echo "$line_id,$run,VPP plugin Init,$PluginVPPInitStamp,$time,$rel_item,$PluginVPPInitTookTime" >> log/measuring_exp.csv
       echo "$line_id,$run,VPP plugin Init,$PluginVPPInitStamp,$time,$rel_item,$PluginVPPInitTookTime"
 
       line_id=$((line_id+1))
       diff=$(echo "$PluginVPPResyncTime-$startAgent" | bc)
-      time=$(showTime $diff)
+      time=$(showTime "$diff")
       echo "$line_id,$run,Resync of VPP config,$PluginVPPResyncStamp,$time,$rel_item,$PluginVPPResyncTookTime" >> log/measuring_exp.csv
       echo "$line_id,$run,Resync of VPP config,$PluginVPPResyncStamp,$time,$rel_item,$PluginVPPResyncTookTime"
 
       line_id=$((line_id+1))
       diff=$(echo "$resyncTime-$startAgent" | bc)
-      time=$(showTime $diff)
+      time=$(showTime "$diff")
       echo "$line_id,$run,Resync done,$resyncStamp,$time,$rel_item,$resyncTookTime" >> log/measuring_exp.csv
       echo "$line_id,$run,Resync done,$resyncStamp,$time,$rel_item,$resyncTookTime"
 
       line_id=$((line_id+1))
       diff=$(echo "$AgentInitTime-$startAgent" | bc)
-      time=$(showTime $diff)
+      time=$(showTime "$diff")
       echo "$line_id,$run,Agent Init,$AgentInitStamp,$time,$rel_item,$AgentInitTookTime" >> log/measuring_exp.csv
       echo "$line_id,$run,Agent Init,$AgentInitStamp,$time,$rel_item,$AgentInitTookTime"
 
       line_id=$((line_id+1))
       diff=$(echo "$AgentAfterInitTime-$startAgent" | bc)
-      time=$(showTime $diff)
+      time=$(showTime "$diff")
       echo "$line_id,$run,Agent AfterInit,$AgentAfterInitStamp,$time,$rel_item,$AgentAfterInitTookTime" >> log/measuring_exp.csv
       echo "$line_id,$run,Agent AfterInit,$AgentAfterInitStamp,$time,$rel_item,$AgentAfterInitTookTime"
 
 
       line_id=$((line_id+1))
       diff=$(echo "$AllInitTime-$startAgent" | bc)
-      time=$(showTime $diff)
+      time=$(showTime "$diff")
       echo "$line_id,$run,Agent ready,$AllInitStamp,$time,$rel_item" >> log/measuring_exp.csv
       echo "$line_id,$run,Agent ready,$AllInitStamp,$time,$rel_item"
       line_id=$((line_id+1))
     fi
   elif [ "$val2" == ' All plugins initialized successfully' ]
   then
-      AllInitTime=$(calcNanoTime $val1)
+      AllInitTime=$(calcNanoTime "$val1")
       AllInitStamp=$val1
-      a=(`echo $val3 | sed -e 's/[:]/ /g'`)
+      a=($(echo "$val3" | sed -e 's/[:]/ /g'))
   fi
-done <$1
+done <"$1"
 }
 
 # starting etcd and kafka containers
@@ -501,18 +501,18 @@ EOF
 KillVppAndCheck() {
     vpp_id_line=$(kubectl exec vpp -- ps aux | grep /usr/bin/vpp)
     #echo $vpp_id_line
-    vpp_id=$(echo $vpp_id_line | awk '{print $2}')
+    vpp_id=$(echo "$vpp_id_line" | awk '{print $2}')
     #echo $vpp_id
     sudo rm -f /tmp/cores/core.dump
     restime0=$(showTime $(date +%s.%N))
     echo "$restime0, VPP Killed" >> log/out.csv
     echo "Killing the vpp - run ${i}"
-    kubectl exec vpp -- kill -s ABRT $vpp_id
+    kubectl exec vpp -- kill -s ABRT "$vpp_id"
     for (( ig = 1; ig <= 800; ig++ ))
     do
       vpp_id_line=$(kubectl exec vpp -- ps aux | grep /bin/vpp-agent)
       #echo $vpp_id_line
-      new_vpp_id=$(echo $vpp_id_line | awk '{print $2}')
+      new_vpp_id=$(echo "$vpp_id_line" | awk '{print $2}')
       if [[ $vpp_id != $new_vpp_id ]]
       then
          echo "VPP was killed!"
@@ -529,18 +529,18 @@ KillVppAndCheck() {
 KillAgentAndCheck() {
     vpp_id_line=$(kubectl exec vpp -- ps aux | grep /bin/vpp-agent)
     #echo $vpp_id_line
-    vpp_id=$(echo $vpp_id_line | awk '{print $2}')
+    vpp_id=$(echo "$vpp_id_line" | awk '{print $2}')
     #echo $vpp_id
     sudo rm -f /tmp/cores/core.dump
     restime0=$(showTime $(date +%s.%N))
     echo "$restime0, VPP-Agent Killed" >> log/out.csv
     echo "Killing the VPP-agent - run ${i}"
-    kubectl exec vpp -- kill -s ABRT $vpp_id
+    kubectl exec vpp -- kill -s ABRT "$vpp_id"
     for (( ig = 1; ig <= 800; ig++ ))
     do
       vpp_id_line=$(kubectl exec vpp -- ps aux | grep /bin/vpp-agent)
       #echo $vpp_id_line
-      new_vpp_id=$(echo $vpp_id_line | awk '{print $2}')
+      new_vpp_id=$(echo "$vpp_id_line" | awk '{print $2}')
       if [[ "$vpp_id" != "$new_vpp_id" ]]
       then
          echo "VPP-agent was killed!"
@@ -559,12 +559,12 @@ getCoreDumpFile() {
       if [ -f  /tmp/cores/core.dump ]
       then
 	vpp_core_final=$(stat -c %y /tmp/cores/core.dump)
-	vpp_core_final_time=$(echo $vpp_core_final | awk '{print $2}')
-	vpp_core_final_time_zone=$(echo $vpp_core_final | awk '{print $3}')
+	vpp_core_final_time=$(echo "$vpp_core_final" | awk '{print $2}')
+	vpp_core_final_time_zone=$(echo "$vpp_core_final" | awk '{print $3}')
 	tz_sign=${vpp_core_final_time_zone:0:1}
 	tz_value=${vpp_core_final_time_zone:1:4}
 	tz=$(echo "$tz_value/100" | bc)
-	vpp_calc=$(calcNanoTime $vpp_core_final_time)
+	vpp_calc=$(calcNanoTime "$vpp_core_final_time")
 	tzsec=$(echo "$tz*3600" | bc)
 	#echo "Core_final:$vpp_core_final"
 	#echo "Core_final_time:$vpp_core_final_time"
@@ -580,11 +580,11 @@ getCoreDumpFile() {
 	  then
 	    #echo "substract"
 	    timecalc=$(echo "$vpp_calc-$tzsec" | bc)
-	    showtime=$(showTime $timecalc)
+	    showtime=$(showTime "$timecalc")
 	  else
 	    #echo "adding"
 	    timecalc=$(echo "$vpp_calc+$tzsec" | bc)
-	    showtime=$(showTime $timecalc)
+	    showtime=$(showTime "$timecalc")
 	  fi
 	  corefilesize=$(stat --format=%s "/tmp/cores/core.dump")
 	  corefilesizekB=$(echo "$corefilesize/1024" | bc)
@@ -616,9 +616,9 @@ getCoreDumpFile() {
 # this is the filter taking away all important lines from the log file
 # and does some extract of data from the lines  
 handleLogsFromOneRun() {
-    kubectl logs vpp > log/vpp$1.log
-    grep -E 'Starting the agent...|stopwatch enabled:|stopwatch disabled:|resync the Linux Configuration|resync the VPP Configuration begin|call took|partial resync time is|stopwatch has no entries|Sleeping while VPP will be ready|VPP is ready to connect|Connecting to etcd took|Resync took|Connecting to VPP took|Connecting to kafka took|All plugins initialized successfully|plugin Linux: Init|plugin GoVPP: Init|plugin VPP: Init|resync the VPP Configuration end|Agent Init|Agent AfterInit'  log/vpp$1.log > log/log$1.log
-    cat log/log$1.log | sed -r 's/^time="[0-9-]{10} ([^"]+)".+ msg="([^"]+)"(([^"]*(durationInNs[:]?[ ]?=([0-9]+)))|(\s*))/\1, \2, \6/' >> log/out.csv
+    kubectl logs vpp > log/vpp"$1".log
+    grep -E 'Starting the agent...|stopwatch enabled:|stopwatch disabled:|resync the Linux Configuration|resync the VPP Configuration begin|call took|partial resync time is|stopwatch has no entries|Sleeping while VPP will be ready|VPP is ready to connect|Connecting to etcd took|Resync took|Connecting to VPP took|Connecting to kafka took|All plugins initialized successfully|plugin Linux: Init|plugin GoVPP: Init|plugin VPP: Init|resync the VPP Configuration end|Agent Init|Agent AfterInit'  log/vpp"$1".log > log/log"$1".log
+    cat log/log"$1".log | sed -r 's/^time="[0-9-]{10} ([^"]+)".+ msg="([^"]+)"(([^"]*(durationInNs[:]?[ ]?=([0-9]+)))|(\s*))/\1, \2, \6/' >> log/out.csv
     echo "--,--,--,--------" >> log/out.csv
 }
 
@@ -668,7 +668,7 @@ sleep ${waitTime}
     
 for (( i = 1; i <= $cycle; i++ ))
 do
-    handleLogsFromOneRun ${i}
+    handleLogsFromOneRun "${i}"
     #if [ $(bc <<< "$i % 2") -eq 0 ]
     #then
     #  echo "Cooling down container for $recoveryTime"

--- a/k8s/tests/topology-generate-fib.sh
+++ b/k8s/tests/topology-generate-fib.sh
@@ -37,11 +37,11 @@ docker exec -it ${ETCD_CONTAINER} etcdctl put /vnf-agent/${VSWITCH_NAME}/vpp/con
 }
 '
 
-if [ $1 -eq 0 ] ; then
+if [ "$1" -eq 0 ] ; then
    exit
 fi
 
-for i in $(eval echo {1..$1});do
+for i in $(eval echo {1.."$1"});do
     a=$(($i / 16 / 16 / 16 % 16))
     b=$(($i / 16 / 16 % 16))
     c=$(($i / 16 % 16))

--- a/k8s/tests/topology-generate-loopback.sh
+++ b/k8s/tests/topology-generate-loopback.sh
@@ -4,10 +4,10 @@ VSWITCH_NAME="vpp1"
 ETCD_CONTAINER="etcd"
 
 
-for i in $(eval echo {1..$1});do
-   echo $i
+for i in $(eval echo {1.."$1"});do
+   echo "$i"
 # VSWITCH - create a loopback interface
-docker exec -it ${ETCD_CONTAINER} etcdctl put /vnf-agent/${VSWITCH_NAME}/vpp/config/v1/interface/loop$i "
+docker exec -it ${ETCD_CONTAINER} etcdctl put /vnf-agent/${VSWITCH_NAME}/vpp/config/v1/interface/loop"$i" "
 {
   \"name\": \"loop$i\",
   \"enabled\": true,

--- a/k8s/tests/topology-generate-routes.sh
+++ b/k8s/tests/topology-generate-routes.sh
@@ -21,11 +21,11 @@ docker exec -it ${ETCD_CONTAINER} etcdctl put /vnf-agent/${VSWITCH_NAME}/vpp/con
 '
 
 
-if [ $1 -eq 0 ] ; then
+if [ "$1" -eq 0 ] ; then
    exit
 fi
 
-for i in $(eval echo {1..$1});do
+for i in $(eval echo {1.."$1"});do
     a=$(($i / 254 + 1))
     b=$(($i % 255))
 

--- a/scripts/check_links.sh
+++ b/scripts/check_links.sh
@@ -2,7 +2,7 @@
 
 res=0
 
-for i in `find . \( -path ./vendor -o -path ./vpp \) -prune -o -name "*.md"`
+for i in $(find . \( -path ./vendor -o -path ./vpp \) -prune -o -name "*.md")
 do
     if [ -d "$i" ]; then
         continue

--- a/scripts/cmpbench.sh
+++ b/scripts/cmpbench.sh
@@ -14,7 +14,7 @@ SCRIPT_DIR="$(dirname $(readlink -e "${BASH_SOURCE[0]}"))"
 
 BENCH_PKG_DIR=${1:-${SCRIPT_DIR}/../plugins/kvscheduler}
 
-[ -z ${OUTPUT_DIR-} ] && OUTPUT_DIR=/tmp/bench
+[ -z "${OUTPUT_DIR-}" ] && OUTPUT_DIR=/tmp/bench
 mkdir -p "$OUTPUT_DIR"
 
 OLD_BENCH="${OUTPUT_DIR}/old.txt"
@@ -27,7 +27,7 @@ function benchtest() {
 	go test -run=NONE -bench=. -benchmem -benchtime=3s
 }
 
-BENCH_PKG=$(go list $BENCH_PKG_DIR)
+BENCH_PKG=$(go list "$BENCH_PKG_DIR")
 
 echo "-> running cmpbench for package: $BENCH_PKG"
 

--- a/scripts/genbinapi.sh
+++ b/scripts/genbinapi.sh
@@ -5,8 +5,8 @@ export VPP_API_DIR=${VPP_API_DIR:-/usr/share/vpp/api}
 
 
 # Generate binapi
-go generate -x ./${VPP_BINAPI}
+go generate -x ./"${VPP_BINAPI}"
 
 # Apply patches
-find ${VPP_BINAPI} -maxdepth 2 -type f -name '*.patch' -exec \
+find "${VPP_BINAPI}" -maxdepth 2 -type f -name '*.patch' -exec \
 	patch --no-backup-if-mismatch -p1 -i {} \;

--- a/scripts/protoc_gen_go.sh
+++ b/scripts/protoc_gen_go.sh
@@ -31,5 +31,5 @@ for dir in $protodirs; do
 	echo "$protofiles"
 
   	protoc --proto_path="${PROTO_PATH}" \
-  		--go_out="${PROTOC_GEN_GO_ARGS}" $protofiles
+  		--go_out="${PROTOC_GEN_GO_ARGS}" "$protofiles"
 done

--- a/scripts/static_analysis.sh
+++ b/scripts/static_analysis.sh
@@ -19,7 +19,7 @@ gometalinter \
 	--linter="vet:go vet ${params}:^(?:vet:.*?\.go:\s+(?P<path>.*?\.go):(?P<line>\d+):(?P<col>\d+):\s*(?P<message>.*))|(?:(?P<path>.*?\.go):(?P<line>\d+):\s*(?P<message>.*))$" \
 	--deadline 3m \
 	--enable-gc \
-	--disable-all $enabledLinters \
+	--disable-all "$enabledLinters" \
 	--exclude="should not use dot imports" \
 	--exclude="don't use an underscore in package name" \
 	--exclude="comment" \

--- a/scripts/update_proto_classes.sh
+++ b/scripts/update_proto_classes.sh
@@ -5,5 +5,5 @@ rm -rf ansible/action_plugins/pout
 mkdir pout
 protoc --proto_path=vendor --proto_path=api --python_out=pout api/models/vpp/interfaces/interface.proto api/models/vpp/ipsec/ipsec.proto api/models/vpp/l3/route.proto api/models/vpp/l2/bridge-domain.proto api/models/vpp/nat/nat.proto api/models/vpp/l2/xconnect.proto api/models/vpp/l3/l3.proto api/models/linux/interfaces/interface.proto  api/models/linux/namespace/namespace.proto
 mv pout ansible/action_plugins/.
-cd ansible/action_plugins/pout
+cd ansible/action_plugins/pout || exit
 find . -type d -exec touch {}/__init__.py \;

--- a/tests/e2e/run_e2e.sh
+++ b/tests/e2e/run_e2e.sh
@@ -49,7 +49,7 @@ cid=$(docker run -d -it \
 	--env GRPC_CONFIG=/etc/grpc.conf \
 	--env CERTS_PATH="$PWD/tests/e2e/resources/certs" \
 	--name vpp-agent-e2e-tests \
-	"${DOCKER_ARGS-}" \
+	${DOCKER_ARGS-} \
 	"$VPP_IMG" bash)
 
 set +x

--- a/tests/e2e/run_e2e.sh
+++ b/tests/e2e/run_e2e.sh
@@ -12,10 +12,10 @@ if [ -z "${COVER_DIR-}" ]; then
       -ldflags "-X github.com/ligato/cn-infra/agent.BuildVersion=TEST_E2E" \
       ./cmd/vpp-agent
 else
-	if [ ! -d ${COVER_DIR}/e2e-coverage ]; then
-		mkdir ${COVER_DIR}/e2e-coverage
-	elif [ "$(ls -A ${COVER_DIR}/e2e-coverage)" ]; then
-		rm -f ${COVER_DIR}/e2e-coverage/*
+	if [ ! -d "${COVER_DIR}"/e2e-coverage ]; then
+		mkdir "${COVER_DIR}"/e2e-coverage
+	elif [ "$(ls -A "${COVER_DIR}"/e2e-coverage)" ]; then
+		rm -f "${COVER_DIR}"/e2e-coverage/*
 	fi
 	go test -covermode=count -coverpkg="go.ligato.io/vpp-agent/v3/..." -c ./cmd/vpp-agent -o ./tests/e2e/vpp-agent.test -tags teste2e
 	DOCKER_ARGS="${DOCKER_ARGS-} -v ${COVER_DIR}/e2e-coverage:${COVER_DIR}/e2e-coverage"
@@ -32,14 +32,14 @@ go test -c -o ./tests/e2e/e2e.test ./tests/e2e
 # TODO: do not run docker image with pid=host,
 #  because any other vpp running now breaks tests
 cid=$(docker run -d -it \
-	-v $PWD/tests/e2e/e2e.test:/e2e.test:ro \
-	-v $PWD/tests/e2e/vpp-agent.test:/vpp-agent:ro \
-	-v $PWD/tests/e2e/agentctl.test:/agentctl:ro \
-	-v $PWD/tests/e2e/resources/grpc.conf:/etc/grpc.conf:ro \
-	-v $PWD/tests/e2e/resources/grpc-secure.conf:/etc/grpc-secure.conf:ro \
-	-v $PWD/tests/e2e/resources/grpc-secure-full.conf:/etc/grpc-secure-full.conf:ro \
-	-v $PWD/tests/e2e/resources/agentctl.conf:/etc/.agentctl/config.yml:ro \
-	-v $PWD/tests/e2e/resources/certs:/etc/certs:ro \
+	-v "$PWD"/tests/e2e/e2e.test:/e2e.test:ro \
+	-v "$PWD"/tests/e2e/vpp-agent.test:/vpp-agent:ro \
+	-v "$PWD"/tests/e2e/agentctl.test:/agentctl:ro \
+	-v "$PWD"/tests/e2e/resources/grpc.conf:/etc/grpc.conf:ro \
+	-v "$PWD"/tests/e2e/resources/grpc-secure.conf:/etc/grpc-secure.conf:ro \
+	-v "$PWD"/tests/e2e/resources/grpc-secure-full.conf:/etc/grpc-secure-full.conf:ro \
+	-v "$PWD"/tests/e2e/resources/agentctl.conf:/etc/.agentctl/config.yml:ro \
+	-v "$PWD"/tests/e2e/resources/certs:/etc/certs:ro \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	--label e2e.test="$*" \
 	--pid="host" \
@@ -49,7 +49,7 @@ cid=$(docker run -d -it \
 	--env GRPC_CONFIG=/etc/grpc.conf \
 	--env CERTS_PATH="$PWD/tests/e2e/resources/certs" \
 	--name vpp-agent-e2e-tests \
-	${DOCKER_ARGS-} \
+	"${DOCKER_ARGS-}" \
 	"$VPP_IMG" bash)
 
 set +x
@@ -63,7 +63,7 @@ cleanup() {
 	# merge coverage
 	if [ ! -z "${COVER_DIR-}" ]; then
 		go get github.com/wadey/gocovmerge
-		find ${COVER_DIR}/e2e-coverage -type f | xargs gocovmerge > ${COVER_DIR}/e2e-cov.out
+		find "${COVER_DIR}"/e2e-coverage -type f | xargs gocovmerge > "${COVER_DIR}"/e2e-cov.out
 	fi
 }
 

--- a/tests/integration/vpp_integration.sh
+++ b/tests/integration/vpp_integration.sh
@@ -25,7 +25,7 @@ echo -e " VPP Integration Test - \e[1;33m${vppver}\e[0m"
 echo "============================================================="
 
 # run integration test
-if docker exec -i "$cid" /vpp-integration.test "$*"; then
+if docker exec -i "$cid" /vpp-integration.test "$@"; then
 	echo >&2 "-------------------------------------------------------------"
 	echo >&2 -e " \e[32mPASSED\e[0m (took: ${SECONDS}s)"
 	echo >&2 "-------------------------------------------------------------"

--- a/tests/integration/vpp_integration.sh
+++ b/tests/integration/vpp_integration.sh
@@ -8,7 +8,7 @@ go test -c ./tests/integration/vpp -o ./tests/integration/vpp/vpp-integration.te
 cid=$(docker run -d -it \
 	-v $(pwd)/tests/integration/vpp/vpp-integration.test:/vpp-integration.test:ro \
 	--label vpp.integration.test="$*" \
-	"${DOCKER_ARGS-}" \
+	${DOCKER_ARGS-} \
 	"$VPP_IMG" bash)
 
 on_exit() {

--- a/tests/integration/vpp_integration.sh
+++ b/tests/integration/vpp_integration.sh
@@ -8,7 +8,7 @@ go test -c ./tests/integration/vpp -o ./tests/integration/vpp/vpp-integration.te
 cid=$(docker run -d -it \
 	-v $(pwd)/tests/integration/vpp/vpp-integration.test:/vpp-integration.test:ro \
 	--label vpp.integration.test="$*" \
-	${DOCKER_ARGS-} \
+	"${DOCKER_ARGS-}" \
 	"$VPP_IMG" bash)
 
 on_exit() {
@@ -25,7 +25,7 @@ echo -e " VPP Integration Test - \e[1;33m${vppver}\e[0m"
 echo "============================================================="
 
 # run integration test
-if docker exec -i "$cid" /vpp-integration.test $*; then
+if docker exec -i "$cid" /vpp-integration.test "$*"; then
 	echo >&2 "-------------------------------------------------------------"
 	echo >&2 -e " \e[32mPASSED\e[0m (took: ${SECONDS}s)"
 	echo >&2 "-------------------------------------------------------------"

--- a/tests/jenkins/jobs5/script.sh
+++ b/tests/jenkins/jobs5/script.sh
@@ -3,7 +3,7 @@ find /root/vpp-agent/tests/robot/suites/ -name *.robot -type f  > list_of_all_ro
 sort list_of_all_robot_tests2 > list_of_all_robot_tests
 rm list_of_all_robot_tests2
 rm p.yaml
-python script.py ${1:-51}
+python script.py "${1:-51}"
 more p.yaml
 #cd ..
 #jenkins-jobs update --delete-old jobs5

--- a/tests/perf/perf_test.sh
+++ b/tests/perf/perf_test.sh
@@ -12,7 +12,7 @@ BASH_ENTRY_DIR="$(dirname $(readlink -e "${BASH_SOURCE[0]}"))"
 _test="${1}"
 _requests="${2-1000}"
 
-[ -z ${REPORT_DIR-} ] && REPORT_DIR="${SCRIPT_DIR}/reports/$_test"
+[ -z "${REPORT_DIR-}" ] && REPORT_DIR="${SCRIPT_DIR}/reports/$_test"
 
 export DEBUG_PROFILE_PATH="${REPORT_DIR}"
 
@@ -34,10 +34,10 @@ memprof="${REPORT_DIR}/mem.pprof"
 
 function run_test() {
 	# create report directory
-	rm -vrf ${REPORT_DIR}/*
-	mkdir --mode=777 -p ${REPORT_DIR}
+	rm -vrf "${REPORT_DIR}"/*
+	mkdir --mode=777 -p "${REPORT_DIR}"
 
-	perftest $* 2>&1 | tee $log_report
+	perftest "$*" 2>&1 | tee "$log_report"
 }
 
 function perftest() {
@@ -59,7 +59,7 @@ function perftest() {
 	echo "-> running $perftest test.."
 	echo "--------------------------------------------------------------"
 	test_result=0
-	$_test_client/$_test ${CLIENT_PARAMS-} --tunnels=$requests || test_result=$?
+	"$_test_client"/"$_test" "${CLIENT_PARAMS-}" --tunnels="$requests" || test_result=$?
 	echo "--------------------------------------------------------------"
 	echo "-> $_test test finished (exit code: $test_result)"
 
@@ -69,39 +69,39 @@ function perftest() {
 	check_agent
 
 	echo "-> collecting system info to: $sys_info"
-	sysinfo "uname -a" > $sys_info
-	sysinfo "env" >> $sys_info
-	sysinfo "pwd" >> $sys_info
-	sysinfo "lscpu" >> $sys_info
-	sysinfo "ip addr" >> $sys_info
-	sysinfo "free -h" >> $sys_info
-	sysinfo "df -h" >> $sys_info
-	sysinfo "ps faux" >> $sys_info
+	sysinfo "uname -a" > "$sys_info"
+	sysinfo "env" >> "$sys_info"
+	sysinfo "pwd" >> "$sys_info"
+	sysinfo "lscpu" >> "$sys_info"
+	sysinfo "ip addr" >> "$sys_info"
+	sysinfo "free -h" >> "$sys_info"
+	sysinfo "df -h" >> "$sys_info"
+	sysinfo "ps faux" >> "$sys_info"
 
 	echo "-> collecting agent info to: $agent_info"
-	grep -B 6 "Starting agent version" $log_agent > $agent_info
-	agentrest "scheduler/stats" >> $agent_info
-	agentrest "govppmux/stats" >> $agent_info
+	grep -B 6 "Starting agent version" "$log_agent" > "$agent_info"
+	agentrest "scheduler/stats" >> "$agent_info"
+	agentrest "govppmux/stats" >> "$agent_info"
 
 	echo "-> collecting VPP info to: $vpp_info"
-	echo -e "VPP info:\n\n" > $vpp_info
-	vppcli "show version verbose" >> $vpp_info
-	vppcli "show version cmdline" >> $vpp_info
-	vppcli "show plugins" >> $vpp_info
-	vppcli "show clock" >> $vpp_info
-	vppcli "show threads" >> $vpp_info
-	vppcli "show cpu" >> $vpp_info
-	vppcli "show physmem" >> $vpp_info
-	vppcli "show memory verbose" >> $vpp_info
-	vppcli "show api clients" >> $vpp_info
-	vppcli "show api histogram" >> $vpp_info
-	vppcli "show api trace-status" >> $vpp_info
-	vppcli "show api ring-stats" >> $vpp_info
-	vppcli "api trace status" >> $vpp_info
-	vppcli "show event-logger" >> $vpp_info
-	vppcli "show unix errors" >> $vpp_info
-	vppcli "show unix files" >> $vpp_info
-	vppcli "show ip fib summary" >> $vpp_info
+	echo -e "VPP info:\n\n" > "$vpp_info"
+	vppcli "show version verbose" >> "$vpp_info"
+	vppcli "show version cmdline" >> "$vpp_info"
+	vppcli "show plugins" >> "$vpp_info"
+	vppcli "show clock" >> "$vpp_info"
+	vppcli "show threads" >> "$vpp_info"
+	vppcli "show cpu" >> "$vpp_info"
+	vppcli "show physmem" >> "$vpp_info"
+	vppcli "show memory verbose" >> "$vpp_info"
+	vppcli "show api clients" >> "$vpp_info"
+	vppcli "show api histogram" >> "$vpp_info"
+	vppcli "show api trace-status" >> "$vpp_info"
+	vppcli "show api ring-stats" >> "$vpp_info"
+	vppcli "api trace status" >> "$vpp_info"
+	vppcli "show event-logger" >> "$vpp_info"
+	vppcli "show unix errors" >> "$vpp_info"
+	vppcli "show unix files" >> "$vpp_info"
+	vppcli "show ip fib summary" >> "$vpp_info"
 
 	if [[ "$test_result" == "0" ]]; then
 		echo "--------------------------------------------------------------------------------"
@@ -182,7 +182,7 @@ function start_vpp() {
 	rm -f /dev/shm/db /dev/shm/global_vm /dev/shm/vpe-api
 	$_vpp -c /etc/vpp/vpp.conf > "$log_vpp" 2>&1 &
 	pid_vpp="$!"
-	timeout "${wait_vpp_boot}" grep -q "vlib_plugin_early_init" <(tail -qF $log_vpp)
+	timeout "${wait_vpp_boot}" grep -q "vlib_plugin_early_init" <(tail -qF "$log_vpp")
 	echo "ok! (PID:${pid_vpp})"
 }
 
@@ -246,7 +246,7 @@ function start_agent() {
 	echo -n "-> starting agent.. "
 	$_agent > "$log_agent" 2>&1 &
 	pid_agent="$!"
-	timeout "${wait_agent_boot}" grep -q "Agent started" <(tail -qF $log_agent) || {
+	timeout "${wait_agent_boot}" grep -q "Agent started" <(tail -qF "$log_agent") || {
 		fail "timeout!"
 	}
 	echo "ok! (PID:${pid_agent})"

--- a/tests/perf/run_all.sh
+++ b/tests/perf/run_all.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-cd $SCRIPT_DIR
+cd "$SCRIPT_DIR"
 
 function run() {
 	test="$1"


### PR DESCRIPTION
:warning:There were 4 problems with adding double quotes to substitution (i.e. `${SMTH-}` -> `"${SMTH-}"`). Not sure about everything else. :warning:

Maybe this PR can be something to start with or not. Maybe do it manually is a better choice. Anyway 

This PR **reduces number of shell script issues from 345 to 105 using auto fix feature of [shellcheck](https://github.com/koalaman/shellcheck)**.

### The command itself:
```
docker run --rm -v "$PWD:/mnt" koalaman/shellcheck-alpine:latest find /mnt -name "*.sh" -exec shellcheck -f diff {} '+' | sed 's/\/mnt/\./g' | git apply
```
### And explanation:
Multiline to better look on it:
```
docker run --rm -v "$PWD:/mnt" koalaman/shellcheck-alpine:latest 
        find /mnt -name "*.sh" 
                -exec shellcheck -f diff {} '+' 

| sed 's/\/mnt/\./g' 
| git apply
```
first start container from "**koalaman/shellcheck-alpine:latest**" and mount there whole project. Command for this container will be "find" which will find (yeah, it will) all "*.sh" files in project's ("/mnt" in this case) directory. Also, "find" command can do "exec" and that's the point where "shellcheck" jumps in. Latest version of "shellcheck" can do **[autofix](https://github.com/koalaman/shellcheck/issues/1220)** with output in diff mode (-f diff). And "+" is for "find" and it means that just pass all file paths to command and call it once instead of calling command ("shellcheck" in this case) for each file (or something like that).
After all of that is done, the output is diff, but file paths are wrong. So "sed" will fix it. And now it is ready for "git apply".

<details><summary>Maybe useful output from shellcheck</summary>
<p>

```sh
➜ docker run --rm koalaman/shellcheck-alpine:latest shellcheck -V                                                
ShellCheck - shell script analysis tool
version: 0.7.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net

➜ docker run --rm koalaman/shellcheck-alpine:latest shellcheck --help
Usage: shellcheck [OPTIONS...] FILES...
  -a                  --check-sourced            Include warnings from sourced files
  -C[WHEN]            --color[=WHEN]             Use color (auto, always, never)
  -i CODE1,CODE2..    --include=CODE1,CODE2..    Consider only given types of warnings
  -e CODE1,CODE2..    --exclude=CODE1,CODE2..    Exclude types of warnings
  -f FORMAT           --format=FORMAT            Output format (checkstyle, diff, gcc, json, json1, quiet, tty)
                      --list-optional            List checks disabled by default
                      --norc                     Don't look for .shellcheckrc files
  -o check1,check2..  --enable=check1,check2..   List of optional checks to enable (or 'all')
  -P SOURCEPATHS      --source-path=SOURCEPATHS  Specify path when looking for sourced files ("SCRIPTDIR" for script's dir)
  -s SHELLNAME        --shell=SHELLNAME          Specify dialect (sh, bash, dash, ksh)
  -S SEVERITY         --severity=SEVERITY        Minimum severity of errors to consider (error, warning, info, style)
  -V                  --version                  Print version information
  -W NUM              --wiki-link-count=NUM      The number of wiki links to show, when applicable
  -x                  --external-sources         Allow 'source' outside of FILES
                      --help                     Show this usage summary and exit

➜
```

</p>
</details>