### PR TITLE
Remove forced delay for linux interface notifications

### DIFF
--- a/plugins/linux/nsplugin/ns_plugin.go
+++ b/plugins/linux/nsplugin/ns_plugin.go
@@ -248,6 +248,7 @@ func (p *NsPlugin) getOrCreateNs(ctx nsLinuxcalls.NamespaceMgmtCtx, ns *nsmodel.
 	case nsmodel.NetNamespace_NSID:
 		nsHandle, err = p.sysHandler.GetNamespaceFromName(ns.Reference)
 		if err != nil {
+			p.Log.Warnf("GetNamespaceFromName %s failed: %v", ns.Reference, err)
 			// Create named namespace if it doesn't exist yet.
 			_, err = p.namedNsHandler.CreateNamedNetNs(ctx, ns.Reference)
 			if err != nil {


### PR DESCRIPTION
This PR is a fix for #1739

Agent log showing all received notifications for same config as in #1734:
```
+======================================================================================================================+
| #0 - NBTransaction                                                                                        FullResync |
+======================================================================================================================+
  * transaction arguments:
      - seqNum: 0
      - type: NB Transaction, Full Resync
      - values:

o----------------------------------------------------------------------------------------------------------------------o
  * executed operations:
      <NONE>
x----------------------------------------------------------------------------------------------------------------------x
| #0 - NBTransaction                                                                                       took 39.8ms |
x----------------------------------------------------------------------------------------------------------------------x

INFO[0000] dispatcher: Transaction #0 successful! (took 40.1ms) 
DEBU[0000] resync: finished resync for orchestrator took 62ms 
INFO[0000] resync: Resync done (took: 82ms)             
INFO[0000] status-check: Agent plugin state update.      lastErr="<nil>" plugin=VPPAgent state=ok
INFO[0000] agent: Agent started with 39 plugins (took 240ms) 
DEBU[0003] dispatcher: Push data with 3 KV pairs (source: grpc) 
DEBU[0003] dispatcher:  - UPDATE: "config/vpp/v2/interfaces/afpacket1"  
DEBU[0003] dispatcher:  - UPDATE: "config/linux/interfaces/v2/interface/veth1"  
DEBU[0003] dispatcher:  - UPDATE: "config/linux/interfaces/v2/interface/veth2"  
+======================================================================================================================+
| #1 - NBTransaction                                                                                                   |
+======================================================================================================================+
  * transaction arguments:
      - seqNum: 1
      - type: NB Transaction
      - values:
          - key: config/linux/interfaces/v2/interface/veth1
            val: { name:"veth1"  type:VETH  host_if_name:"veth-1"  enabled:true  ip_addresses:"10.0.2.1/30"  veth:{peer_if_name:"veth2"} }
          - key: config/linux/interfaces/v2/interface/veth2
            val: { name:"veth2"  type:VETH  host_if_name:"veth-2"  enabled:true  ip_addresses:"10.0.3.1/30"  veth:{peer_if_name:"veth1"} }
          - key: config/vpp/v2/interfaces/afpacket1
            val: { name:"afpacket1"  type:AF_PACKET  enabled:true  ip_addresses:"192.168.99.1/30"  afpacket:{host_if_name:"veth-1"} }

WARN[0003] linux-ifplugin.if-watcher:  ---> LINK NOTIFICATION: veth-2101756059 
 (attrs: &{Index:10 MTU:1500 TxQLen:1000 Name:veth-2101756059 HardwareAddr:0e:5a:0e:53:f5:70 Flags:broadcast|multicast RawFlags:4098 ParentIndex:0 MasterIndex:0 Namespace:<nil> Alias: Statistics:0xc000806108 Promisc:0 Xdp:0xc00036fda0 EncapType:ether Protinfo:<nil> OperState:down NetNsID:0 NumTxQueues:0 NumRxQueues:0 Vfs:[]})
 ({IfInfomsg:{IfInfomsg:{Family:0 _:0 Type:1 Index:10 Flags:4098 Change:4294967295}} Header:{Len:1352 Type:16 Flags:0 Seq:0 Pid:0} Link:0xc000238400}) 
WARN[0003] linux-ifplugin.if-watcher:  ---> LINK NOTIFICATION: veth-2118533678 
 (attrs: &{Index:11 MTU:1500 TxQLen:1000 Name:veth-2118533678 HardwareAddr:06:9d:85:f8:8c:9d Flags:broadcast|multicast RawFlags:4098 ParentIndex:10 MasterIndex:0 Namespace:<nil> Alias: Statistics:0xc000bf0108 Promisc:0 Xdp:0xc00036fde0 EncapType:ether Protinfo:<nil> OperState:down NetNsID:0 NumTxQueues:0 NumRxQueues:0 Vfs:[]})
 ({IfInfomsg:{IfInfomsg:{Family:0 _:0 Type:1 Index:11 Flags:4098 Change:4294967295}} Header:{Len:1352 Type:16 Flags:0 Seq:0 Pid:0} Link:0xc000238700}) 
WARN[0003] linux-ifplugin.if-watcher:  ---> LINK NOTIFICATION: veth-2 
 (attrs: &{Index:11 MTU:1500 TxQLen:1000 Name:veth-2 HardwareAddr:06:9d:85:f8:8c:9d Flags:broadcast|multicast RawFlags:4098 ParentIndex:10 MasterIndex:0 Namespace:<nil> Alias:/vnf-agent/agent0/veth2/veth1 Statistics:0xc000c98124 Promisc:0 Xdp:0xc00036ff80 EncapType:ether Protinfo:<nil> OperState:down NetNsID:0 NumTxQueues:0 NumRxQueues:0 Vfs:[]})
 ({IfInfomsg:{IfInfomsg:{Family:0 _:0 Type:1 Index:11 Flags:4098 Change:0}} Header:{Len:1380 Type:16 Flags:0 Seq:0 Pid:0} Link:0xc000238900}) 
WARN[0003] linux-ifplugin.if-watcher:  ---> LINK NOTIFICATION: veth-2 
 (attrs: &{Index:11 MTU:1500 TxQLen:1000 Name:veth-2 HardwareAddr:06:9d:85:f8:8c:9d Flags:up|broadcast|multicast RawFlags:4099 ParentIndex:10 MasterIndex:0 Namespace:<nil> Alias:/vnf-agent/agent0/veth2/veth1 Statistics:0xc000d34124 Promisc:0 Xdp:0xc00036ffe0 EncapType:ether Protinfo:<nil> OperState:lower-layer-down NetNsID:0 NumTxQueues:0 NumRxQueues:0 Vfs:[]})
 ({IfInfomsg:{IfInfomsg:{Family:0 _:0 Type:1 Index:11 Flags:4099 Change:1}} Header:{Len:1380 Type:16 Flags:0 Seq:0 Pid:0} Link:0xc000238b00}) 
WARN[0003] linux-ifplugin.if-watcher:  ---> LINK NOTIFICATION: veth-1 
 (attrs: &{Index:10 MTU:1500 TxQLen:1000 Name:veth-1 HardwareAddr:0e:5a:0e:53:f5:70 Flags:broadcast|multicast RawFlags:4098 ParentIndex:11 MasterIndex:0 Namespace:<nil> Alias:/vnf-agent/agent0/veth1/veth2 Statistics:0xc0007d4124 Promisc:0 Xdp:0xc000a90040 EncapType:ether Protinfo:<nil> OperState:down NetNsID:0 NumTxQueues:0 NumRxQueues:0 Vfs:[]})
 ({IfInfomsg:{IfInfomsg:{Family:0 _:0 Type:1 Index:10 Flags:4098 Change:0}} Header:{Len:1380 Type:16 Flags:0 Seq:0 Pid:0} Link:0xc000238100}) 
WARN[0003] linux-ifplugin.if-watcher:  ---> LINK NOTIFICATION: veth-1 
 (attrs: &{Index:10 MTU:1500 TxQLen:1000 Name:veth-1 HardwareAddr:0e:5a:0e:53:f5:70 Flags:up|broadcast|multicast RawFlags:69635 ParentIndex:11 MasterIndex:0 Namespace:<nil> Alias:/vnf-agent/agent0/veth1/veth2 Statistics:0xc0007e4124 Promisc:0 Xdp:0xc000a900a0 EncapType:ether Protinfo:<nil> OperState:lower-layer-down NetNsID:0 NumTxQueues:0 NumRxQueues:0 Vfs:[]})
 ({IfInfomsg:{IfInfomsg:{Family:0 _:0 Type:1 Index:10 Flags:69635 Change:1}} Header:{Len:1380 Type:16 Flags:0 Seq:0 Pid:0} Link:0xc000238300}) 
o----------------------------------------------------------------------------------------------------------------------o
  * executed operations (2020-10-13 09:35:43.271 +0000 UTC -> 2020-10-13 09:35:43.309 +0000 UTC, dur: 38ms):
      1. CREATE:
          - key: config/linux/interfaces/v2/interface/veth2
          - value: { name:"veth2"  type:VETH  host_if_name:"veth-2"  enabled:true  ip_addresses:"10.0.3.1/30"  veth:{peer_if_name:"veth1"} } 
      2. CREATE:
          - key: config/linux/interfaces/v2/interface/veth1
          - value: { name:"veth1"  type:VETH  host_if_name:"veth-1"  enabled:true  ip_addresses:"10.0.2.1/30"  veth:{peer_if_name:"veth2"} } 
      3. CREATE [PROPERTY]:
          - key: linux/interface/state/veth1/UP
          - value: <EMPTY> 
      4. CREATE [DERIVED]:
          - key: linux/interface/veth1/address/static/10.0.2.1/30
          - value: <EMPTY> 
      5. CREATE [PROPERTY]:
          - key: linux/interface/state/veth2/UP
          - value: <EMPTY> 
      6. CREATE [DERIVED]:
          - key: linux/interface/veth2/address/static/10.0.3.1/30
          - value: <EMPTY> 
      7. CREATE [NOOP IS-PENDING]:
          - key: config/vpp/v2/interfaces/afpacket1
          - value: { name:"afpacket1"  type:AF_PACKET  enabled:true  ip_addresses:"192.168.99.1/30"  afpacket:{host_if_name:"veth-1"} } 
x----------------------------------------------------------------------------------------------------------------------x
| #1 - NBTransaction                                                                                       took 38.1ms |
x----------------------------------------------------------------------------------------------------------------------x

+======================================================================================================================+
| #2 - SBNotification                                                                                                  |
+======================================================================================================================+
  * transaction arguments:
      - seqNum: 2
      - type: SB Notification
      - values:
          - key: linux/interface/host-name/veth-2
            val: <EMPTY>

o----------------------------------------------------------------------------------------------------------------------o
  * executed operations (2020-10-13 09:35:43.31 +0000 UTC -> 2020-10-13 09:35:43.31 +0000 UTC, dur: 0s):
      1. CREATE [OBTAINED]:
          - key: linux/interface/host-name/veth-2
          - value: <EMPTY> 
x----------------------------------------------------------------------------------------------------------------------x
| #2 - SBNotification                                                                                          took 0s |
x----------------------------------------------------------------------------------------------------------------------x

DEBU[0003] kvscheduler: Transaction 2 successful        
+======================================================================================================================+
| #3 - SBNotification                                                                                                  |
+======================================================================================================================+
  * transaction arguments:
      - seqNum: 3
      - type: SB Notification
      - values:
          - key: linux/interface/host-name/veth-1
            val: <EMPTY>

WARN[0003] linux-ifplugin.if-watcher:  ---> LINK NOTIFICATION: veth-1 
 (attrs: &{Index:10 MTU:1500 TxQLen:1000 Name:veth-1 HardwareAddr:0e:5a:0e:53:f5:70 Flags:up|broadcast|multicast RawFlags:69699 ParentIndex:11 MasterIndex:0 Namespace:<nil> Alias:/vnf-agent/agent0/veth1/veth2 Statistics:0xc000966124 Promisc:0 Xdp:0xc000a90280 EncapType:ether Protinfo:<nil> OperState:up NetNsID:0 NumTxQueues:0 NumRxQueues:0 Vfs:[]})
 ({IfInfomsg:{IfInfomsg:{Family:0 _:0 Type:1 Index:10 Flags:69699 Change:0}} Header:{Len:1380 Type:16 Flags:0 Seq:0 Pid:0} Link:0xc000238500}) 
WARN[0003] linux-ifplugin.if-watcher:  ---> LINK NOTIFICATION: veth-2 
 (attrs: &{Index:11 MTU:1500 TxQLen:1000 Name:veth-2 HardwareAddr:06:9d:85:f8:8c:9d Flags:up|broadcast|multicast RawFlags:69699 ParentIndex:10 MasterIndex:0 Namespace:<nil> Alias:/vnf-agent/agent0/veth2/veth1 Statistics:0xc000be0124 Promisc:0 Xdp:0xc000a902e0 EncapType:ether Protinfo:<nil> OperState:up NetNsID:0 NumTxQueues:0 NumRxQueues:0 Vfs:[]})
 ({IfInfomsg:{IfInfomsg:{Family:0 _:0 Type:1 Index:11 Flags:69699 Change:0}} Header:{Len:1380 Type:16 Flags:0 Seq:0 Pid:0} Link:0xc000238800}) 
DEBU[0003] vpp-ifplugin.if-descriptor: publish add to ifplugin_ifstate{{afpacket1 false false vpp-interface-index} 0xc0002d7090} 
DEBU[0003] vpp-ifplugin: Interface 1 set to VRF 0       
o----------------------------------------------------------------------------------------------------------------------o
  * executed operations (2020-10-13 09:35:43.31 +0000 UTC -> 2020-10-13 09:35:43.389 +0000 UTC, dur: 79ms):
      1. CREATE [OBTAINED]:
          - key: linux/interface/host-name/veth-1
          - value: <EMPTY> 
      2. CREATE [WAS-PENDING]:
          - key: config/vpp/v2/interfaces/afpacket1
          - value: { name:"afpacket1"  type:AF_PACKET  enabled:true  ip_addresses:"192.168.99.1/30"  afpacket:{host_if_name:"veth-1"} } 
      3. CREATE [DERIVED]:
          - key: vpp/interface/afpacket1/vrf/0/ip-version/v4
          - value: <EMPTY> 
      4. CREATE [DERIVED]:
          - key: vpp/interface/afpacket1/address/static/192.168.99.1/30
          - value: <EMPTY> 
      5. CREATE [DERIVED]:
          - key: vpp/interface/afpacket1/has-IP-address
          - value: <EMPTY> 
x----------------------------------------------------------------------------------------------------------------------x
| #3 - SBNotification                                                                                      took 79.2ms |
x----------------------------------------------------------------------------------------------------------------------x

DEBU[0003] kvscheduler: Transaction 3 successful        
INFO[0003] dispatcher: Transaction #1 successful! (took 118ms) 
DEBU[0003] configurator.configurator: no pendings keys to wait for 
INFO[0003] configurator.configurator: finished waiting for done (took 75.014µs) 
DEBU[0003] configurator.configurator: config update finished with 4 results 
+======================================================================================================================+
| #4 - SBNotification                                                                                                  |
+======================================================================================================================+
  * transaction arguments:
      - seqNum: 4
      - type: SB Notification
      - values:
          - key: vpp/interface/afpacket1/link-state/DOWN
            val: <EMPTY>

o----------------------------------------------------------------------------------------------------------------------o
  * executed operations (2020-10-13 09:35:43.393 +0000 UTC -> 2020-10-13 09:35:43.393 +0000 UTC, dur: 0s):
      1. CREATE [OBTAINED]:
          - key: vpp/interface/afpacket1/link-state/DOWN
          - value: <EMPTY> 
x----------------------------------------------------------------------------------------------------------------------x
| #4 - SBNotification                                                                                       took 200µs |
x----------------------------------------------------------------------------------------------------------------------x

DEBU[0003] kvscheduler: Transaction 4 successful        
INFO[0005] status-check: Agent plugin state update.      lastErr="<nil>" plugin=etcd state=ok
DEBU[0009] vpp-ifplugin.if-state: updating interface states for 2 interfaces 
INFO[0009] status-check: Agent plugin state update.      lastErr="<nil>" plugin=vpp-ifplugin state=ok
DEBU[0009] status-check: Global interface state data added: internal_name:"local0" status:"DOWN" mac_address:"00:00:00:00:00:00"  
DEBU[0009] status-check: Global interface state data added: internal_name:"host-veth-1" index:1 status:"UP" mac_address:"02:fe:30:29:80:98"  
+======================================================================================================================+
| #5 - SBNotification                                                                                                  |
+======================================================================================================================+
  * transaction arguments:
      - seqNum: 5
      - type: SB Notification
      - values:
          - key: vpp/interface/afpacket1/link-state/DOWN
            val: <NIL>
          - key: vpp/interface/afpacket1/link-state/UP
            val: <EMPTY>

o----------------------------------------------------------------------------------------------------------------------o
  * executed operations (2020-10-13 09:35:49.147 +0000 UTC -> 2020-10-13 09:35:49.147 +0000 UTC, dur: 0s):
      1. DELETE [WAS-OBTAINED]:
          - key: vpp/interface/afpacket1/link-state/DOWN
          - value: <EMPTY> 
      2. CREATE [OBTAINED]:
          - key: vpp/interface/afpacket1/link-state/UP
          - value: <EMPTY> 
x----------------------------------------------------------------------------------------------------------------------x
| #5 - SBNotification                                                                                       took 200µs |
x----------------------------------------------------------------------------------------------------------------------x

DEBU[0009] kvscheduler: Transaction 5 successful     
```