### PR TITLE
fix: Fix grpc context timeout for agentctl import command

### DIFF
--- a/cmd/agentctl/commands/import.go
+++ b/cmd/agentctl/commands/import.go
@@ -41,10 +41,7 @@ const (
 )
 
 func NewImportCommand(cli agentcli.Cli) *cobra.Command {
-	var (
-		opts    ImportOptions
-		timeout uint
-	)
+	var opts ImportOptions
 	cmd := &cobra.Command{
 		Use:   "import FILE",
 		Args:  cobra.ExactArgs(1),
@@ -80,7 +77,6 @@ KEY FORMAT
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.InputFile = args[0]
-			opts.Timeout = time.Duration(timeout)
 			return RunImport(cli, opts)
 		},
 	}


### PR DESCRIPTION
Timeout was always zero and not the default 30s or whatever has been configured.

Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>