### PR TITLE
fix(vpp/ifplugin): Recognize interface name prefix "tun" as TAP

### DIFF
--- a/plugins/vpp/ifplugin/vppcalls/vpp2005/dump_interface_vppcalls.go
+++ b/plugins/vpp/ifplugin/vppcalls/vpp2005/dump_interface_vppcalls.go
@@ -936,7 +936,8 @@ func guessInterfaceType(ifName string) ifs.Interface_Type {
 	case strings.HasPrefix(ifName, "memif"):
 		return ifs.Interface_MEMIF
 
-	case strings.HasPrefix(ifName, "tap"):
+	case strings.HasPrefix(ifName, "tap"),
+		strings.HasPrefix(ifName, "tun"):
 		return ifs.Interface_TAP
 
 	case strings.HasPrefix(ifName, "host"):


### PR DESCRIPTION
This PR should fix resync issue for VPP TAPs with tunnel mode.

It will work correctly when this VPP change gets merged: https://gerrit.fd.io/r/c/vpp/+/27769