### PR TITLE
fix: Fix bridge domain dump for VPP 20.05

### DIFF
--- a/plugins/vpp/l2plugin/vppcalls/vpp2005/bridge_domain_vppcalls.go
+++ b/plugins/vpp/l2plugin/vppcalls/vpp2005/bridge_domain_vppcalls.go
@@ -55,10 +55,3 @@ func (h *BridgeDomainVppHandler) DeleteBridgeDomain(bdIdx uint32) error {
 
 	return nil
 }
-
-func boolToUint(value bool) uint8 {
-	if value {
-		return 1
-	}
-	return 0
-}

--- a/plugins/vpp/l2plugin/vppcalls/vpp2005/dump_vppcalls.go
+++ b/plugins/vpp/l2plugin/vppcalls/vpp2005/dump_vppcalls.go
@@ -38,7 +38,10 @@ func (h *BridgeDomainVppHandler) DumpBridgeDomains() ([]*vppcalls.BridgeDomainDe
 	var bds []*vppcalls.BridgeDomainDetails
 
 	// dump bridge domains
-	reqCtx := h.callsChannel.SendMultiRequest(&vpp_l2.BridgeDomainDump{BdID: ^uint32(0)})
+	reqCtx := h.callsChannel.SendMultiRequest(&vpp_l2.BridgeDomainDump{
+		BdID:      ^uint32(0),
+		SwIfIndex: ^vpp_l2.InterfaceIndex(0),
+	})
 
 	for {
 		bdDetails := &vpp_l2.BridgeDomainDetails{}


### PR DESCRIPTION
InterfaceIndex has to be set to max uint32 to properly dump all interfaces.