### PR TITLE
test: Fix failing unit test for go1.15

### DIFF
--- a/plugins/vpp/srplugin/vppcalls/vpp1904/srv6.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp1904/srv6.go
@@ -172,7 +172,7 @@ func (h *SRv6VppHandler) interfaceNameMapping() (map[string]string, error) {
 
 func (h *SRv6VppHandler) installationVrfID(localSID *srv6.LocalSID) string {
 	if localSID != nil {
-		return string(localSID.InstallationVrfId)
+		return fmt.Sprint(localSID.InstallationVrfId)
 	}
 	return "<nil>"
 }

--- a/plugins/vpp/srplugin/vppcalls/vpp1908/srv6.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp1908/srv6.go
@@ -171,7 +171,7 @@ func (h *SRv6VppHandler) interfaceNameMapping() (map[string]string, error) {
 
 func (h *SRv6VppHandler) installationVrfID(localSID *srv6.LocalSID) string {
 	if localSID != nil {
-		return string(localSID.InstallationVrfId)
+		return fmt.Sprint(localSID.InstallationVrfId)
 	}
 	return "<nil>"
 }

--- a/plugins/vpp/srplugin/vppcalls/vpp2001/srv6.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp2001/srv6.go
@@ -172,7 +172,7 @@ func (h *SRv6VppHandler) interfaceNameMapping() (map[string]string, error) {
 
 func (h *SRv6VppHandler) installationVrfID(localSID *srv6.LocalSID) string {
 	if localSID != nil {
-		return string(localSID.InstallationVrfId)
+		return fmt.Sprint(localSID.InstallationVrfId)
 	}
 	return "<nil>"
 }

--- a/plugins/vpp/srplugin/vppcalls/vpp2005/srv6.go
+++ b/plugins/vpp/srplugin/vppcalls/vpp2005/srv6.go
@@ -177,7 +177,7 @@ func (h *SRv6VppHandler) interfaceNameMapping() (map[string]string, error) {
 
 func (h *SRv6VppHandler) installationVrfID(localSID *srv6.LocalSID) string {
 	if localSID != nil {
-		return string(localSID.InstallationVrfId)
+		return fmt.Sprint(localSID.InstallationVrfId)
 	}
 	return "<nil>"
 }


### PR DESCRIPTION
```sh
# go.ligato.io/vpp-agent/v3/plugins/vpp/srplugin/vppcalls/vpp1904
plugins/vpp/srplugin/vppcalls/vpp1904/srv6.go:175: conversion from uint32 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
FAIL	go.ligato.io/vpp-agent/v3/plugins/vpp/srplugin/vppcalls/vpp1904 [build failed]
# go.ligato.io/vpp-agent/v3/plugins/vpp/srplugin/vppcalls/vpp1908
plugins/vpp/srplugin/vppcalls/vpp1908/srv6.go:174: conversion from uint32 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
FAIL	go.ligato.io/vpp-agent/v3/plugins/vpp/srplugin/vppcalls/vpp1908 [build failed]
# go.ligato.io/vpp-agent/v3/plugins/vpp/srplugin/vppcalls/vpp2001
plugins/vpp/srplugin/vppcalls/vpp2001/srv6.go:175: conversion from uint32 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
FAIL	go.ligato.io/vpp-agent/v3/plugins/vpp/srplugin/vppcalls/vpp2001 [build failed]
# go.ligato.io/vpp-agent/v3/plugins/vpp/srplugin/vppcalls/vpp2005
plugins/vpp/srplugin/vppcalls/vpp2005/srv6.go:180: conversion from uint32 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
FAIL	go.ligato.io/vpp-agent/v3/plugins/vpp/srplugin/vppcalls/vpp2005 [build failed]
```