### PR TITLE
fix: Fix VPP TAP dump/create

### DIFF
--- a/plugins/vpp/ifplugin/vppcalls/vpp2001/dump_interface_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp2001/dump_interface_vppcalls.go
@@ -497,7 +497,9 @@ func (h *InterfaceVppHandler) dumpTapDetails(interfaces map[uint32]*vppcalls.Int
 	// Original TAP v1 was DEPRECATED
 
 	// TAP v2
-	reqCtx := h.callsChannel.SendMultiRequest(&vpp_tapv2.SwInterfaceTapV2Dump{})
+	reqCtx := h.callsChannel.SendMultiRequest(&vpp_tapv2.SwInterfaceTapV2Dump{
+		SwIfIndex: ^vpp_tapv2.InterfaceIndex(0),
+	})
 	for {
 		tapDetails := &vpp_tapv2.SwInterfaceTapV2Details{}
 		stop, err := reqCtx.ReceiveReply(tapDetails)

--- a/plugins/vpp/ifplugin/vppcalls/vpp2001/tap_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp2001/tap_vppcalls.go
@@ -44,6 +44,7 @@ func (h *InterfaceVppHandler) AddTapInterface(ifName string, tapIf *ifs.TapLink)
 		// Configure fast virtio-based TAP interface
 		req := &vpp_tapv2.TapCreateV2{
 			ID:            ^uint32(0),
+			NumRxQueues:   1,
 			HostIfName:    tapIf.HostIfName,
 			HostIfNameSet: true,
 			UseRandomMac:  true,


### PR DESCRIPTION
This adds missing default values to tapv2 binapi requests that was causing e2e tets to fail.