### PR TITLE
Disable allowed failures for VPP 20.09

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,8 @@ jobs:
       after_success:
         - bash <(curl -s https://codecov.io/bash) -f /tmp/e2e-cov.out -F e2e
 
-  allow_failures:
-    - env: VPP_VERSION=2009
+#  allow_failures:
+#    - env: VPP_VERSION=2009
 
 notifications:
   slack:

--- a/plugins/vpp/binapi/vpp2009/wireguard/wireguard.ba.go
+++ b/plugins/vpp/binapi/vpp2009/wireguard/wireguard.ba.go
@@ -10,12 +10,12 @@
 package wireguard
 
 import (
-	interface_types "go.ligato.io/vpp-agent/v3/plugins/vpp/binapi/vpp2009/interface_types"
-	ip_types "go.ligato.io/vpp-agent/v3/plugins/vpp/binapi/vpp2009/ip_types"
 	"strconv"
 
 	api "git.fd.io/govpp.git/api"
 	codec "git.fd.io/govpp.git/codec"
+	interface_types "go.ligato.io/vpp-agent/v3/plugins/vpp/binapi/vpp2009/interface_types"
+	ip_types "go.ligato.io/vpp-agent/v3/plugins/vpp/binapi/vpp2009/ip_types"
 )
 
 // This is a compile-time assertion to ensure that this generated file


### PR DESCRIPTION
This PR disables `allowed_failures` in travis for VPP 20.09. It also contains minor formatting fix for genrated binapi of wireguard in vpp2009 to avoid failing integration test.