### PR TITLE
Bring back env var with path to supervisor config

### DIFF
--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -52,6 +52,8 @@ COPY --from=devimg \
     /go/bin/vpp-agent-init \
  /bin/
 
+ENV SUPERVISOR_CONFIG=/opt/vpp-agent/dev/supervisor.conf
+
 CMD rm -f /dev/shm/db /dev/shm/global_vm /dev/shm/vpe-api && \
 	mkdir -p /run/vpp && \
 	exec vpp-agent-init


### PR DESCRIPTION
Looks like it was removed by accident. Current behaviour:
```sh
➜ docker run -it --rm --name agent1 --privileged ligato/vpp-agent
INFO[0000] Starting agent version: v3.0.0-beta.2-10-gf4e780adb  BuildDate="2020-01-28T12:31+00:00" CommitHash=f4e780adb77b7959e830ba066b163e9d8706cf37 loc="agent/agent.go(134)" logger=agent
panic: failed to retrieve supervisor config file: failed to load supervisor config file: not found

goroutine 1 [running]:
main.main()
        /src/ligato/vpp-agent/cmd/vpp-agent-init/main.go:28 +0xda
➜
```
and if path to supervisor.conf passed as env variable:
```sh
➜  docker run -it --rm --name agent1 --privileged -e SUPERVISOR_CONFIG=/opt/vpp-agent/dev/supervisor.conf ligato/vpp-agent
INFO[0000] Starting agent version: v3.0.0-beta.2-10-gf4e780adb  BuildDate="2020-01-28T12:31+00:00" CommitHash=f4e780adb77b7959e830ba066b163e9d8706cf37 loc="agent/agent.go(134)" logger=agent
INFO[0000] Agent started with 2 plugins (took 1ms)       loc="agent/agent.go(179)" logger=agent
[...]
```