### PR TITLE
Permit agent to run even when VPP stats are unavailable

### DIFF
--- a/plugins/govppmux/plugin_impl_govppmux.go
+++ b/plugins/govppmux/plugin_impl_govppmux.go
@@ -173,9 +173,10 @@ func (p *Plugin) Init() (err error) {
 		}
 		err := p.startProxy(NewVppAdapter(address, useShm), NewStatsAdapter(statsSocket))
 		if err != nil {
-			return err
+			p.Log.Warnf("VPP proxy failed to start: %v", err)
+		} else {
+			p.Log.Infof("VPP proxy ready")
 		}
-		p.Log.Infof("VPP proxy ready")
 	}
 
 	// register REST API handlers

--- a/plugins/telemetry/stats_poller.go
+++ b/plugins/telemetry/stats_poller.go
@@ -31,6 +31,9 @@ func (s *statsPollerServer) PollStats(req *configurator.PollStatsRequest, svr co
 	if req.GetPeriodSec() == 0 && req.GetNumPolls() > 1 {
 		return status.Error(codes.InvalidArgument, "period must be > 0 if number of polls is > 1")
 	}
+	if s.handler == nil {
+		return status.Errorf(codes.Unavailable, "VPP telemetry handler not available")
+	}
 
 	ctx := svr.Context()
 

--- a/plugins/telemetry/telemetry.go
+++ b/plugins/telemetry/telemetry.go
@@ -159,10 +159,11 @@ func (p *Plugin) AfterInit() error {
 func (p *Plugin) setupStatsPoller() error {
 	h := vppcalls.CompatibleTelemetryHandler(p.VPP)
 	if h == nil {
-		return fmt.Errorf("VPP telemetry handler unavailable")
+		p.Log.Warnf("VPP telemetry handler unavailable")
+	} else {
+		p.statsPollerServer.handler = h
 	}
-	p.statsPollerServer.handler = h
-	p.ifIndex = p.IfPlugin.GetInterfaceIndex()
+	p.statsPollerServer.ifIndex = p.IfPlugin.GetInterfaceIndex()
 
 	if p.GRPC != nil && p.GRPC.GetServer() != nil {
 		configurator.RegisterStatsPollerServiceServer(p.GRPC.GetServer(), &p.statsPollerServer)


### PR DESCRIPTION
This fixes situations where agent cannot connect to stats or when there is with compatibility, e.g. when stats segment version changes. This fixes VPP 20.09 support until GoVPP is compatible with version 2 of stat segment (already in progress by @VladoLavor)