### PR TITLE
perf: Performance enhancement for adding many rules to Linux IPtables chain

### DIFF
--- a/plugins/linux/iptablesplugin/iptablesplugin.go
+++ b/plugins/linux/iptablesplugin/iptablesplugin.go
@@ -63,9 +63,10 @@ type Deps struct {
 
 // Config holds the plugin configuration.
 type Config struct {
-	Disabled                        bool `json:"disabled"`
-	GoRoutinesCnt                   int  `json:"go-routines-count"`
-	MinRuleCountForPerfRuleAddition int  `json:"min-rule-count-for-performance-rule-addition"`
+	linuxcalls.HandlerConfig `json:"handler"`
+
+	Disabled      bool `json:"disabled"`
+	GoRoutinesCnt int  `json:"go-routines-count"`
 }
 
 // Init initializes and registers descriptors and handlers for Linux iptables rules.
@@ -84,7 +85,7 @@ func (p *IPTablesPlugin) Init() error {
 
 	// init iptables handler
 	p.iptHandler = linuxcalls.NewIPTablesHandler()
-	err = p.iptHandler.Init()
+	err = p.iptHandler.Init(&config.HandlerConfig)
 	if err != nil && p.configFound {
 		// just warn here, iptables / ip6tables just may not be installed - will return
 		// an error by attempt to configure it
@@ -112,8 +113,10 @@ func (p *IPTablesPlugin) Close() error {
 func (p *IPTablesPlugin) retrieveConfig() (*Config, error) {
 	config := &Config{
 		// default configuration
-		GoRoutinesCnt:                   defaultGoRoutinesCnt,
-		MinRuleCountForPerfRuleAddition: defaultMinRuleCountForPerfRuleAddition,
+		GoRoutinesCnt: defaultGoRoutinesCnt,
+		HandlerConfig: linuxcalls.HandlerConfig{
+			MinRuleCountForPerfRuleAddition: defaultMinRuleCountForPerfRuleAddition,
+		},
 	}
 	found, err := p.Cfg.LoadValue(config)
 	if !found {

--- a/plugins/linux/iptablesplugin/linux-iptablesplugin.conf
+++ b/plugins/linux/iptablesplugin/linux-iptablesplugin.conf
@@ -4,3 +4,11 @@ disabled: false
 # How many go routines (at most) will split configured network namespaces to execute
 # the Retrieve operation in parallel.
 go-routines-count: 10
+
+# Minimal rule count needed to perform alternative rule additions by creating RuleChain.
+# Alternative method is based on exporting iptables data(iptables-save), adding rules
+# into that exported data and import them back (iptables-restore). This can very efficient
+# in case of filling many rules at once.
+# By default off (rule count to activate alternative method is super high and therefore
+# practically turned off)
+min-rule-count-for-performance-rule-addition: 2147483647

--- a/plugins/linux/iptablesplugin/linux-iptablesplugin.conf
+++ b/plugins/linux/iptablesplugin/linux-iptablesplugin.conf
@@ -5,10 +5,11 @@ disabled: false
 # the Retrieve operation in parallel.
 go-routines-count: 10
 
-# Minimal rule count needed to perform alternative rule additions by creating RuleChain.
-# Alternative method is based on exporting iptables data(iptables-save), adding rules
-# into that exported data and import them back (iptables-restore). This can very efficient
-# in case of filling many rules at once.
-# By default off (rule count to activate alternative method is super high and therefore
-# practically turned off)
-min-rule-count-for-performance-rule-addition: 2147483647
+handler:
+    # Minimal rule count needed to perform alternative rule additions by creating RuleChain.
+    # Alternative method is based on exporting iptables data(iptables-save), adding rules
+    # into that exported data and import them back (iptables-restore). This can very efficient
+    # in case of filling many rules at once.
+    # By default off (rule count to activate alternative method is super high and therefore
+    # practically turned off)
+    min-rule-count-for-performance-rule-addition: 2147483647

--- a/plugins/linux/iptablesplugin/linuxcalls/iptables_api.go
+++ b/plugins/linux/iptablesplugin/linuxcalls/iptables_api.go
@@ -52,6 +52,9 @@ type IPTablesAPIWrite interface {
 
 	// DeleteAllRules deletes all rules within the specified chain.
 	DeleteAllRules(protocol L3Protocol, table, chain string) error
+
+	// RestoreTable import all data (in IPTable-save output format) for given table
+	RestoreTable(protocol L3Protocol, table string, data []byte, flush bool, importCounters bool) error
 }
 
 // IPTablesAPIRead interface covers read methods inside linux calls package
@@ -59,6 +62,9 @@ type IPTablesAPIWrite interface {
 type IPTablesAPIRead interface {
 	// ListRules lists all rules within the specified chain.
 	ListRules(protocol L3Protocol, table, chain string) (rules []string, err error)
+
+	// SaveTable exports all data for given table in IPTable-save output format
+	SaveTable(protocol L3Protocol, table string, exportCounters bool) ([]byte, error)
 }
 
 // NewIPTablesHandler creates new instance of iptables handler.

--- a/plugins/linux/iptablesplugin/linuxcalls/iptables_api.go
+++ b/plugins/linux/iptablesplugin/linuxcalls/iptables_api.go
@@ -26,7 +26,7 @@ const (
 // to manage linux iptables rules.
 type IPTablesAPI interface {
 	// Init initializes an iptables handler.
-	Init() error
+	Init(config *HandlerConfig) error
 
 	IPTablesAPIWrite
 	IPTablesAPIRead
@@ -47,14 +47,14 @@ type IPTablesAPIWrite interface {
 	// AppendRule appends a rule into the specified chain.
 	AppendRule(protocol L3Protocol, table, chain string, rule string) error
 
+	// AppendRules appends rules into the specified chain.
+	AppendRules(protocol L3Protocol, table, chain string, rules ...string) error
+
 	// DeleteRule deletes a rule from the specified chain.
 	DeleteRule(protocol L3Protocol, table, chain string, rule string) error
 
 	// DeleteAllRules deletes all rules within the specified chain.
 	DeleteAllRules(protocol L3Protocol, table, chain string) error
-
-	// RestoreTable import all data (in IPTable-save output format) for given table
-	RestoreTable(protocol L3Protocol, table string, data []byte, flush bool, importCounters bool) error
 }
 
 // IPTablesAPIRead interface covers read methods inside linux calls package
@@ -62,9 +62,11 @@ type IPTablesAPIWrite interface {
 type IPTablesAPIRead interface {
 	// ListRules lists all rules within the specified chain.
 	ListRules(protocol L3Protocol, table, chain string) (rules []string, err error)
+}
 
-	// SaveTable exports all data for given table in IPTable-save output format
-	SaveTable(protocol L3Protocol, table string, exportCounters bool) ([]byte, error)
+// HandlerConfig holds the IPTablesHandler related configuration.
+type HandlerConfig struct {
+	MinRuleCountForPerfRuleAddition int `json:"min-rule-count-for-performance-rule-addition"`
 }
 
 // NewIPTablesHandler creates new instance of iptables handler.


### PR DESCRIPTION
The performance enhancement is based on usage of `iptables-save`/`iptables-restore`. It can speed up insertion of rules into chain significantly, but it is different approach then use of more generic `iptables` tool.

Due to changing `iptables-save`-exported data that are in not well documented format (not an API in classic sense), i made this performance enhancement optional and by default turned off.

The usage of this method is regulated by rule count that we want to insert into chain. So inserting few rules that can be quick also with generic `iptables` tool can benefit from stability of `iptables` tool API. Inserting many rules will switch to performance method and can be done much more quickly, but with possibility of future incompatibility break. The data export format can change without notice, but i don't think that it will break anytime soon, because:
a) this format seems to quite mature and stable (didn't find signs of changes in last years)
b) i don't do massive data parsing - i just insert data into one place
