### PR TITLE
fix: Fix IPv4 link-local IP address handling

### DIFF
--- a/plugins/vpp/ifplugin/descriptor/interface_address.go
+++ b/plugins/vpp/ifplugin/descriptor/interface_address.go
@@ -122,7 +122,8 @@ func (d *InterfaceAddressDescriptor) Delete(key string, emptyVal proto.Message, 
 		return err
 	}
 
-	if ipAddr.IP.IsLinkLocalUnicast() {
+	// do not delete (auto-assigned) IPv6 link-local addresses
+	if ipAddr.IP.To4() == nil && ipAddr.IP.IsLinkLocalUnicast() {
 		return nil
 	}
 


### PR DESCRIPTION
A check in Delete operation in interface_address descriptor was preventing deletion of IPv4 link-local addresses (from the 169.254.0.0/16 range). That was causing multiple IPv4 addresses applied on a single interface after subsequent update operations.

This check only makes sense for IPv6 link-local addresses, which are auto-assigned by VPP on IPv6-enabled interfaces.

Signed-off-by: Rastislav Szabo raszabo@cisco.com