### PR TITLE
feat: proxied models (remotely learned models used in DefaultRegistry)

### DIFF
--- a/pkg/models/api.go
+++ b/pkg/models/api.go
@@ -47,9 +47,11 @@ type Registry interface {
 	// RegisteredModels returns all registered modules.
 	RegisteredModels() []KnownModel
 
-	// Register registers a protobuf message (for LocalRegistry)/ModelInfo
-	// (for remote registry) with given model specification. If spec.Class
-	// is unset empty it defaults to 'config'.
+	// Register registers either a protobuf message known at compile-time together
+	// with the given model specification (for LocalRegistry),
+	// or a remote model represented by an instance of ModelInfo obtained via KnownModels RPC from MetaService
+	// (for RemoteRegistry or also for LocalRegistry but most likely just proxied to a remote agent).
+	// If spec.Class is unset, then it defaults to 'config'.
 	Register(x interface{}, spec Spec, opts ...ModelOption) (KnownModel, error)
 }
 

--- a/pkg/models/item.go
+++ b/pkg/models/item.go
@@ -75,17 +75,17 @@ func UnmarshalItem(item *api.Item) (proto.Message, error) {
 // UnmarshalItemUsingModelRegistry is helper function for unmarshalling items (using given model registry)
 func UnmarshalItemUsingModelRegistry(item *api.Item, modelRegistry Registry) (proto.Message, error) {
 	// check existence of known model
-	_, err := GetModelFromModelRegistryForItem(item, modelRegistry)
+	model, err := GetModelFromModelRegistryForItem(item, modelRegistry)
 	if err != nil {
 		return nil, err
 	}
 
 	// unmarshal item's inner data
-	// (we must distinguish between model registries due to different go types produced by using different
-	// model registry. The LocalRegistry use cases need go types as generated from models, but
-	// the RemoteRegistry can't produce such go typed instances (we know the name of go type, but can't
-	// produce it from remote information) so dynamic proto message must be enough (*dynamicpb.Message))
-	if _, ok := modelRegistry.(*LocalRegistry); ok {
+	// We must distinguish between locally and remotely known models with respect to the underlying go type.
+	// LocallyKnownModel is used for proto message with go type generated from imported proto file and known
+	// at compile time, while RemotelyKnownModel can't produce such go typed instances (we know the name of go type,
+	// but can't produce it from remote information) so dynamic proto message must be enough (*dynamicpb.Message))
+	if _, ok := model.(*LocallyKnownModel); ok {
 		return unmarshalItemDataAnyOfLocalModel(item.GetData().GetAny())
 	}
 	return unmarshalItemDataAnyOfRemoteModel(item.GetData().GetAny(), modelRegistry.MessageTypeRegistry())


### PR DESCRIPTION
This small PR allows to register models learned remotely (i.e. over gRCP using the meta service) into the LocalRegistry.

Why is this useful?
This change can be used as a building block for integration of multiple (distributed) CNFs (pairs of agent + some data-plane component) into one appliance with a single API endpoint. A central agent can dynamically discover all CNFs, learn their models over gRPC and generate kv descriptors for them that would mostly just forward CRUD operations via remoteclient.
So basically the change allows the following configuration sequence:
```
agentctl/etcd/... -> [proxy agent(s) ->]  target agent
```

To proxy a given model one would write something like:
```
client, err = remoteclient.NewClientGRPC(grpcConn, remoteclient.UseRemoteRegistry("config"))
models, err := swMod.cfgClient.KnownModels("config")
for _, model := range models {
    if !proxyThisModel {
      continue
    }
    spec := models.ToSpec(cnfModel.info.Spec)
    _, err := models.DefaultRegistry.Register(cnfModel.info, spec)
    // build descriptor for it, etc...
}
```

Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>