### PR TITLE
feat: add reading VPP threads to the telemetry plugin

### DIFF
--- a/examples/vpp_stats/main.go
+++ b/examples/vpp_stats/main.go
@@ -1,0 +1,215 @@
+//  Copyright (c) 2020 Cisco and/or its affiliates.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at:
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// The VPP stats example shows how to use telemetry API to access
+// VPP stats via the GoVPP stats socket API and the telemetry vpp calls.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"git.fd.io/govpp.git/api"
+	"go.ligato.io/cn-infra/v2/agent"
+	"go.ligato.io/cn-infra/v2/config"
+	"go.ligato.io/cn-infra/v2/logging"
+	"go.ligato.io/cn-infra/v2/logging/logrus"
+	"go.ligato.io/vpp-agent/v3/plugins/govppmux"
+	"go.ligato.io/vpp-agent/v3/plugins/telemetry"
+	"go.ligato.io/vpp-agent/v3/plugins/telemetry/vppcalls"
+	"log"
+	"time"
+)
+
+const PluginName = "stats-example"
+
+func main() {
+	ep := &StatsExamplePlugin{
+		Log:       logging.DefaultLogger,
+		Telemetry: &telemetry.DefaultPlugin,
+	}
+	stopExample := make(chan struct{})
+
+	a := agent.NewAgent(
+		agent.AllPlugins(ep),
+		agent.QuitOnClose(stopExample),
+	)
+	if err := a.Run(); err != nil {
+		log.Fatal(err)
+	}
+
+	go closeExample("Stats example finished", stopExample)
+}
+
+// StatsExamplePlugin displays VPP stats using telemetry plugin
+type StatsExamplePlugin struct {
+	handler vppcalls.TelemetryVppAPI
+
+	config.PluginConfig
+	Log       logging.Logger
+	Telemetry *telemetry.Plugin
+}
+
+func (p *StatsExamplePlugin) Init() error {
+	var err error
+	p.handler, err = vppcalls.NewHandler(&govppmux.DefaultPlugin)
+	if err != nil {
+		panic(err)
+	}
+
+	go p.processStats()
+	return nil
+}
+
+func (p *StatsExamplePlugin) Close() error {
+	p.Log.Info("Stats example closed")
+	return nil
+}
+
+func (p *StatsExamplePlugin) String() string {
+	return PluginName
+}
+
+func closeExample(message string, stopExample chan struct{}) {
+	time.Sleep(10 * time.Second)
+	logrus.DefaultLogger().Info(message)
+	close(stopExample)
+}
+
+func (p *StatsExamplePlugin) processStats() {
+	// give the Agent some time to initialize
+	// so the output is not mixed
+	time.Sleep(1 * time.Second)
+	p.Log.Infoln("Processing stats")
+
+	var errors []error
+
+	// collect stats
+	ifStats, err := p.handler.GetInterfaceStats(context.Background())
+	if err != nil {
+		errors = append(errors, fmt.Errorf("eroror retireving interface stats: %v", err))
+	}
+	nodeCounters, err := p.handler.GetNodeCounters(context.Background())
+	if err != nil {
+		errors = append(errors, fmt.Errorf("eroror retireving node counters: %v", err))
+	}
+
+	systemStats, err := p.handler.GetSystemStats(context.Background())
+	if err != nil {
+		errors = append(errors, fmt.Errorf("eroror retireving system stats: %v", err))
+	}
+
+	runtimeInfo, err := p.handler.GetRuntimeInfo(context.Background())
+	if err != nil {
+		errors = append(errors, fmt.Errorf("eroror retireving runtime info: %v", err))
+	}
+
+	bufferInfo, err := p.handler.GetBuffersInfo(context.Background())
+	if err != nil {
+		errors = append(errors, fmt.Errorf("eroror retireving buffers info: %v", err))
+	}
+
+	threadsInfo, err := p.handler.GetThreads(context.Background())
+	if err != nil {
+		errors = append(errors, fmt.Errorf("eroror retireving threads: %v", err))
+	}
+
+	// print all errors and return if there is any
+	if len(errors) != 0 {
+		for _, err := range errors {
+			p.Log.Error(err)
+		}
+		return
+	}
+
+	// print collected stats
+	printIfStats(ifStats)
+	printNodeCounters(nodeCounters)
+	printSystemStats(systemStats)
+	printRuntimeInfo(runtimeInfo)
+	printBufferInfo(bufferInfo)
+	printThreadsInfo(threadsInfo)
+}
+
+func printIfStats(ifStats *api.InterfaceStats) {
+	for _, ifStat := range ifStats.Interfaces {
+		fmt.Printf(`
+Interface name: %s (sw_if_idx %d)
+	Received: %d (rx errors %d)
+	Transmitted: %d (tx errors %d)
+	Drops: %d
+`, ifStat.InterfaceName, ifStat.InterfaceIndex, ifStat.Rx, ifStat.RxErrors,
+			ifStat.Tx, ifStat.TxErrors, ifStat.Drops)
+	}
+}
+
+func printNodeCounters(nodeCountersInfo *vppcalls.NodeCounterInfo) {
+	maxLen := 5
+	for i, nodeCounters := range nodeCountersInfo.GetCounters() {
+		if i >= maxLen {
+			// do not print everything, it is not necessary
+			break
+		}
+		fmt.Printf(`
+Node name: %s 
+Node: %s 
+
+`, nodeCounters.Name, nodeCounters.Node)
+	}
+	if len(nodeCountersInfo.GetCounters()) >= maxLen {
+		fmt.Printf("... and another %d nodes\n", len(nodeCountersInfo.GetCounters())-maxLen)
+	}
+}
+
+func printSystemStats(systemStats *api.SystemStats) {
+	fmt.Printf(`
+Last update: %d
+Last stats clear: %d
+Input rate: %d
+Num. Worker Threads: %d
+Vector rate: %d (per worker: %+v)
+Heartbeat: %d
+`, systemStats.LastUpdate, systemStats.LastStatsClear, systemStats.InputRate, systemStats.NumWorkerThreads,
+		systemStats.VectorRate, systemStats.VectorRatePerWorker, systemStats.Heartbeat)
+}
+
+func printRuntimeInfo(runtimeInfo *vppcalls.RuntimeInfo) {
+	for _, thread := range runtimeInfo.GetThreads() {
+		fmt.Printf("\nThread: %s (ID %d)", thread.Name, thread.ID)
+	}
+}
+
+func printBufferInfo(bufferInfo *vppcalls.BuffersInfo) {
+	for _, buffer := range bufferInfo.GetItems() {
+		fmt.Printf(`
+
+Buffer name: %s (index %d)
+	Alloc: %d (num %d)
+	Free: %d (num %d)
+	Size: %d
+	Thread ID: %d
+`, buffer.Name, buffer.Index, buffer.Alloc, buffer.NumAlloc, buffer.Free, buffer.NumFree, buffer.Size, buffer.ThreadID)
+	}
+}
+
+func printThreadsInfo(threadsInfo *vppcalls.ThreadsInfo) {
+	for _, thread := range threadsInfo.GetItems() {
+		fmt.Printf(`
+Thread name: %s (ID %d)
+	Type: %s
+	PID: %d 
+	Core: %d (CPU ID %d, CPU socket %d)
+`, thread.Name, thread.ID, thread.Type, thread.PID, thread.Core, thread.CPUID, thread.CPUSocket)
+	}
+}

--- a/examples/vpp_stats/main.go
+++ b/examples/vpp_stats/main.go
@@ -125,6 +125,12 @@ func (p *StatsExamplePlugin) processStats() {
 		errors = append(errors, fmt.Errorf("eroror retireving threads: %v", err))
 	}
 
+	memoryInfo, err := p.handler.GetMemory(context.Background())
+	fmt.Printf("mem %v, err %v", memoryInfo, err)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("eroror retireving memory info: %v", err))
+	}
+
 	// print all errors and return if there is any
 	if len(errors) != 0 {
 		for _, err := range errors {
@@ -140,6 +146,7 @@ func (p *StatsExamplePlugin) processStats() {
 	printRuntimeInfo(runtimeInfo)
 	printBufferInfo(bufferInfo)
 	printThreadsInfo(threadsInfo)
+	printMemoryInfo(memoryInfo)
 }
 
 func printIfStats(ifStats *api.InterfaceStats) {
@@ -211,5 +218,18 @@ Thread name: %s (ID %d)
 	PID: %d 
 	Core: %d (CPU ID %d, CPU socket %d)
 `, thread.Name, thread.ID, thread.Type, thread.PID, thread.Core, thread.CPUID, thread.CPUSocket)
+	}
+}
+
+func printMemoryInfo(memoryInfo *vppcalls.MemoryInfo) {
+	for _, thread := range memoryInfo.GetThreads() {
+		fmt.Printf(`
+Thread %d %s
+  size %d, %d pages, page size %d
+  total: %d, used: %d, free: %d, trimmable: %d
+    free chunks %d free fastbin blks %d
+    max total allocated %d
+`, thread.ID, thread.Name, thread.Size, thread.Pages, thread.PageSize, thread.Total, thread.Used,
+			thread.Free, thread.Trimmable, thread.FreeChunks, thread.FreeFastbinBlks, thread.MaxTotalAlloc)
 	}
 }

--- a/plugins/govppmux/vppcalls/vpp1908/vpe_vppcalls.go
+++ b/plugins/govppmux/vppcalls/vpp1908/vpe_vppcalls.go
@@ -132,6 +132,26 @@ func (h *VpeHandler) GetPlugins(ctx context.Context) ([]vppcalls.PluginInfo, err
 	return plugins, nil
 }
 
+func (h *VpeHandler) GetThreads(ctx context.Context) ([]vppcalls.ThreadInfo, error) {
+	resp, err := h.vpe.ShowThreads(ctx, &vpe.ShowThreads{})
+	if err != nil {
+		return nil, err
+	}
+	threads := make([]vppcalls.ThreadInfo, len(resp.ThreadData))
+	for i, thread := range resp.ThreadData {
+		threads[i] = vppcalls.ThreadInfo{
+			Name:      string(thread.Name),
+			ID:        thread.ID,
+			Type:      string(thread.Type),
+			PID:       thread.PID,
+			Core:      thread.Core,
+			CPUID:     thread.CPUID,
+			CPUSocket: thread.CPUSocket,
+		}
+	}
+	return threads, nil
+}
+
 // RunCli sends CLI command to VPP and returns response.
 func (h *VpeHandler) RunCli(ctx context.Context, cmd string) (string, error) {
 	resp, err := h.vpe.CliInband(ctx, &vpe.CliInband{

--- a/plugins/govppmux/vppcalls/vpp2001/vpe_vppcalls.go
+++ b/plugins/govppmux/vppcalls/vpp2001/vpe_vppcalls.go
@@ -134,6 +134,26 @@ func (h *VpeHandler) GetPlugins(ctx context.Context) ([]vppcalls.PluginInfo, err
 	return plugins, nil
 }
 
+func (h *VpeHandler) GetThreads(ctx context.Context) ([]vppcalls.ThreadInfo, error) {
+	resp, err := h.vpe.ShowThreads(ctx, &vpe.ShowThreads{})
+	if err != nil {
+		return nil, err
+	}
+	threads := make([]vppcalls.ThreadInfo, len(resp.ThreadData))
+	for i, thread := range resp.ThreadData {
+		threads[i] = vppcalls.ThreadInfo{
+			Name:      string(thread.Name),
+			ID:        thread.ID,
+			Type:      string(thread.Type),
+			PID:       thread.PID,
+			Core:      thread.Core,
+			CPUID:     thread.CPUID,
+			CPUSocket: thread.CPUSocket,
+		}
+	}
+	return threads, nil
+}
+
 // RunCli sends CLI command to VPP and returns response.
 func (h *VpeHandler) RunCli(ctx context.Context, cmd string) (string, error) {
 	resp, err := h.vpe.CliInband(ctx, &vpe.CliInband{

--- a/plugins/govppmux/vppcalls/vpp2005/vpe_vppcalls.go
+++ b/plugins/govppmux/vppcalls/vpp2005/vpe_vppcalls.go
@@ -134,6 +134,26 @@ func (h *VpeHandler) GetPlugins(ctx context.Context) ([]vppcalls.PluginInfo, err
 	return plugins, nil
 }
 
+func (h *VpeHandler) GetThreads(ctx context.Context) ([]vppcalls.ThreadInfo, error) {
+	resp, err := h.vpe.ShowThreads(ctx, &vpe.ShowThreads{})
+	if err != nil {
+		return nil, err
+	}
+	threads := make([]vppcalls.ThreadInfo, len(resp.ThreadData))
+	for i, thread := range resp.ThreadData {
+		threads[i] = vppcalls.ThreadInfo{
+			Name:      thread.Name,
+			ID:        thread.ID,
+			Type:      thread.Type,
+			PID:       thread.PID,
+			Core:      thread.Core,
+			CPUID:     thread.CPUID,
+			CPUSocket: thread.CPUSocket,
+		}
+	}
+	return threads, nil
+}
+
 // RunCli sends CLI command to VPP and returns response.
 func (h *VpeHandler) RunCli(ctx context.Context, cmd string) (string, error) {
 	resp, err := h.vpe.CliInband(ctx, &vpe.CliInband{

--- a/plugins/govppmux/vppcalls/vpp2009/vpe_vppcalls.go
+++ b/plugins/govppmux/vppcalls/vpp2009/vpe_vppcalls.go
@@ -135,6 +135,26 @@ func (h *VpeHandler) GetPlugins(ctx context.Context) ([]vppcalls.PluginInfo, err
 	return plugins, nil
 }
 
+func (h *VpeHandler) GetThreads(ctx context.Context) ([]vppcalls.ThreadInfo, error) {
+	resp, err := h.vpe.ShowThreads(ctx, &vpe.ShowThreads{})
+	if err != nil {
+		return nil, err
+	}
+	threads := make([]vppcalls.ThreadInfo, len(resp.ThreadData))
+	for i, thread := range resp.ThreadData {
+		threads[i] = vppcalls.ThreadInfo{
+			Name:      thread.Name,
+			ID:        thread.ID,
+			Type:      thread.Type,
+			PID:       thread.PID,
+			Core:      thread.Core,
+			CPUID:     thread.CPUID,
+			CPUSocket: thread.CPUSocket,
+		}
+	}
+	return threads, nil
+}
+
 // RunCli sends CLI command to VPP and returns response.
 func (h *VpeHandler) RunCli(ctx context.Context, cmd string) (string, error) {
 	reply, err := h.vpe.CliInband(ctx, &vpe.CliInband{

--- a/plugins/govppmux/vppcalls/vpp_handler_api.go
+++ b/plugins/govppmux/vppcalls/vpp_handler_api.go
@@ -28,7 +28,7 @@ import (
 type VppCoreAPI interface {
 	// Ping sends control ping to VPP.
 	Ping(context.Context) error
-	// RunCli sends CLI commmand to VPP.
+	// RunCli sends CLI command to VPP.
 	RunCli(ctx context.Context, cmd string) (string, error)
 	// GetVersion retrieves info about VPP version.
 	GetVersion(context.Context) (*VersionInfo, error)
@@ -38,6 +38,8 @@ type VppCoreAPI interface {
 	GetModules(context.Context) ([]APIModule, error)
 	// GetPlugins retrieves info about loaded VPP plugins.
 	GetPlugins(context.Context) ([]PluginInfo, error)
+	// GetThreads retrieves info about VPP threads.
+	GetThreads(ctx context.Context) ([]ThreadInfo, error)
 }
 
 // SessionInfo contains info about VPP session.
@@ -81,6 +83,17 @@ type PluginInfo struct {
 	Path        string
 	Version     string
 	Description string
+}
+
+// ThreadInfo wraps all thread data counters.
+type ThreadInfo struct {
+	Name      string
+	ID        uint32
+	Type      string
+	PID       uint32
+	CPUID     uint32
+	Core      uint32
+	CPUSocket uint32
 }
 
 func (p PluginInfo) String() string {

--- a/plugins/telemetry/prometheus.go
+++ b/plugins/telemetry/prometheus.go
@@ -54,14 +54,16 @@ const (
 	memoryThreadLabel   = "thread"
 	memoryThreadIDLabel = "threadID"
 
-	memoryObjectsMetric   = "objects"
-	memoryUsedMetric      = "used"
-	memoryTotalMetric     = "total"
-	memoryFreeMetric      = "free"
-	memoryReclaimedMetric = "reclaimed"
-	memoryOverheadMetric  = "overhead"
-	memorySizeMetric      = "size"
-	memoryPagesMetric     = "pages"
+	memoryObjectsMetric         = "objects"
+	memoryUsedMetric            = "used"
+	memoryTotalMetric           = "total"
+	memoryFreeMetric            = "free"
+	memoryTrimmableMetric       = "trimmable"
+	memoryFreeChunksMetric      = "free_chunks"
+	memoryFreeFastbinBlksMetric = "free_fastbin_blks"
+	memoryMaxTotalAlloc         = "max_total_allocated"
+	memorySizeMetric            = "size"
+	memoryPagesMetric           = "pages"
 )
 
 // Buffers metrics
@@ -181,7 +183,6 @@ func (p *Plugin) registerPrometheus() error {
 				agentLabel: p.ServiceLabel.GetAgentLabel(),
 			},
 		}, []string{runtimeItemLabel, runtimeThreadLabel, runtimeThreadIDLabel})
-
 	}
 
 	// register created vectors to prometheus
@@ -201,10 +202,12 @@ func (p *Plugin) registerPrometheus() error {
 		{memoryUsedMetric, "Used memory"},
 		{memoryTotalMetric, "Total memory"},
 		{memoryFreeMetric, "Free memory"},
-		{memoryReclaimedMetric, "Reclaimed memory"},
-		{memoryOverheadMetric, "Overhead"},
 		{memorySizeMetric, "Size"},
 		{memoryPagesMetric, "Pages"},
+		{memoryTrimmableMetric, "Trimmable"},
+		{memoryFreeChunksMetric, "Free Chunks"},
+		{memoryFreeFastbinBlksMetric, "Free Fastbin Bulks"},
+		{memoryMaxTotalAlloc, "Max Total Allocations"},
 	} {
 		name := metric[0]
 		p.memoryGaugeVecs[name] = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -443,14 +446,15 @@ func (p *Plugin) updatePrometheus(ctx context.Context) {
 					}
 				}
 
-				stats.metrics[memoryObjectsMetric].Set(float64(thread.Objects))
 				stats.metrics[memoryUsedMetric].Set(float64(thread.Used))
 				stats.metrics[memoryTotalMetric].Set(float64(thread.Total))
 				stats.metrics[memoryFreeMetric].Set(float64(thread.Free))
-				stats.metrics[memoryReclaimedMetric].Set(float64(thread.Reclaimed))
-				stats.metrics[memoryOverheadMetric].Set(float64(thread.Overhead))
 				stats.metrics[memorySizeMetric].Set(float64(thread.Size))
 				stats.metrics[memoryPagesMetric].Set(float64(thread.Pages))
+				stats.metrics[memoryTrimmableMetric].Set(float64(thread.Trimmable))
+				stats.metrics[memoryFreeChunksMetric].Set(float64(thread.FreeChunks))
+				stats.metrics[memoryFreeFastbinBlksMetric].Set(float64(thread.FreeFastbinBlks))
+				stats.metrics[memoryMaxTotalAlloc].Set(float64(thread.MaxTotalAlloc))
 			}
 		}
 	}

--- a/plugins/telemetry/vppcalls/telemetry_handler_api.go
+++ b/plugins/telemetry/vppcalls/telemetry_handler_api.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	// FallbackToCli defines wether should telemetry handler
+	// FallbackToCli defines whether should telemetry handler
 	// fallback to parsing stats from CLI output.
 	FallbackToCli = false
 )
@@ -37,6 +37,7 @@ type TelemetryVppAPI interface {
 	GetRuntimeInfo(context.Context) (*RuntimeInfo, error)
 	GetBuffersInfo(context.Context) (*BuffersInfo, error)
 	GetInterfaceStats(context.Context) (*govppapi.InterfaceStats, error)
+	GetThreads(ctx context.Context) (*ThreadsInfo, error)
 }
 
 // MemoryInfo contains memory thread info.
@@ -153,6 +154,30 @@ type BuffersItem struct {
 	NumFree  uint64 `json:"num_free"`
 }
 
+// ThreadsInfo contains values returned form `show threads`
+type ThreadsInfo struct {
+	Items []ThreadsItem
+}
+
+// GetItems is safe getter for thread items
+func (i *ThreadsInfo) GetItems() []ThreadsItem {
+	if i == nil {
+		return nil
+	}
+	return i.Items
+}
+
+// ThreadsItem represents single threads item
+type ThreadsItem struct {
+	Name      string `json:"name"`
+	ID        uint32 `json:"id"`
+	Type      string `json:"type"`
+	PID       uint32 `json:"pid"`
+	CPUID     uint32 `json:"cpuid"`
+	Core      uint32 `json:"core"`
+	CPUSocket uint32 `json:"cpu_socket"`
+}
+
 var Handler = vpp.RegisterHandler(vpp.HandlerDesc{
 	Name:       "telemetry",
 	HandlerAPI: (*TelemetryVppAPI)(nil),
@@ -173,30 +198,47 @@ func AddHandlerVersion(version vpp.Version, msgs []govppapi.Message, h NewHandle
 	})
 }
 
+// NewHandler returns the telemetry handler preferring the VPP stats API
+// with CLI/binary API handler injected to retrieve data not included in
+// stats. In case the stats API is not available, CLI handler is returned.
 func NewHandler(c vpp.Client) (TelemetryVppAPI, error) {
-	// Prefer using VPP stats API.
-	if stats := c.Stats(); stats != nil {
-		return NewTelemetryVppStats(stats), nil
-	}
+	var compatibleHandler TelemetryVppAPI = nil
 	v, err := Handler.GetCompatibleVersion(c)
+	if err != nil {
+		log.Warnf("compatible handler unavailable: %v", err)
+	} else {
+		compatibleHandler = v.NewHandler(c).(TelemetryVppAPI)
+	}
+	// Prefer the VPP stats API (even without the handler)
+	if stats := c.Stats(); stats != nil {
+		return NewTelemetryVppStats(stats, compatibleHandler), nil
+	}
 	if err != nil {
 		return nil, err
 	}
-	return v.New.(NewHandlerFunc)(c), nil
+	return compatibleHandler, nil
 }
 
+// CompatibleTelemetryHandler returns the telemetry handler respecting
+// VPP version. It returns the stats API handler when available, or
+// fallbacks to the CLI when requested.
 func CompatibleTelemetryHandler(c vpp.Client) TelemetryVppAPI {
-	// Prefer using VPP stats API.
+	var compatibleHandler TelemetryVppAPI = nil
+	v := Handler.FindCompatibleVersion(c)
+	if v != nil {
+		compatibleHandler = v.NewHandler(c).(TelemetryVppAPI)
+	}
+	if FallbackToCli && v != nil {
+		log.Info("falling back to parsing CLI output for telemetry")
+		return v.NewHandler(c).(TelemetryVppAPI)
+	}
 	if stats := c.Stats(); stats != nil {
-		return NewTelemetryVppStats(stats)
-	}
-	if FallbackToCli {
-		if v := Handler.FindCompatibleVersion(c); v != nil {
-			log.Info("falling back to parsing CLI output for telemetry")
-			return v.NewHandler(c).(TelemetryVppAPI)
+		if v == nil {
+			log.Warn("handler unavailable, functionality limited")
 		}
-		// no compatible version found
+		return NewTelemetryVppStats(stats, compatibleHandler)
 	}
+	// no compatible version found
 	log.Warnf("stats connection not available for telemetry")
 	return nil
 }

--- a/plugins/telemetry/vppcalls/telemetry_handler_api.go
+++ b/plugins/telemetry/vppcalls/telemetry_handler_api.go
@@ -55,17 +55,18 @@ func (i *MemoryInfo) GetThreads() []MemoryThread {
 
 // MemoryThread represents single thread memory counters
 type MemoryThread struct {
-	ID        uint   `json:"id"`
-	Name      string `json:"name"`
-	Size      uint64 `json:"size"`
-	Objects   uint64 `json:"objects"`
-	Used      uint64 `json:"used"`
-	Total     uint64 `json:"total"`
-	Free      uint64 `json:"free"`
-	Reclaimed uint64 `json:"reclaimed"`
-	Overhead  uint64 `json:"overhead"`
-	Pages     uint64 `json:"pages"`
-	PageSize  uint64 `json:"page_size"`
+	ID              uint   `json:"id"`
+	Name            string `json:"name"`
+	Size            uint64 `json:"size"`
+	Pages           uint64 `json:"pages"`
+	PageSize        uint64 `json:"page_size"`
+	Total           uint64 `json:"total"`
+	Used            uint64 `json:"used"`
+	Free            uint64 `json:"free"`
+	Trimmable       uint64 `json:"trimmable"`
+	FreeChunks      uint64 `json:"free_chunks"`
+	FreeFastbinBlks uint64 `json:"free_fastbin_blks"`
+	MaxTotalAlloc   uint64 `json:"max_total_allocated"`
 }
 
 // NodeCounterInfo contains node counters info.

--- a/plugins/telemetry/vppcalls/telemetry_stats.go
+++ b/plugins/telemetry/vppcalls/telemetry_stats.go
@@ -61,9 +61,7 @@ func (h *TelemetryStats) GetMemory(ctx context.Context) (*MemoryInfo, error) {
 	if h.telemetryAPI == nil {
 		return nil, fmt.Errorf("`GetMemory` unavailable, telemetry handler was not provided")
 	}
-	// todo failing, temporary disabled
-	// return h.telemetryAPI.GetMemory(ctx)
-	return nil, nil
+	return h.telemetryAPI.GetMemory(ctx)
 }
 
 // GetThreads retrieves `show threads` info.

--- a/plugins/telemetry/vppcalls/telemetry_stats.go
+++ b/plugins/telemetry/vppcalls/telemetry_stats.go
@@ -16,6 +16,7 @@ package vppcalls
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -26,6 +27,10 @@ import (
 // VPP stats API to retrieve the telemetry data.
 type TelemetryStats struct {
 	stats govppapi.StatsProvider
+	// telemetry API helps with reading Memory/Threads data
+	// (i.e. those who are not a part of the stats API or are not
+	// implemented yet)
+	telemetryAPI TelemetryVppAPI
 
 	sysStats  govppapi.SystemStats
 	ifStats   govppapi.InterfaceStats
@@ -34,9 +39,10 @@ type TelemetryStats struct {
 	bufStats  govppapi.BufferStats
 }
 
-func NewTelemetryVppStats(stats govppapi.StatsProvider) *TelemetryStats {
+func NewTelemetryVppStats(stats govppapi.StatsProvider, teleApi TelemetryVppAPI) *TelemetryStats {
 	return &TelemetryStats{
-		stats: stats,
+		stats:        stats,
+		telemetryAPI: teleApi,
 	}
 }
 
@@ -50,9 +56,23 @@ func (h *TelemetryStats) GetSystemStats(context.Context) (*govppapi.SystemStats,
 }
 
 // GetMemory retrieves `show memory` info.
+// todo switch to stats when memory data will be implemented
 func (h *TelemetryStats) GetMemory(ctx context.Context) (*MemoryInfo, error) {
-	// TODO: retrieve memory stats
+	if h.telemetryAPI == nil {
+		return nil, fmt.Errorf("`GetMemory` unavailable, telemetry handler was not provided")
+	}
+	// todo failing, temporary disabled
+	// return h.telemetryAPI.GetMemory(ctx)
 	return nil, nil
+}
+
+// GetThreads retrieves `show threads` info.
+// todo switch to stats when threads data will be available
+func (h *TelemetryStats) GetThreads(ctx context.Context) (*ThreadsInfo, error) {
+	if h.telemetryAPI == nil {
+		return nil, fmt.Errorf("`GetThreads` unavailable, telemetry handler was not provided")
+	}
+	return h.telemetryAPI.GetThreads(ctx)
 }
 
 // GetInterfaceStats retrieves interface stats.

--- a/plugins/telemetry/vppcalls/vpp1908/telemetry_vppcalls.go
+++ b/plugins/telemetry/vppcalls/vpp1908/telemetry_vppcalls.go
@@ -266,6 +266,29 @@ func (h *TelemetryHandler) GetBuffersInfo(ctx context.Context) (*vppcalls.Buffer
 	return info, nil
 }
 
+// GetThreads retrieves info about the VPP threads
+func (h *TelemetryHandler) GetThreads(ctx context.Context) (*vppcalls.ThreadsInfo, error) {
+	threads, err := h.vpe.GetThreads(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var items []vppcalls.ThreadsItem
+	for _, thread := range threads {
+		items = append(items, vppcalls.ThreadsItem{
+			Name:      thread.Name,
+			ID:        thread.ID,
+			Type:      thread.Type,
+			PID:       thread.PID,
+			CPUID:     thread.CPUID,
+			Core:      thread.Core,
+			CPUSocket: thread.CPUSocket,
+		})
+	}
+	return &vppcalls.ThreadsInfo{
+		Items: items,
+	}, err
+}
+
 func strToFloat64(s string) float64 {
 	// Replace 'k' (thousands) with 'e3' to make it parsable with strconv
 	s = strings.Replace(s, "k", "e3", 1)

--- a/plugins/telemetry/vppcalls/vpp1908/telemetry_vppcalls.go
+++ b/plugins/telemetry/vppcalls/vpp1908/telemetry_vppcalls.go
@@ -37,13 +37,14 @@ var (
 			`virtual memory start 0x[0-9a-f]+, size ([\dkmg\.]+), ([\dkmg\.]+) pages, page size ([\dkmg\.]+)\s+` +
 			`(?:page information not available.*\s+)*` +
 			`(?:(?:\s+(?:numa [\d]+|not mapped|unknown): [\dkmg\.]+ pages, [\dkmg\.]+\s+)*\s+)*` +
-			`\s+total: ([\dkmgKMG\.]+), used: ([\dkmgKMG\.]+), free: ([\dkmgKMG\.]+), trimmable: ([\dkmgKMG\.]+)`,
+			`\s+total: ([\dkmgKMG\.]+), used: ([\dkmgKMG\.]+), free: ([\dkmgKMG\.]+), trimmable: ([\dkmgKMG\.]+)\s+` +
+			`free chunks (\d+)\s+free fastbin blks (\d+)\s+max total allocated\s+([\dkmgKMG\.]+)`,
 	)
 )
 
 // GetMemory retrieves `show memory` info.
 func (h *TelemetryHandler) GetMemory(ctx context.Context) (*vppcalls.MemoryInfo, error) {
-	input, err := h.vpe.RunCli(context.TODO(), "show memory main-heap")
+	input, err := h.vpe.RunCli(context.TODO(), "show memory main-heap verbose")
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +58,7 @@ func (h *TelemetryHandler) GetMemory(ctx context.Context) (*vppcalls.MemoryInfo,
 	var threads []vppcalls.MemoryThread
 	for _, matches := range threadMatches {
 		fields := matches[1:]
-		if len(fields) != 9 {
+		if len(fields) != 12 {
 			return nil, fmt.Errorf("invalid memory data %v for thread: %q", fields, matches[0])
 		}
 		id, err := strconv.ParseUint(fields[0], 10, 64)
@@ -65,15 +66,18 @@ func (h *TelemetryHandler) GetMemory(ctx context.Context) (*vppcalls.MemoryInfo,
 			return nil, err
 		}
 		thread := &vppcalls.MemoryThread{
-			ID:        uint(id),
-			Name:      fields[1],
-			Size:      strToUint64(fields[2]),
-			Pages:     strToUint64(fields[3]),
-			PageSize:  strToUint64(fields[4]),
-			Total:     strToUint64(fields[5]),
-			Used:      strToUint64(fields[6]),
-			Free:      strToUint64(fields[7]),
-			Reclaimed: strToUint64(fields[8]),
+			ID:              uint(id),
+			Name:            fields[1],
+			Size:            strToUint64(fields[2]),
+			Pages:           strToUint64(fields[3]),
+			PageSize:        strToUint64(fields[4]),
+			Total:           strToUint64(fields[5]),
+			Used:            strToUint64(fields[6]),
+			Free:            strToUint64(fields[7]),
+			Trimmable:       strToUint64(fields[8]),
+			FreeChunks:      strToUint64(fields[9]),
+			FreeFastbinBlks: strToUint64(fields[10]),
+			MaxTotalAlloc:   strToUint64(fields[11]),
 		}
 		threads = append(threads, *thread)
 	}

--- a/plugins/telemetry/vppcalls/vpp1908/telemetry_vppcalls_test.go
+++ b/plugins/telemetry/vppcalls/vpp1908/telemetry_vppcalls_test.go
@@ -320,116 +320,133 @@ func TestGetMemory(t *testing.T) {
 		{
 			name: "single",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7f60d0ee7000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5677 pages, 22708k
-    not mapped: 256483 pages, 1025932k
+  virtual memory start 0x7fe5bedf9000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 6190 pages, 24760k
+    not mapped: 255970 pages, 1023880k
   total: 1.00G, used: 19.18M, free: 1004.88M, trimmable: 1004.87M
-no traced allocations
+    free chunks 432 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 1,
 			threadIdx:   0,
 			thread: vppcalls.MemoryThread{
-				ID:        0,
-				Name:      "vpp_main",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      19.18e6,
-				Total:     1e9,
-				Free:      1004.88e6,
-				Reclaimed: 1004.87e6,
+				ID:              0,
+				Name:            "vpp_main",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            19.18e6,
+				Total:           1e9,
+				Free:            1004.88e6,
+				Trimmable:       1004.87e6,
+				FreeChunks:      432,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1000.00e6,
 			},
 		},
 		{
 			name: "unknown",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7f60d0ee7000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5677 pages, 22708k
-    not mapped: 256483 pages, 1025932k
-    unknown: 368 pages, 1472k
-  total: 1.00G, used: 19.18M, free: 1004.88M, trimmable: 1004.87M
-no traced allocations
+  virtual memory start 0x7fe5bedf9000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 6190 pages, 24760k
+    not mapped: 255970 pages, 1023880k
+	unknown: 368 pages, 1472k
+  total: 1.00G, used: 26.97M, free: 997.09M, trimmable: 996.64M
+    free chunks 292 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 1,
 			threadIdx:   0,
 			thread: vppcalls.MemoryThread{
-				ID:        0,
-				Name:      "vpp_main",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      19.18e6,
-				Total:     1e9,
-				Free:      1004.88e6,
-				Reclaimed: 1004.87e6,
+				ID:              0,
+				Name:            "vpp_main",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            26.97e6,
+				Total:           1e9,
+				Free:            997.09e6,
+				Trimmable:       996.64e6,
+				FreeChunks:      292,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1000.00e6,
 			},
 		},
 		{
 			name: "3 workers",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
-
+  virtual memory start 0x7fe5bedf9000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 6190 pages, 24760k
+    not mapped: 255970 pages, 1023880k
+  total: 1.00G, used: 26.97M, free: 997.09M, trimmable: 996.64M
+    free chunks 292 free fastbin blks 0
+    max total allocated 1.00G
 
 Thread 1 vpp_wk_0
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
-
+  virtual memory start 0x7fe5bedf9000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 6190 pages, 24760k
+    not mapped: 255970 pages, 1023880k
+  total: 1.00G, used: 26.97M, free: 997.09M, trimmable: 996.64M
+    free chunks 292 free fastbin blks 0
+    max total allocated 1.00G
 
 Thread 2 vpp_wk_1
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
-
+  virtual memory start 0x7fe5bedf9000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 6190 pages, 24760k
+    not mapped: 255970 pages, 1023880k
+  total: 1.00G, used: 26.97M, free: 997.09M, trimmable: 996.64M
+    free chunks 293 free fastbin blks 0
+    max total allocated 1.00G
 
 Thread 3 vpp_wk_2
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
+  virtual memory start 0x7fe5bedf9000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 6190 pages, 24760k
+    not mapped: 255970 pages, 1023880k
+  total: 1.00G, used: 26.97M, free: 997.09M, trimmable: 996.64M
+    free chunks 293 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 4,
 			threadIdx:   1,
 			thread: vppcalls.MemoryThread{
-				ID:        1,
-				Name:      "vpp_wk_0",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      24.33e6,
-				Total:     1e9,
-				Free:      999.73e6,
-				Reclaimed: 996.12e6,
+				ID:              1,
+				Name:            "vpp_wk_0",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            26.97e6,
+				Total:           1e9,
+				Free:            997.09e6,
+				Trimmable:       996.64e6,
+				FreeChunks:      292,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1000.00e6,
 			},
 		},
 		{
 			name: "19.08 update",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7ff41b3ca000, size 1048640k, 262160 pages, page size 4k
+  virtual memory start 0x7fe5bedf9000, size 1048640k, 262160 pages, page size 4k
     page information not available (errno 1)
-  total: 1.00G, used: 19.81M, free: 1004.25M, trimmable: 1004.24M
+  total: 1.00G, used: 26.97M, free: 997.09M, trimmable: 996.64M
+    free chunks 292 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 1,
 			threadIdx:   0,
 			thread: vppcalls.MemoryThread{
-				ID:        0,
-				Name:      "vpp_main",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      19.81e6,
-				Total:     1e9,
-				Free:      1004.25e6,
-				Reclaimed: 1004.24e6,
+				ID:              0,
+				Name:            "vpp_main",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            26.97e6,
+				Total:           1e9,
+				Free:            997.09e6,
+				Trimmable:       996.64e6,
+				FreeChunks:      292,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1000.00e6,
 			},
 		},
 	}

--- a/plugins/telemetry/vppcalls/vpp2001/telemetry_vppcalls.go
+++ b/plugins/telemetry/vppcalls/vpp2001/telemetry_vppcalls.go
@@ -266,6 +266,29 @@ func (h *TelemetryHandler) GetBuffersInfo(ctx context.Context) (*vppcalls.Buffer
 	return info, nil
 }
 
+// GetThreads retrieves info about the VPP threads
+func (h *TelemetryHandler) GetThreads(ctx context.Context) (*vppcalls.ThreadsInfo, error) {
+	threads, err := h.vpe.GetThreads(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var items []vppcalls.ThreadsItem
+	for _, thread := range threads {
+		items = append(items, vppcalls.ThreadsItem{
+			Name:      thread.Name,
+			ID:        thread.ID,
+			Type:      thread.Type,
+			PID:       thread.PID,
+			CPUID:     thread.CPUID,
+			Core:      thread.Core,
+			CPUSocket: thread.CPUSocket,
+		})
+	}
+	return &vppcalls.ThreadsInfo{
+		Items: items,
+	}, err
+}
+
 func strToFloat64(s string) float64 {
 	// Replace 'k' (thousands) with 'e3' to make it parsable with strconv
 	s = strings.Replace(s, "k", "e3", 1)

--- a/plugins/telemetry/vppcalls/vpp2001/telemetry_vppcalls.go
+++ b/plugins/telemetry/vppcalls/vpp2001/telemetry_vppcalls.go
@@ -37,13 +37,14 @@ var (
 			`virtual memory start 0x[0-9a-f]+, size ([\dkmg\.]+), ([\dkmg\.]+) pages, page size ([\dkmg\.]+)\s+` +
 			`(?:page information not available.*\s+)*` +
 			`(?:(?:\s+(?:numa [\d]+|not mapped|unknown): [\dkmg\.]+ pages, [\dkmg\.]+\s+)*\s+)*` +
-			`\s+total: ([\dkmgKMG\.]+), used: ([\dkmgKMG\.]+), free: ([\dkmgKMG\.]+), trimmable: ([\dkmgKMG\.]+)`,
+			`\s+total: ([\dkmgKMG\.]+), used: ([\dkmgKMG\.]+), free: ([\dkmgKMG\.]+), trimmable: ([\dkmgKMG\.]+)\s+` +
+			`free chunks (\d+)\s+free fastbin blks (\d+)\s+max total allocated\s+([\dkmgKMG\.]+)`,
 	)
 )
 
 // GetMemory retrieves `show memory` info.
 func (h *TelemetryHandler) GetMemory(ctx context.Context) (*vppcalls.MemoryInfo, error) {
-	input, err := h.vpe.RunCli(context.TODO(), "show memory main-heap")
+	input, err := h.vpe.RunCli(context.TODO(), "show memory main-heap verbose")
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +58,7 @@ func (h *TelemetryHandler) GetMemory(ctx context.Context) (*vppcalls.MemoryInfo,
 	var threads []vppcalls.MemoryThread
 	for _, matches := range threadMatches {
 		fields := matches[1:]
-		if len(fields) != 9 {
+		if len(fields) != 12 {
 			return nil, fmt.Errorf("invalid memory data %v for thread: %q", fields, matches[0])
 		}
 		id, err := strconv.ParseUint(fields[0], 10, 64)
@@ -65,15 +66,18 @@ func (h *TelemetryHandler) GetMemory(ctx context.Context) (*vppcalls.MemoryInfo,
 			return nil, err
 		}
 		thread := &vppcalls.MemoryThread{
-			ID:        uint(id),
-			Name:      fields[1],
-			Size:      strToUint64(fields[2]),
-			Pages:     strToUint64(fields[3]),
-			PageSize:  strToUint64(fields[4]),
-			Total:     strToUint64(fields[5]),
-			Used:      strToUint64(fields[6]),
-			Free:      strToUint64(fields[7]),
-			Reclaimed: strToUint64(fields[8]),
+			ID:              uint(id),
+			Name:            fields[1],
+			Size:            strToUint64(fields[2]),
+			Pages:           strToUint64(fields[3]),
+			PageSize:        strToUint64(fields[4]),
+			Total:           strToUint64(fields[5]),
+			Used:            strToUint64(fields[6]),
+			Free:            strToUint64(fields[7]),
+			Trimmable:       strToUint64(fields[8]),
+			FreeChunks:      strToUint64(fields[9]),
+			FreeFastbinBlks: strToUint64(fields[10]),
+			MaxTotalAlloc:   strToUint64(fields[11]),
 		}
 		threads = append(threads, *thread)
 	}

--- a/plugins/telemetry/vppcalls/vpp2001/telemetry_vppcalls_test.go
+++ b/plugins/telemetry/vppcalls/vpp2001/telemetry_vppcalls_test.go
@@ -320,116 +320,133 @@ func TestGetMemory(t *testing.T) {
 		{
 			name: "single",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7f60d0ee7000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5677 pages, 22708k
-    not mapped: 256483 pages, 1025932k
-  total: 1.00G, used: 19.18M, free: 1004.88M, trimmable: 1004.87M
-no traced allocations
+  virtual memory start 0x7f435fa4a000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 10084 pages, 40336k
+    not mapped: 252076 pages, 1008304k
+  total: 1.00G, used: 31.56M, free: 992.50M, trimmable: 991.39M
+    free chunks 285 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 1,
 			threadIdx:   0,
 			thread: vppcalls.MemoryThread{
-				ID:        0,
-				Name:      "vpp_main",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      19.18e6,
-				Total:     1e9,
-				Free:      1004.88e6,
-				Reclaimed: 1004.87e6,
+				ID:              0,
+				Name:            "vpp_main",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            31.56e6,
+				Total:           1.00e9,
+				Free:            992.50e6,
+				Trimmable:       991.39e6,
+				FreeChunks:      285,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1e9,
 			},
 		},
 		{
 			name: "unknown",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7f60d0ee7000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5677 pages, 22708k
-    not mapped: 256483 pages, 1025932k
+  virtual memory start 0x7f435fa4a000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 10084 pages, 40336k
+    not mapped: 252076 pages, 1008304k
     unknown: 368 pages, 1472k
-  total: 1.00G, used: 19.18M, free: 1004.88M, trimmable: 1004.87M
-no traced allocations
+  total: 1.00G, used: 31.56M, free: 992.50M, trimmable: 991.39M
+    free chunks 285 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 1,
 			threadIdx:   0,
 			thread: vppcalls.MemoryThread{
-				ID:        0,
-				Name:      "vpp_main",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      19.18e6,
-				Total:     1e9,
-				Free:      1004.88e6,
-				Reclaimed: 1004.87e6,
+				ID:              0,
+				Name:            "vpp_main",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            31.56e6,
+				Total:           1.00e9,
+				Free:            992.50e6,
+				Trimmable:       991.39e6,
+				FreeChunks:      285,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1e9,
 			},
 		},
 		{
 			name: "3 workers",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
-
+  virtual memory start 0x7f435fa4a000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 10084 pages, 40336k
+    not mapped: 252076 pages, 1008304k
+  total: 1.00G, used: 31.56M, free: 992.50M, trimmable: 991.39M
+    free chunks 285 free fastbin blks 0
+    max total allocated 1.00G
 
 Thread 1 vpp_wk_0
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
-
+  virtual memory start 0x7f435fa4a000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 10084 pages, 40336k
+    not mapped: 252076 pages, 1008304k
+  total: 1.00G, used: 31.56M, free: 992.50M, trimmable: 991.39M
+    free chunks 284 free fastbin blks 0
+    max total allocated 1.00G
 
 Thread 2 vpp_wk_1
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
-
+  virtual memory start 0x7f435fa4a000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 10084 pages, 40336k
+    not mapped: 252076 pages, 1008304k
+  total: 1.00G, used: 31.56M, free: 992.50M, trimmable: 991.39M
+    free chunks 285 free fastbin blks 0
+    max total allocated 1.00G
 
 Thread 3 vpp_wk_2
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
+  virtual memory start 0x7f435fa4a000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 10084 pages, 40336k
+    not mapped: 252076 pages, 1008304k
+  total: 1.00G, used: 31.56M, free: 992.50M, trimmable: 991.39M
+    free chunks 285 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 4,
 			threadIdx:   1,
 			thread: vppcalls.MemoryThread{
-				ID:        1,
-				Name:      "vpp_wk_0",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      24.33e6,
-				Total:     1e9,
-				Free:      999.73e6,
-				Reclaimed: 996.12e6,
+				ID:              1,
+				Name:            "vpp_wk_0",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            31.56e6,
+				Total:           1.00e9,
+				Free:            992.50e6,
+				Trimmable:       991.39e6,
+				FreeChunks:      284,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1e9,
 			},
 		},
 		{
 			name: "19.08 update",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7ff41b3ca000, size 1048640k, 262160 pages, page size 4k
+  virtual memory start 0x7f435fa4a000, size 1048640k, 262160 pages, page size 4k
     page information not available (errno 1)
-  total: 1.00G, used: 19.81M, free: 1004.25M, trimmable: 1004.24M
+  total: 1.00G, used: 31.56M, free: 992.50M, trimmable: 991.39M
+    free chunks 285 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 1,
 			threadIdx:   0,
 			thread: vppcalls.MemoryThread{
-				ID:        0,
-				Name:      "vpp_main",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      19.81e6,
-				Total:     1e9,
-				Free:      1004.25e6,
-				Reclaimed: 1004.24e6,
+				ID:              0,
+				Name:            "vpp_main",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            31.56e6,
+				Total:           1e9,
+				Free:            992.50e6,
+				Trimmable:       991.39e6,
+				FreeChunks:      285,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1e9,
 			},
 		},
 	}

--- a/plugins/telemetry/vppcalls/vpp2005/telemetry_vppcalls.go
+++ b/plugins/telemetry/vppcalls/vpp2005/telemetry_vppcalls.go
@@ -266,6 +266,29 @@ func (h *TelemetryHandler) GetBuffersInfo(ctx context.Context) (*vppcalls.Buffer
 	return info, nil
 }
 
+// GetThreads retrieves info about the VPP threads
+func (h *TelemetryHandler) GetThreads(ctx context.Context) (*vppcalls.ThreadsInfo, error) {
+	threads, err := h.vpe.GetThreads(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var items []vppcalls.ThreadsItem
+	for _, thread := range threads {
+		items = append(items, vppcalls.ThreadsItem{
+			Name:      thread.Name,
+			ID:        thread.ID,
+			Type:      thread.Type,
+			PID:       thread.PID,
+			CPUID:     thread.CPUID,
+			Core:      thread.Core,
+			CPUSocket: thread.CPUSocket,
+		})
+	}
+	return &vppcalls.ThreadsInfo{
+		Items: items,
+	}, err
+}
+
 func strToFloat64(s string) float64 {
 	// Replace 'k' (thousands) with 'e3' to make it parsable with strconv
 	s = strings.Replace(s, "k", "e3", 1)

--- a/plugins/telemetry/vppcalls/vpp2005/telemetry_vppcalls.go
+++ b/plugins/telemetry/vppcalls/vpp2005/telemetry_vppcalls.go
@@ -37,13 +37,14 @@ var (
 			`virtual memory start 0x[0-9a-f]+, size ([\dkmg\.]+), ([\dkmg\.]+) pages, page size ([\dkmg\.]+)\s+` +
 			`(?:page information not available.*\s+)*` +
 			`(?:(?:\s+(?:numa [\d]+|not mapped|unknown): [\dkmg\.]+ pages, [\dkmg\.]+\s+)*\s+)*` +
-			`\s+total: ([\dkmgKMG\.]+), used: ([\dkmgKMG\.]+), free: ([\dkmgKMG\.]+), trimmable: ([\dkmgKMG\.]+)`,
+			`\s+total: ([\dkmgKMG\.]+), used: ([\dkmgKMG\.]+), free: ([\dkmgKMG\.]+), trimmable: ([\dkmgKMG\.]+)\s+` +
+			`free chunks (\d+)\s+free fastbin blks (\d+)\s+max total allocated\s+([\dkmgKMG\.]+)`,
 	)
 )
 
 // GetMemory retrieves `show memory` info.
 func (h *TelemetryHandler) GetMemory(ctx context.Context) (*vppcalls.MemoryInfo, error) {
-	input, err := h.vpe.RunCli(context.TODO(), "show memory main-heap")
+	input, err := h.vpe.RunCli(context.TODO(), "show memory main-heap verbose")
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +58,7 @@ func (h *TelemetryHandler) GetMemory(ctx context.Context) (*vppcalls.MemoryInfo,
 	var threads []vppcalls.MemoryThread
 	for _, matches := range threadMatches {
 		fields := matches[1:]
-		if len(fields) != 9 {
+		if len(fields) != 12 {
 			return nil, fmt.Errorf("invalid memory data %v for thread: %q", fields, matches[0])
 		}
 		id, err := strconv.ParseUint(fields[0], 10, 64)
@@ -65,15 +66,18 @@ func (h *TelemetryHandler) GetMemory(ctx context.Context) (*vppcalls.MemoryInfo,
 			return nil, err
 		}
 		thread := &vppcalls.MemoryThread{
-			ID:        uint(id),
-			Name:      fields[1],
-			Size:      strToUint64(fields[2]),
-			Pages:     strToUint64(fields[3]),
-			PageSize:  strToUint64(fields[4]),
-			Total:     strToUint64(fields[5]),
-			Used:      strToUint64(fields[6]),
-			Free:      strToUint64(fields[7]),
-			Reclaimed: strToUint64(fields[8]),
+			ID:              uint(id),
+			Name:            fields[1],
+			Size:            strToUint64(fields[2]),
+			Pages:           strToUint64(fields[3]),
+			PageSize:        strToUint64(fields[4]),
+			Total:           strToUint64(fields[5]),
+			Used:            strToUint64(fields[6]),
+			Free:            strToUint64(fields[7]),
+			Trimmable:       strToUint64(fields[8]),
+			FreeChunks:      strToUint64(fields[9]),
+			FreeFastbinBlks: strToUint64(fields[10]),
+			MaxTotalAlloc:   strToUint64(fields[11]),
 		}
 		threads = append(threads, *thread)
 	}

--- a/plugins/telemetry/vppcalls/vpp2005/telemetry_vppcalls_test.go
+++ b/plugins/telemetry/vppcalls/vpp2005/telemetry_vppcalls_test.go
@@ -320,116 +320,133 @@ func TestGetMemory(t *testing.T) {
 		{
 			name: "single",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7f60d0ee7000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5677 pages, 22708k
-    not mapped: 256483 pages, 1025932k
-  total: 1.00G, used: 19.18M, free: 1004.88M, trimmable: 1004.87M
-no traced allocations
+  virtual memory start 0x7fd26d831000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 9732 pages, 38928k
+    not mapped: 252428 pages, 1009712k
+  total: 1.00G, used: 40.63M, free: 983.44M, trimmable: 982.83M
+    free chunks 333 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 1,
 			threadIdx:   0,
 			thread: vppcalls.MemoryThread{
-				ID:        0,
-				Name:      "vpp_main",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      19.18e6,
-				Total:     1e9,
-				Free:      1004.88e6,
-				Reclaimed: 1004.87e6,
+				ID:              0,
+				Name:            "vpp_main",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            40.63e6,
+				Total:           1e9,
+				Free:            983.44e6,
+				Trimmable:       982.83e6,
+				FreeChunks:      333,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1e9,
 			},
 		},
 		{
 			name: "unknown",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7f60d0ee7000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5677 pages, 22708k
-    not mapped: 256483 pages, 1025932k
-    unknown: 368 pages, 1472k
-  total: 1.00G, used: 19.18M, free: 1004.88M, trimmable: 1004.87M
-no traced allocations
+  virtual memory start 0x7fd26d831000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 9732 pages, 38928k
+    not mapped: 252428 pages, 1009712k
+	unknown: 368 pages, 1472k
+  total: 1.00G, used: 40.63M, free: 983.44M, trimmable: 982.83M
+    free chunks 333 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 1,
 			threadIdx:   0,
 			thread: vppcalls.MemoryThread{
-				ID:        0,
-				Name:      "vpp_main",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      19.18e6,
-				Total:     1e9,
-				Free:      1004.88e6,
-				Reclaimed: 1004.87e6,
+				ID:              0,
+				Name:            "vpp_main",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            40.63e6,
+				Total:           1e9,
+				Free:            983.44e6,
+				Trimmable:       982.83e6,
+				FreeChunks:      333,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1e9,
 			},
 		},
 		{
 			name: "3 workers",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
-
+  virtual memory start 0x7fd26d831000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 9732 pages, 38928k
+    not mapped: 252428 pages, 1009712k
+  total: 1.00G, used: 40.63M, free: 983.44M, trimmable: 982.83M
+    free chunks 333 free fastbin blks 0
+    max total allocated 1.00G
 
 Thread 1 vpp_wk_0
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
-
+  virtual memory start 0x7fd26d831000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 9732 pages, 38928k
+    not mapped: 252428 pages, 1009712k
+  total: 1.00G, used: 40.63M, free: 983.44M, trimmable: 982.83M
+    free chunks 335 free fastbin blks 0
+    max total allocated 1.00G
 
 Thread 2 vpp_wk_1
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
-
+  virtual memory start 0x7fd26d831000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 9732 pages, 38928k
+    not mapped: 252428 pages, 1009712k
+  total: 1.00G, used: 40.63M, free: 983.43M, trimmable: 982.83M
+    free chunks 334 free fastbin blks 0
+    max total allocated 1.00G
 
 Thread 3 vpp_wk_2
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
+  virtual memory start 0x7fd26d831000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 9732 pages, 38928k
+    not mapped: 252428 pages, 1009712k
+  total: 1.00G, used: 40.63M, free: 983.43M, trimmable: 982.83M
+    free chunks 334 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 4,
 			threadIdx:   1,
 			thread: vppcalls.MemoryThread{
-				ID:        1,
-				Name:      "vpp_wk_0",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      24.33e6,
-				Total:     1e9,
-				Free:      999.73e6,
-				Reclaimed: 996.12e6,
+				ID:              1,
+				Name:            "vpp_wk_0",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            40.63e6,
+				Total:           1e9,
+				Free:            983.44e6,
+				Trimmable:       982.83e6,
+				FreeChunks:      335,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1e9,
 			},
 		},
 		{
 			name: "19.08 update",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7ff41b3ca000, size 1048640k, 262160 pages, page size 4k
+  virtual memory start 0x7fd26d831000, size 1048640k, 262160 pages, page size 4k
     page information not available (errno 1)
-  total: 1.00G, used: 19.81M, free: 1004.25M, trimmable: 1004.24M
+  total: 1.00G, used: 40.63M, free: 983.44M, trimmable: 982.83M
+    free chunks 333 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 1,
 			threadIdx:   0,
 			thread: vppcalls.MemoryThread{
-				ID:        0,
-				Name:      "vpp_main",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      19.81e6,
-				Total:     1e9,
-				Free:      1004.25e6,
-				Reclaimed: 1004.24e6,
+				ID:              0,
+				Name:            "vpp_main",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            40.63e6,
+				Total:           1e9,
+				Free:            983.44e6,
+				Trimmable:       982.83e6,
+				FreeChunks:      333,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1e9,
 			},
 		},
 	}

--- a/plugins/telemetry/vppcalls/vpp2009/telemetry_vppcalls.go
+++ b/plugins/telemetry/vppcalls/vpp2009/telemetry_vppcalls.go
@@ -266,6 +266,30 @@ func (h *TelemetryHandler) GetBuffersInfo(ctx context.Context) (*vppcalls.Buffer
 	return info, nil
 }
 
+// GetThreads retrieves info about the VPP threads
+func (h *TelemetryHandler) GetThreads(ctx context.Context) (*vppcalls.ThreadsInfo, error) {
+	threads, err := h.vpe.GetThreads(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var items []vppcalls.ThreadsItem
+	for _, thread := range threads {
+		fmt.Printf("thread: %v", thread)
+		items = append(items, vppcalls.ThreadsItem{
+			Name:      thread.Name,
+			ID:        thread.ID,
+			Type:      thread.Type,
+			PID:       thread.PID,
+			CPUID:     thread.CPUID,
+			Core:      thread.Core,
+			CPUSocket: thread.CPUSocket,
+		})
+	}
+	return &vppcalls.ThreadsInfo{
+		Items: items,
+	}, err
+}
+
 func strToFloat64(s string) float64 {
 	// Replace 'k' (thousands) with 'e3' to make it parsable with strconv
 	s = strings.Replace(s, "k", "e3", 1)

--- a/plugins/telemetry/vppcalls/vpp2009/telemetry_vppcalls.go
+++ b/plugins/telemetry/vppcalls/vpp2009/telemetry_vppcalls.go
@@ -37,13 +37,14 @@ var (
 			`virtual memory start 0x[0-9a-f]+, size ([\dkmg\.]+), ([\dkmg\.]+) pages, page size ([\dkmg\.]+)\s+` +
 			`(?:page information not available.*\s+)*` +
 			`(?:(?:\s+(?:numa [\d]+|not mapped|unknown): [\dkmg\.]+ pages, [\dkmg\.]+\s+)*\s+)*` +
-			`\s+total: ([\dkmgKMG\.]+), used: ([\dkmgKMG\.]+), free: ([\dkmgKMG\.]+), trimmable: ([\dkmgKMG\.]+)`,
+			`\s+total: ([\dkmgKMG\.]+), used: ([\dkmgKMG\.]+), free: ([\dkmgKMG\.]+), trimmable: ([\dkmgKMG\.]+)\s+` +
+			`free chunks (\d+)\s+free fastbin blks (\d+)\s+max total allocated\s+([\dkmgKMG\.]+)`,
 	)
 )
 
 // GetMemory retrieves `show memory` info.
 func (h *TelemetryHandler) GetMemory(ctx context.Context) (*vppcalls.MemoryInfo, error) {
-	input, err := h.vpe.RunCli(context.TODO(), "show memory main-heap")
+	input, err := h.vpe.RunCli(context.TODO(), "show memory main-heap verbose")
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +58,7 @@ func (h *TelemetryHandler) GetMemory(ctx context.Context) (*vppcalls.MemoryInfo,
 	var threads []vppcalls.MemoryThread
 	for _, matches := range threadMatches {
 		fields := matches[1:]
-		if len(fields) != 9 {
+		if len(fields) != 12 {
 			return nil, fmt.Errorf("invalid memory data %v for thread: %q", fields, matches[0])
 		}
 		id, err := strconv.ParseUint(fields[0], 10, 64)
@@ -65,15 +66,18 @@ func (h *TelemetryHandler) GetMemory(ctx context.Context) (*vppcalls.MemoryInfo,
 			return nil, err
 		}
 		thread := &vppcalls.MemoryThread{
-			ID:        uint(id),
-			Name:      fields[1],
-			Size:      strToUint64(fields[2]),
-			Pages:     strToUint64(fields[3]),
-			PageSize:  strToUint64(fields[4]),
-			Total:     strToUint64(fields[5]),
-			Used:      strToUint64(fields[6]),
-			Free:      strToUint64(fields[7]),
-			Reclaimed: strToUint64(fields[8]),
+			ID:              uint(id),
+			Name:            fields[1],
+			Size:            strToUint64(fields[2]),
+			Pages:           strToUint64(fields[3]),
+			PageSize:        strToUint64(fields[4]),
+			Total:           strToUint64(fields[5]),
+			Used:            strToUint64(fields[6]),
+			Free:            strToUint64(fields[7]),
+			Trimmable:       strToUint64(fields[8]),
+			FreeChunks:      strToUint64(fields[9]),
+			FreeFastbinBlks: strToUint64(fields[10]),
+			MaxTotalAlloc:   strToUint64(fields[11]),
 		}
 		threads = append(threads, *thread)
 	}

--- a/plugins/telemetry/vppcalls/vpp2009/telemetry_vppcalls_test.go
+++ b/plugins/telemetry/vppcalls/vpp2009/telemetry_vppcalls_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"go.ligato.io/vpp-agent/v3/plugins/telemetry/vppcalls"
-	vpp2009 "go.ligato.io/vpp-agent/v3/plugins/telemetry/vppcalls/vpp2009"
+	"go.ligato.io/vpp-agent/v3/plugins/telemetry/vppcalls/vpp2009"
 	"go.ligato.io/vpp-agent/v3/plugins/vpp/binapi/vpp2009/vpe"
 	"go.ligato.io/vpp-agent/v3/plugins/vpp/vppmock"
 )
@@ -320,116 +320,133 @@ func TestGetMemory(t *testing.T) {
 		{
 			name: "single",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7f60d0ee7000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5677 pages, 22708k
-    not mapped: 256483 pages, 1025932k
-  total: 1.00G, used: 19.18M, free: 1004.88M, trimmable: 1004.87M
-no traced allocations
+  virtual memory start 0x7fc363c20000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 13937 pages, 55748k
+    not mapped: 248223 pages, 992892k
+  total: 1.00G, used: 56.78M, free: 967.29M, trimmable: 966.64M
+    free chunks 337 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 1,
 			threadIdx:   0,
 			thread: vppcalls.MemoryThread{
-				ID:        0,
-				Name:      "vpp_main",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      19.18e6,
-				Total:     1e9,
-				Free:      1004.88e6,
-				Reclaimed: 1004.87e6,
+				ID:              0,
+				Name:            "vpp_main",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            56.78e6,
+				Total:           1e9,
+				Free:            967.29e6,
+				Trimmable:       966.64e6,
+				FreeChunks:      337,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1e9,
 			},
 		},
 		{
 			name: "unknown",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7f60d0ee7000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5677 pages, 22708k
-    not mapped: 256483 pages, 1025932k
+  virtual memory start 0x7fc363c20000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 13937 pages, 55748k
+    not mapped: 248223 pages, 992892k
     unknown: 368 pages, 1472k
-  total: 1.00G, used: 19.18M, free: 1004.88M, trimmable: 1004.87M
-no traced allocations
+  total: 1.00G, used: 56.78M, free: 967.29M, trimmable: 966.64M
+    free chunks 337 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 1,
 			threadIdx:   0,
 			thread: vppcalls.MemoryThread{
-				ID:        0,
-				Name:      "vpp_main",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      19.18e6,
-				Total:     1e9,
-				Free:      1004.88e6,
-				Reclaimed: 1004.87e6,
+				ID:              0,
+				Name:            "vpp_main",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            56.78e6,
+				Total:           1e9,
+				Free:            967.29e6,
+				Trimmable:       966.64e6,
+				FreeChunks:      337,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1e9,
 			},
 		},
 		{
 			name: "3 workers",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
-
+  virtual memory start 0x7fc363c20000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 13937 pages, 55748k
+    not mapped: 248223 pages, 992892k
+  total: 1.00G, used: 56.78M, free: 967.29M, trimmable: 966.64M
+    free chunks 337 free fastbin blks 0
+    max total allocated 1.00G
 
 Thread 1 vpp_wk_0
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
-
+  virtual memory start 0x7fc363c20000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 13937 pages, 55748k
+    not mapped: 248223 pages, 992892k
+  total: 1.00G, used: 56.78M, free: 967.29M, trimmable: 966.64M
+    free chunks 339 free fastbin blks 0
+    max total allocated 1.00G
 
 Thread 2 vpp_wk_1
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
-
+  virtual memory start 0x7fc363c20000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 13937 pages, 55748k
+    not mapped: 248223 pages, 992892k
+  total: 1.00G, used: 56.78M, free: 967.28M, trimmable: 966.64M
+    free chunks 338 free fastbin blks 0
+    max total allocated 1.00G
 
 Thread 3 vpp_wk_2
-  virtual memory start 0x7f1fb0e0f000, size 1048640k, 262160 pages, page size 4k
-    numa 0: 5587 pages, 22348k
-    not mapped: 256573 pages, 1026292k
-  total: 1.00G, used: 24.33M, free: 999.73M, trimmable: 996.12M
-no traced allocations
+  virtual memory start 0x7fc363c20000, size 1048640k, 262160 pages, page size 4k
+    numa 0: 13937 pages, 55748k
+    not mapped: 248223 pages, 992892k
+  total: 1.00G, used: 56.78M, free: 967.28M, trimmable: 966.64M
+    free chunks 338 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 4,
 			threadIdx:   1,
 			thread: vppcalls.MemoryThread{
-				ID:        1,
-				Name:      "vpp_wk_0",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      24.33e6,
-				Total:     1e9,
-				Free:      999.73e6,
-				Reclaimed: 996.12e6,
+				ID:              1,
+				Name:            "vpp_wk_0",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            56.78e6,
+				Total:           1e9,
+				Free:            967.29e6,
+				Trimmable:       966.64e6,
+				FreeChunks:      339,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1e9,
 			},
 		},
 		{
 			name: "19.08 update",
 			reply: `Thread 0 vpp_main
-  virtual memory start 0x7ff41b3ca000, size 1048640k, 262160 pages, page size 4k
+  virtual memory start 0x7fc363c20000, size 1048640k, 262160 pages, page size 4k
     page information not available (errno 1)
-  total: 1.00G, used: 19.81M, free: 1004.25M, trimmable: 1004.24M
+  total: 1.00G, used: 56.78M, free: 967.29M, trimmable: 966.64M
+    free chunks 337 free fastbin blks 0
+    max total allocated 1.00G
 `,
 			threadCount: 1,
 			threadIdx:   0,
 			thread: vppcalls.MemoryThread{
-				ID:        0,
-				Name:      "vpp_main",
-				Size:      1048.64e6,
-				Pages:     262160,
-				PageSize:  4000,
-				Used:      19.81e6,
-				Total:     1e9,
-				Free:      1004.25e6,
-				Reclaimed: 1004.24e6,
+				ID:              0,
+				Name:            "vpp_main",
+				Size:            1048.64e6,
+				Pages:           262160,
+				PageSize:        4000,
+				Used:            56.78e6,
+				Total:           1e9,
+				Free:            967.29e6,
+				Trimmable:       966.64e6,
+				FreeChunks:      337,
+				FreeFastbinBlks: 0,
+				MaxTotalAlloc:   1e9,
 			},
 		},
 	}


### PR DESCRIPTION
* Added 'GetThreads' for all supported VPP versions in
  the telemetry vppcalls. Data are read using the
  binary API (via govppmux)
* VPP stats API telemetry handler also has CLI/binapi
  part in order to read data not yet available in stats
* Added simple stats example reading VPP stats via the
  telemetry plugin
* Fixed 'GetMemory' regex + added 'verbose' output to 
  match VPPTop requirements

TODO:
* ~Fix 'GetMemory' and add it to the example~

Signed-off-by: Vladimir Lavor <vlavor@cisco.com>