### PR TITLE
fix: Fix IPv4 link-local IP address handling

### DIFF
--- a/cmd/agentctl/commands/dump.go
+++ b/cmd/agentctl/commands/dump.go
@@ -191,10 +191,11 @@ func printDumpTable(out io.Writer, dump []api.KVWithMetadata) {
 		"Model", "Origin", "Value", "Metadata", "Key",
 	})
 	table.SetAutoMergeCells(true)
+	table.SetAutoWrapText(false)
 	table.SetRowLine(true)
 
 	for _, d := range dump {
-		val := proto.MarshalTextString(d.Value)
+		val := yamlTmpl(d.Value)
 		var meta string
 		if d.Metadata != nil {
 			meta = yamlTmpl(d.Metadata)
@@ -211,7 +212,7 @@ func printDumpTable(out io.Writer, dump []api.KVWithMetadata) {
 				name = d.Key
 			}
 		}
-		val = fmt.Sprintf("[%s]\n%s", proto.MessageName(d.Value), val)
+		val = fmt.Sprintf("# %s\n%s", proto.MessageName(d.Value), val)
 		var row []string
 		row = []string{
 			model,

--- a/plugins/govppmux/plugin_impl_govppmux.go
+++ b/plugins/govppmux/plugin_impl_govppmux.go
@@ -173,9 +173,10 @@ func (p *Plugin) Init() (err error) {
 		}
 		err := p.startProxy(NewVppAdapter(address, useShm), NewStatsAdapter(statsSocket))
 		if err != nil {
-			return err
+			p.Log.Warnf("VPP proxy failed to start: %v", err)
+		} else {
+			p.Log.Infof("VPP proxy ready")
 		}
-		p.Log.Infof("VPP proxy ready")
 	}
 
 	// register REST API handlers

--- a/plugins/telemetry/stats_poller.go
+++ b/plugins/telemetry/stats_poller.go
@@ -31,6 +31,9 @@ func (s *statsPollerServer) PollStats(req *configurator.PollStatsRequest, svr co
 	if req.GetPeriodSec() == 0 && req.GetNumPolls() > 1 {
 		return status.Error(codes.InvalidArgument, "period must be > 0 if number of polls is > 1")
 	}
+	if s.handler == nil {
+		return status.Errorf(codes.Unavailable, "VPP telemetry handler not available")
+	}
 
 	ctx := svr.Context()
 

--- a/plugins/telemetry/telemetry.go
+++ b/plugins/telemetry/telemetry.go
@@ -159,10 +159,11 @@ func (p *Plugin) AfterInit() error {
 func (p *Plugin) setupStatsPoller() error {
 	h := vppcalls.CompatibleTelemetryHandler(p.VPP)
 	if h == nil {
-		return fmt.Errorf("VPP telemetry handler unavailable")
+		p.Log.Warnf("VPP telemetry handler unavailable")
+	} else {
+		p.statsPollerServer.handler = h
 	}
-	p.statsPollerServer.handler = h
-	p.ifIndex = p.IfPlugin.GetInterfaceIndex()
+	p.statsPollerServer.ifIndex = p.IfPlugin.GetInterfaceIndex()
 
 	if p.GRPC != nil && p.GRPC.GetServer() != nil {
 		configurator.RegisterStatsPollerServiceServer(p.GRPC.GetServer(), &p.statsPollerServer)

--- a/plugins/vpp/ifplugin/descriptor/interface_address.go
+++ b/plugins/vpp/ifplugin/descriptor/interface_address.go
@@ -122,7 +122,8 @@ func (d *InterfaceAddressDescriptor) Delete(key string, emptyVal proto.Message, 
 		return err
 	}
 
-	if ipAddr.IP.IsLinkLocalUnicast() {
+	// do not delete (auto-assigned) IPv6 link-local addresses
+	if ipAddr.IP.To4() == nil && ipAddr.IP.IsLinkLocalUnicast() {
 		return nil
 	}
 


### PR DESCRIPTION
A check in Delete operation in interface_address descriptor was preventing deletion of IPv4 link-local addresses (from the `169.254.0.0/16` range). That was causing multiple IPv4 addresses applied on a single interface after subsequent update operations.

This check only makes sense for IPv6 link-local addresses, which are auto-assigned by VPP on IPv6-enabled interfaces.

Signed-off-by: Rastislav Szabo <raszabo@cisco.com>