### PR TITLE
fix(binapi): Regenerate binapi for VPP 20.01-45~g7a071e370~b63

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,10 @@ include vpp.env
 ifeq ($(VPP_VERSION),)
 VPP_VERSION=$(VPP_DEFAULT)
 endif
-VPP_IMG:=$(value VPP_$(VPP_VERSION)_IMAGE)
+
+VPP_IMG?=$(value VPP_$(VPP_VERSION)_IMAGE)
 ifeq ($(UNAME_ARCH), aarch64)
-VPP_IMG:=$(subst vpp-base,vpp-base-arm64,$(VPP_IMG))
+VPP_IMG?=$(subst vpp-base,vpp-base-arm64,$(VPP_IMG))
 endif
 VPP_BINAPI?=$(value VPP_$(VPP_VERSION)_BINAPI)
 

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /src/ligato/vpp-agent
 
+ARG VPP_IMG
 ARG VPP_BINAPI
 ARG SKIP_CHECK
 
@@ -28,12 +29,26 @@ RUN set -x; \
 	gofmt -w plugins/vpp/binapi; \
 	cp -r plugins/vpp/binapi /tmp/orig_binapi && \
 	make generate-binapi && \
- 	diff -r plugins/vpp/binapi /tmp/orig_binapi || \
+ 	diff --color=always -r plugins/vpp/binapi /tmp/orig_binapi || \
  	{ \
+ 		set +x; \
  		vpp_version="$(cat /vpp-version)"; \
+ 		echo >&2 "==============================================================="; \
+ 		echo >&2 "!!! VPP BINARY API CHECK FAILED !!!"; \
+ 		echo >&2 "==============================================================="; \
+ 		echo >&2 " - VPP version:   ${vpp_version}"; \
+ 		echo >&2 " - VPP base img:  ${VPP_IMG}"; \
+ 		echo >&2 " - binapi folder: ${VPP_BINAPI}"; \
  		echo >&2 "---------------------------------------------------------------"; \
- 		echo >&2 " Generated binapi does not match with used version!"; \
- 		echo >&2 " VPP version: ${vpp_version}"; \
+ 		echo >&2 " Generated binapi does not seem to be up-to-date with used VPP!"; \
+ 		echo >&2 ""; \
+ 		echo >&2 " This might happen when VPP API change gets merged to a branch of used VPP."; \
+ 		echo >&2 " Ensure that VPP base image is compatible with the selected VPP version!"; \
+ 		echo >&2 "---------------------------------------------------------------"; \
+ 		echo >&2 " To resolve this now, you could:"; \
+ 		echo >&2 ""; \
+ 		echo >&2 "  1. Ignore this check by setting: SKIP_CHECK=y"; \
+ 		echo >&2 "  2. Override used VPP base image by setting: VPP_IMG=ligato/vpp-base:<TAG>"; \
  		echo >&2 "---------------------------------------------------------------"; \
  		[ -n "$SKIP_CHECK" ] && exit 0; \
  	}
@@ -57,7 +72,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  	&& rm -rf /var/lib/apt/lists/*
 
 # Install Go
-ENV GOLANG_VERSION 1.14.2
+ENV GOLANG_VERSION 1.14.4
 RUN set -eux; \
 	dpkgArch="$(dpkg --print-architecture)"; \
 		case "${dpkgArch##*-}" in \

--- a/plugins/vpp/binapi/vpp2001/abf/abf.ba.go
+++ b/plugins/vpp/binapi/vpp2001/abf/abf.ba.go
@@ -31,6 +31,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "abf"
+	// APIVersion is the API version of this module.
+	APIVersion = "1.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0xc2e5c644
 )

--- a/plugins/vpp/binapi/vpp2001/acl/acl.ba.go
+++ b/plugins/vpp/binapi/vpp2001/acl/acl.ba.go
@@ -24,6 +24,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "acl"
+	// APIVersion is the API version of this module.
+	APIVersion = "1.0.1"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x11c5c1e5
 )

--- a/plugins/vpp/binapi/vpp2001/af_packet/af_packet.ba.go
+++ b/plugins/vpp/binapi/vpp2001/af_packet/af_packet.ba.go
@@ -28,6 +28,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "af_packet"
+	// APIVersion is the API version of this module.
+	APIVersion = "2.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0xba745e20
 )

--- a/plugins/vpp/binapi/vpp2001/arp/arp.ba.go
+++ b/plugins/vpp/binapi/vpp2001/arp/arp.ba.go
@@ -31,6 +31,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "arp"
+	// APIVersion is the API version of this module.
+	APIVersion = "1.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0xa818aaf3
 )

--- a/plugins/vpp/binapi/vpp2001/bond/bond.ba.go
+++ b/plugins/vpp/binapi/vpp2001/bond/bond.ba.go
@@ -28,6 +28,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "bond"
+	// APIVersion is the API version of this module.
+	APIVersion = "2.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x69f583ad
 )

--- a/plugins/vpp/binapi/vpp2001/dhcp/dhcp.ba.go
+++ b/plugins/vpp/binapi/vpp2001/dhcp/dhcp.ba.go
@@ -31,6 +31,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "dhcp"
+	// APIVersion is the API version of this module.
+	APIVersion = "3.0.1"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x96a5f046
 )

--- a/plugins/vpp/binapi/vpp2001/fib_types/fib_types.ba.go
+++ b/plugins/vpp/binapi/vpp2001/fib_types/fib_types.ba.go
@@ -27,6 +27,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "fib_types"
+	// APIVersion is the API version of this module.
+	APIVersion = "2.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x57387845
 )

--- a/plugins/vpp/binapi/vpp2001/flowprobe/flowprobe.ba.go
+++ b/plugins/vpp/binapi/vpp2001/flowprobe/flowprobe.ba.go
@@ -27,6 +27,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "flowprobe"
+	// APIVersion is the API version of this module.
+	APIVersion = "1.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0xbb4dfc0d
 )

--- a/plugins/vpp/binapi/vpp2001/gre/gre.ba.go
+++ b/plugins/vpp/binapi/vpp2001/gre/gre.ba.go
@@ -30,6 +30,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "gre"
+	// APIVersion is the API version of this module.
+	APIVersion = "2.0.1"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0xb7663194
 )

--- a/plugins/vpp/binapi/vpp2001/gtpu/gtpu.ba.go
+++ b/plugins/vpp/binapi/vpp2001/gtpu/gtpu.ba.go
@@ -30,6 +30,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "gtpu"
+	// APIVersion is the API version of this module.
+	APIVersion = "2.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x6305cc01
 )

--- a/plugins/vpp/binapi/vpp2001/interfaces/interfaces.ba.go
+++ b/plugins/vpp/binapi/vpp2001/interfaces/interfaces.ba.go
@@ -31,6 +31,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "interface"
+	// APIVersion is the API version of this module.
+	APIVersion = "3.2.2"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0xfebc3ffa
 )

--- a/plugins/vpp/binapi/vpp2001/ip/ip.ba.go
+++ b/plugins/vpp/binapi/vpp2001/ip/ip.ba.go
@@ -32,6 +32,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "ip"
+	// APIVersion is the API version of this module.
+	APIVersion = "3.0.1"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0xfc3fea46
 )

--- a/plugins/vpp/binapi/vpp2001/ip_neighbor/ip_neighbor.ba.go
+++ b/plugins/vpp/binapi/vpp2001/ip_neighbor/ip_neighbor.ba.go
@@ -31,6 +31,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "ip_neighbor"
+	// APIVersion is the API version of this module.
+	APIVersion = "1.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0xdae37c55
 )

--- a/plugins/vpp/binapi/vpp2001/ip_types/ip_types.ba.go
+++ b/plugins/vpp/binapi/vpp2001/ip_types/ip_types.ba.go
@@ -25,6 +25,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "ip_types"
+	// APIVersion is the API version of this module.
+	APIVersion = "3.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x80424562
 )

--- a/plugins/vpp/binapi/vpp2001/ipfix_export/ipfix_export.ba.go
+++ b/plugins/vpp/binapi/vpp2001/ipfix_export/ipfix_export.ba.go
@@ -29,6 +29,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "ipfix_export"
+	// APIVersion is the API version of this module.
+	APIVersion = "2.0.1"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0xee6ea488
 )

--- a/plugins/vpp/binapi/vpp2001/ipip/ipip.ba.go
+++ b/plugins/vpp/binapi/vpp2001/ipip/ipip.ba.go
@@ -30,6 +30,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "ipip"
+	// APIVersion is the API version of this module.
+	APIVersion = "2.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0xf108649c
 )

--- a/plugins/vpp/binapi/vpp2001/ipsec/ipsec.ba.go
+++ b/plugins/vpp/binapi/vpp2001/ipsec/ipsec.ba.go
@@ -31,6 +31,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "ipsec"
+	// APIVersion is the API version of this module.
+	APIVersion = "3.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x5a59fef9
 )

--- a/plugins/vpp/binapi/vpp2001/ipsec_types/ipsec_types.ba.go
+++ b/plugins/vpp/binapi/vpp2001/ipsec_types/ipsec_types.ba.go
@@ -27,6 +27,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "ipsec_types"
+	// APIVersion is the API version of this module.
+	APIVersion = "3.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x6e9f4c73
 )

--- a/plugins/vpp/binapi/vpp2001/l2/l2.ba.go
+++ b/plugins/vpp/binapi/vpp2001/l2/l2.ba.go
@@ -31,6 +31,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "l2"
+	// APIVersion is the API version of this module.
+	APIVersion = "2.2.2"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x2e148df3
 )

--- a/plugins/vpp/binapi/vpp2001/l3xc/l3xc.ba.go
+++ b/plugins/vpp/binapi/vpp2001/l3xc/l3xc.ba.go
@@ -31,6 +31,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "l3xc"
+	// APIVersion is the API version of this module.
+	APIVersion = "1.0.1"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x80b00c99
 )

--- a/plugins/vpp/binapi/vpp2001/memclnt/memclnt.ba.go
+++ b/plugins/vpp/binapi/vpp2001/memclnt/memclnt.ba.go
@@ -24,6 +24,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "memclnt"
+	// APIVersion is the API version of this module.
+	APIVersion = "2.1.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x8d3dd881
 )

--- a/plugins/vpp/binapi/vpp2001/memif/memif.ba.go
+++ b/plugins/vpp/binapi/vpp2001/memif/memif.ba.go
@@ -28,6 +28,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "memif"
+	// APIVersion is the API version of this module.
+	APIVersion = "3.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x88dc56c9
 )

--- a/plugins/vpp/binapi/vpp2001/nat/nat.ba.go
+++ b/plugins/vpp/binapi/vpp2001/nat/nat.ba.go
@@ -30,6 +30,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "nat"
+	// APIVersion is the API version of this module.
+	APIVersion = "5.2.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0xef1a1c94
 )

--- a/plugins/vpp/binapi/vpp2001/punt/punt.ba.go
+++ b/plugins/vpp/binapi/vpp2001/punt/punt.ba.go
@@ -29,6 +29,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "punt"
+	// APIVersion is the API version of this module.
+	APIVersion = "2.2.1"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x51716f7f
 )

--- a/plugins/vpp/binapi/vpp2001/span/span.ba.go
+++ b/plugins/vpp/binapi/vpp2001/span/span.ba.go
@@ -23,6 +23,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "span"
+	// APIVersion is the API version of this module.
+	APIVersion = "1.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x10769b5
 )

--- a/plugins/vpp/binapi/vpp2001/sr/sr.ba.go
+++ b/plugins/vpp/binapi/vpp2001/sr/sr.ba.go
@@ -24,6 +24,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "sr"
+	// APIVersion is the API version of this module.
+	APIVersion = "1.2.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0xbf277f96
 )

--- a/plugins/vpp/binapi/vpp2001/stn/stn.ba.go
+++ b/plugins/vpp/binapi/vpp2001/stn/stn.ba.go
@@ -30,6 +30,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "stn"
+	// APIVersion is the API version of this module.
+	APIVersion = "2.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x619d8f3
 )

--- a/plugins/vpp/binapi/vpp2001/tapv2/tapv2.ba.go
+++ b/plugins/vpp/binapi/vpp2001/tapv2/tapv2.ba.go
@@ -31,6 +31,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "tapv2"
+	// APIVersion is the API version of this module.
+	APIVersion = "3.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x7d58f9a4
 )

--- a/plugins/vpp/binapi/vpp2001/vmxnet3/vmxnet3.ba.go
+++ b/plugins/vpp/binapi/vpp2001/vmxnet3/vmxnet3.ba.go
@@ -29,6 +29,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "vmxnet3"
+	// APIVersion is the API version of this module.
+	APIVersion = "1.1.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0xe89a60f7
 )

--- a/plugins/vpp/binapi/vpp2001/vpe/vpe.ba.go
+++ b/plugins/vpp/binapi/vpp2001/vpe/vpe.ba.go
@@ -28,6 +28,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "vpe"
+	// APIVersion is the API version of this module.
+	APIVersion = "1.6.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0xc6c0bcf6
 )

--- a/plugins/vpp/binapi/vpp2001/vxlan/vxlan.ba.go
+++ b/plugins/vpp/binapi/vpp2001/vxlan/vxlan.ba.go
@@ -23,6 +23,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "vxlan"
+	// APIVersion is the API version of this module.
+	APIVersion = "1.1.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0xa95aa271
 )

--- a/plugins/vpp/binapi/vpp2001/vxlan_gpe/vxlan_gpe.ba.go
+++ b/plugins/vpp/binapi/vpp2001/vxlan_gpe/vxlan_gpe.ba.go
@@ -23,6 +23,8 @@ import (
 const (
 	// ModuleName is the name of this module.
 	ModuleName = "vxlan_gpe"
+	// APIVersion is the API version of this module.
+	APIVersion = "1.0.0"
 	// VersionCrc is the CRC of this module.
 	VersionCrc = 0x25bfb55d
 )


### PR DESCRIPTION
This PR includes regenerated binapi for VPP 20.01 because of a minor VPP API change (no CRC was changed) that was merged to stable/2001 branch. 