### PR TITLE
feat: Added possibility to setup NB configuration from file at VPP-Agent start

### DIFF
--- a/client/local_client.go
+++ b/client/local_client.go
@@ -23,7 +23,7 @@ import (
 	"go.ligato.io/cn-infra/v2/db/keyval"
 
 	"go.ligato.io/vpp-agent/v3/pkg/models"
-	orch "go.ligato.io/vpp-agent/v3/plugins/orchestrator"
+	"go.ligato.io/vpp-agent/v3/plugins/orchestrator/contextdecorator"
 	"go.ligato.io/vpp-agent/v3/proto/ligato/generic"
 )
 
@@ -64,7 +64,7 @@ func (c *client) ResyncConfig(items ...proto.Message) error {
 	}
 
 	ctx := context.Background()
-	ctx = orch.DataSrcContext(ctx, "localclient")
+	ctx = contextdecorator.DataSrcContext(ctx, "localclient")
 	return txn.Commit(ctx)
 }
 
@@ -121,9 +121,9 @@ func (r *changeRequest) Send(ctx context.Context) error {
 	if r.err != nil {
 		return r.err
 	}
-	_, withDataSrc := orch.DataSrcFromContext(ctx)
+	_, withDataSrc := contextdecorator.DataSrcFromContext(ctx)
 	if !withDataSrc {
-		ctx = orch.DataSrcContext(ctx, "localclient")
+		ctx = contextdecorator.DataSrcContext(ctx, "localclient")
 	}
 	return r.txn.Commit(ctx)
 }

--- a/clientv2/vpp/dbadapter/data_change_db.go
+++ b/clientv2/vpp/dbadapter/data_change_db.go
@@ -18,11 +18,10 @@ import (
 	"context"
 
 	"go.ligato.io/cn-infra/v2/db/keyval"
-
 	"go.ligato.io/vpp-agent/v3/pkg/models"
+	"go.ligato.io/vpp-agent/v3/plugins/orchestrator/contextdecorator"
 
 	vppclient "go.ligato.io/vpp-agent/v3/clientv2/vpp"
-	orch "go.ligato.io/vpp-agent/v3/plugins/orchestrator"
 	abf "go.ligato.io/vpp-agent/v3/proto/ligato/vpp/abf"
 	acl "go.ligato.io/vpp-agent/v3/proto/ligato/vpp/acl"
 	intf "go.ligato.io/vpp-agent/v3/proto/ligato/vpp/interfaces"
@@ -73,7 +72,7 @@ func (dsl *DataChangeDSL) Delete() vppclient.DeleteDSL {
 // Send propagates requested changes to the plugins.
 func (dsl *DataChangeDSL) Send() vppclient.Reply {
 	ctx := context.Background()
-	ctx = orch.DataSrcContext(ctx, "localclient")
+	ctx = contextdecorator.DataSrcContext(ctx, "localclient")
 	err := dsl.txn.Commit(ctx)
 	return &Reply{err}
 }

--- a/clientv2/vpp/dbadapter/data_resync_db.go
+++ b/clientv2/vpp/dbadapter/data_resync_db.go
@@ -18,11 +18,10 @@ import (
 	"context"
 
 	"go.ligato.io/cn-infra/v2/db/keyval"
-
 	"go.ligato.io/vpp-agent/v3/pkg/models"
+	"go.ligato.io/vpp-agent/v3/plugins/orchestrator/contextdecorator"
 
 	vppclient "go.ligato.io/vpp-agent/v3/clientv2/vpp"
-	orch "go.ligato.io/vpp-agent/v3/plugins/orchestrator"
 	abf "go.ligato.io/vpp-agent/v3/proto/ligato/vpp/abf"
 	acl "go.ligato.io/vpp-agent/v3/proto/ligato/vpp/acl"
 	intf "go.ligato.io/vpp-agent/v3/proto/ligato/vpp/interfaces"
@@ -367,7 +366,7 @@ func (dsl *DataResyncDSL) Send() vppclient.Reply {
 	}
 
 	ctx := context.Background()
-	ctx = orch.DataSrcContext(ctx, "localclient")
+	ctx = contextdecorator.DataSrcContext(ctx, "localclient")
 	err := dsl.txn.Commit(ctx)
 
 	return &Reply{err: err}

--- a/cmd/vpp-agent/app/vpp_agent.go
+++ b/cmd/vpp-agent/app/vpp_agent.go
@@ -101,7 +101,7 @@ func New() *VPPAgent {
 	)
 
 	// Set watcher for KVScheduler.
-	initFileRegistry := localregistry.NewNBInitFileRegistryPlugin()
+	initFileRegistry := localregistry.NewInitFileRegistryPlugin()
 	watchers := watcher.NewPlugin(watcher.UseWatchers(
 		local.DefaultRegistry,
 		initFileRegistry,

--- a/cmd/vpp-agent/app/vpp_agent.go
+++ b/cmd/vpp-agent/app/vpp_agent.go
@@ -15,11 +15,11 @@
 package app
 
 import (
+	"github.com/go-errors/errors"
 	"go.ligato.io/cn-infra/v2/datasync"
 	"go.ligato.io/cn-infra/v2/datasync/kvdbsync"
 	"go.ligato.io/cn-infra/v2/datasync/kvdbsync/local"
 	"go.ligato.io/cn-infra/v2/datasync/msgsync"
-	"go.ligato.io/cn-infra/v2/datasync/resync"
 	"go.ligato.io/cn-infra/v2/db/keyval/consul"
 	"go.ligato.io/cn-infra/v2/db/keyval/etcd"
 	"go.ligato.io/cn-infra/v2/db/keyval/redis"
@@ -28,7 +28,6 @@ import (
 	"go.ligato.io/cn-infra/v2/infra"
 	"go.ligato.io/cn-infra/v2/logging/logmanager"
 	"go.ligato.io/cn-infra/v2/messaging/kafka"
-
 	"go.ligato.io/vpp-agent/v3/plugins/configurator"
 	linux_ifplugin "go.ligato.io/vpp-agent/v3/plugins/linux/ifplugin"
 	linux_iptablesplugin "go.ligato.io/vpp-agent/v3/plugins/linux/iptablesplugin"
@@ -36,6 +35,8 @@ import (
 	linux_nsplugin "go.ligato.io/vpp-agent/v3/plugins/linux/nsplugin"
 	"go.ligato.io/vpp-agent/v3/plugins/netalloc"
 	"go.ligato.io/vpp-agent/v3/plugins/orchestrator"
+	"go.ligato.io/vpp-agent/v3/plugins/orchestrator/localregistry"
+	"go.ligato.io/vpp-agent/v3/plugins/orchestrator/watcher"
 	"go.ligato.io/vpp-agent/v3/plugins/restapi"
 	"go.ligato.io/vpp-agent/v3/plugins/telemetry"
 	"go.ligato.io/vpp-agent/v3/plugins/vpp/abfplugin"
@@ -100,12 +101,14 @@ func New() *VPPAgent {
 	)
 
 	// Set watcher for KVScheduler.
-	watchers := datasync.KVProtoWatchers{
+	initFileRegistry := localregistry.NewNBInitFileRegistryPlugin()
+	watchers := watcher.NewPlugin(watcher.UseWatchers(
 		local.DefaultRegistry,
+		initFileRegistry,
 		etcdDataSync,
 		consulDataSync,
 		redisDataSync,
-	}
+	))
 	orchestrator.DefaultPlugin.Watcher = watchers
 	orchestrator.DefaultPlugin.StatusPublisher = writers
 	orchestrator.EnabledGrpcMetrics()
@@ -157,9 +160,9 @@ func (a *VPPAgent) Init() error {
 
 // AfterInit executes resync.
 func (a *VPPAgent) AfterInit() error {
-	// manually start resync after all plugins started
-	resync.DefaultPlugin.DoResync()
-	//orchestrator.DefaultPlugin.InitialSync()
+	if err := orchestrator.DefaultPlugin.InitialSync(); err != nil {
+		return errors.Errorf("failure in initial sync: %v", err)
+	}
 	a.StatusCheck.ReportStateChange(a.PluginName, statuscheck.OK, nil)
 	return nil
 }

--- a/pkg/models/model.go
+++ b/pkg/models/model.go
@@ -150,5 +150,5 @@ func (m *LocallyKnownModel) InstanceName(x interface{}) (string, error) {
 	if m.nameFunc == nil {
 		return "", nil
 	}
-	return m.nameFunc(x)
+	return m.nameFunc(x, m.goType)
 }

--- a/pkg/models/registry.go
+++ b/pkg/models/registry.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/go-errors/errors"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	protoV2 "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -267,16 +266,8 @@ func dynamicMessageToRegisteredGoType(dynamicMessage *dynamicpb.Message, goType 
 	}
 
 	// fill empty proto message with data from its dynamic proto message counterpart
-	// (dynamic proto message -> json -> registered-type proto message)
-	marshaller := jsonpb.Marshaler{EmitDefaults: true} // using jsonbp to generate json with json name field in proto tag
-	jsonData, err := marshaller.MarshalToString(dynamicMessage)
-	if err != nil {
-		return nil, errors.Errorf("can't marshall dynamic proto message "+
-			"to json due to: %v (message: %+v)", err, dynamicMessage)
-	}
-	if err := jsonpb.Unmarshal(strings.NewReader(jsonData), message); err != nil {
-		return nil, errors.Errorf("can't load json to registered-type "+
-			"proto message due to: %v (json=%v)", err, jsonData)
-	}
+	// (alternative approach to this is marshalling dynamicMessage to json and unmarshalling it back to message)
+	proto.Merge(message, dynamicMessage)
+
 	return message, nil
 }

--- a/pkg/models/registry.go
+++ b/pkg/models/registry.go
@@ -20,7 +20,10 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/go-errors/errors"
+	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
+	protoV2 "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/dynamicpb"
@@ -36,18 +39,20 @@ var (
 // LocalRegistry defines model registry for managing registered local models. Local models are locally compiled into
 // the program binary and hence some additional information in compare to remote models, i.e. go type.
 type LocalRegistry struct {
-	registeredTypes map[reflect.Type]*LocallyKnownModel
-	modelNames      map[string]*LocallyKnownModel
-	ordered         []reflect.Type
-	proxied         *RemoteRegistry
+	registeredModelsByGoType    map[reflect.Type]*LocallyKnownModel
+	registeredModelsByProtoName map[string]*LocallyKnownModel
+	modelNames                  map[string]*LocallyKnownModel
+	ordered                     []reflect.Type
+	proxied                     *RemoteRegistry
 }
 
 // NewRegistry returns initialized Registry.
 func NewRegistry() *LocalRegistry {
 	return &LocalRegistry{
-		registeredTypes: make(map[reflect.Type]*LocallyKnownModel),
-		modelNames:      make(map[string]*LocallyKnownModel),
-		proxied:         NewRemoteRegistry(),
+		registeredModelsByGoType:    make(map[reflect.Type]*LocallyKnownModel),
+		registeredModelsByProtoName: make(map[string]*LocallyKnownModel),
+		modelNames:                  make(map[string]*LocallyKnownModel),
+		proxied:                     NewRemoteRegistry(),
 	}
 }
 
@@ -66,12 +71,35 @@ func (r *LocalRegistry) GetModel(name string) (KnownModel, error) {
 
 // GetModelFor returns registered model for the given proto message.
 func (r *LocalRegistry) GetModelFor(x interface{}) (KnownModel, error) {
+	// find model by Go type
 	t := reflect.TypeOf(x)
-	model, found := r.registeredTypes[t]
+	model, found := r.registeredModelsByGoType[t]
 	if !found {
+		// check remotely retrieved models registered in local registry
 		if proxModel, err := r.proxied.GetModelFor(x); err == nil {
 			return proxModel, nil
 		}
+
+		// find model by Proto name
+		// (useful when using dynamically generated config instead of configurator.Config => go type of proto
+		// messages is in such case always dynamicpb.Message and never the go type of registered (generated)
+		// proto message)
+		if len(r.registeredModelsByProtoName) == 0 && len(r.registeredModelsByGoType) > 0 {
+			r.lazyInitRegisteredTypesByProtoName()
+		}
+		var protoName string
+		if pb, ok := x.(protoreflect.ProtoMessage); ok {
+			protoName = string(pb.ProtoReflect().Descriptor().FullName())
+		} else if v1, ok := x.(proto.Message); ok {
+			protoName = string(proto.MessageV2(v1).ProtoReflect().Descriptor().FullName())
+		}
+		if protoName != "" {
+			if model, found = r.registeredModelsByProtoName[protoName]; found {
+				return model, nil
+			}
+		}
+
+		// find model by checking proto options
 		if model = r.checkProtoOptions(x); model == nil {
 			return &LocallyKnownModel{}, fmt.Errorf("no model registered for type %v", t)
 		}
@@ -79,9 +107,23 @@ func (r *LocalRegistry) GetModelFor(x interface{}) (KnownModel, error) {
 	return model, nil
 }
 
+// lazyInitRegisteredTypesByProtoName performs lazy initialization of registeredModelsByProtoName. The reason
+// why initialization can't happen while registration (call of func Register(...)) is that some proto reflect
+// functionality is not available during this time. The registration happens as variable initialization, but
+// the reflection is initialized in init() func and that happens after variable initialization.
+//
+// Alternative solution would be to change when the models are registered (VPP-Agent have it like described
+// above and 3rd party model are probably copying the same behaviour). So to not break anything, the lazy
+// initialization seems like the best solution for now.
+func (r *LocalRegistry) lazyInitRegisteredTypesByProtoName() {
+	for _, model := range r.registeredModelsByGoType {
+		r.registeredModelsByProtoName[model.ProtoName()] = model // ProtoName() == ProtoReflect().Descriptor().FullName()
+	}
+}
+
 // GetModelForKey returns registered model for the given key or error.
 func (r *LocalRegistry) GetModelForKey(key string) (KnownModel, error) {
-	for _, model := range r.registeredTypes {
+	for _, model := range r.registeredModelsByGoType {
 		if model.IsKeyValid(key) {
 			return model, nil
 		}
@@ -96,7 +138,7 @@ func (r *LocalRegistry) GetModelForKey(key string) (KnownModel, error) {
 func (r *LocalRegistry) RegisteredModels() []KnownModel {
 	var models []KnownModel
 	for _, typ := range r.ordered {
-		models = append(models, r.registeredTypes[typ])
+		models = append(models, r.registeredModelsByGoType[typ])
 	}
 	models = append(models, r.proxied.RegisteredModels()...)
 	return models
@@ -109,7 +151,7 @@ func (r *LocalRegistry) MessageTypeRegistry() *protoregistry.Types {
 		typeRegistry.RegisterMessage(dynamicpb.NewMessageType(model.proto.ProtoReflect().Descriptor()))
 	}
 	proxiedTypes := r.proxied.MessageTypeRegistry()
-	proxiedTypes.RangeMessages(func (mt protoreflect.MessageType) bool {
+	proxiedTypes.RangeMessages(func(mt protoreflect.MessageType) bool {
 		typeRegistry.RegisterMessage(mt)
 		return true
 	})
@@ -135,7 +177,7 @@ func (r *LocalRegistry) Register(x interface{}, spec Spec, opts ...ModelOption) 
 
 	goType := reflect.TypeOf(x)
 	// Check go type duplicate registration
-	if m, ok := r.registeredTypes[goType]; ok {
+	if m, ok := r.registeredModelsByGoType[goType]; ok {
 		return nil, fmt.Errorf("go type %v already registered for model %v", goType, m.Name())
 	}
 
@@ -174,6 +216,14 @@ func (r *LocalRegistry) Register(x interface{}, spec Spec, opts ...ModelOption) 
 	// Use GetName as fallback for generating name
 	if _, ok := x.(named); ok {
 		model.nameFunc = func(obj interface{}) (s string, e error) {
+			// handling dynamic messages (they don't implement named interface)
+			if dynMessage, ok := obj.(*dynamicpb.Message); ok {
+				obj, e = dynamicMessageToRegisteredGoType(dynMessage, model.goType)
+				if e != nil {
+					return "", e
+				}
+			}
+			// handling other proto message
 			return obj.(named).GetName(), nil
 		}
 		model.nameTemplate = namedTemplate
@@ -184,7 +234,7 @@ func (r *LocalRegistry) Register(x interface{}, spec Spec, opts ...ModelOption) 
 		opt(&model.modelOptions)
 	}
 
-	r.registeredTypes[goType] = model
+	r.registeredModelsByGoType[goType] = model
 	r.modelNames[model.Name()] = model
 	r.ordered = append(r.ordered, goType)
 
@@ -192,4 +242,41 @@ func (r *LocalRegistry) Register(x interface{}, spec Spec, opts ...ModelOption) 
 		fmt.Printf("- model %s registered: %+v\n", model.Name(), model)
 	}
 	return model, nil
+}
+
+// dynamicMessageToRegisteredGoType converts proto dynamic message to proto message that was used at
+// the registration of the proto model corresponding to the proto dynamic message.
+// The registration proto message is usually the protoc-generated proto message. This conversion method
+// should help handling dynamic proto messages in mostly protoc-generated proto message oriented codebase
+// (i.e. help for type conversions to named, help handle missing data fields as seen in generated proto messages,...)
+func dynamicMessageToRegisteredGoType(dynamicMessage *dynamicpb.Message, goType reflect.Type) (proto.Message, error) {
+	// create empty proto message of the same type as it was used for registration
+	var registeredGoType interface{}
+	if goType.Kind() == reflect.Ptr {
+		registeredGoType = reflect.New(goType.Elem()).Interface()
+	} else {
+		registeredGoType = reflect.Zero(goType).Interface()
+	}
+	message, isProtoV1 := registeredGoType.(proto.Message)
+	if !isProtoV1 {
+		messageV2, isProtoV2 := registeredGoType.(protoV2.Message)
+		if !isProtoV2 {
+			return nil, errors.Errorf("registered go type(%T) is not proto.Message", registeredGoType)
+		}
+		message = proto.MessageV1(messageV2)
+	}
+
+	// fill empty proto message with data from its dynamic proto message counterpart
+	// (dynamic proto message -> json -> registered-type proto message)
+	marshaller := jsonpb.Marshaler{EmitDefaults: true} // using jsonbp to generate json with json name field in proto tag
+	jsonData, err := marshaller.MarshalToString(dynamicMessage)
+	if err != nil {
+		return nil, errors.Errorf("can't marshall dynamic proto message "+
+			"to json due to: %v (message: %+v)", err, dynamicMessage)
+	}
+	if err := jsonpb.Unmarshal(strings.NewReader(jsonData), message); err != nil {
+		return nil, errors.Errorf("can't load json to registered-type "+
+			"proto message due to: %v (json=%v)", err, jsonData)
+	}
+	return message, nil
 }

--- a/pkg/models/remote_model.go
+++ b/pkg/models/remote_model.go
@@ -155,7 +155,7 @@ func (m *RemotelyKnownModel) InstanceName(x interface{}) (string, error) {
 		return "", errors.Errorf("can't load json of marshalled "+
 			"message to generic map due to: %v (json=%v)", err, jsonData)
 	}
-	name, err := NameTemplate(nameTemplate)(mapData)
+	name, err := NameTemplate(nameTemplate)(mapData, nil)
 	if err != nil {
 		return "", errors.Errorf("can't compute name from name template by applying generic map "+
 			"due to: %v (name template=%v, generic map=%v)", err, nameTemplate, mapData)

--- a/pkg/models/remote_model.go
+++ b/pkg/models/remote_model.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/protobuf/types/dynamicpb"
 )
 
-// RemotelyKnownModel represents a registered remnote model (remote model has only information about model
+// RemotelyKnownModel represents a registered remote model (remote model has only information about model
 // from remote source, i.e. missing go type because VPP-Agent meta service doesn't provide it)
 type RemotelyKnownModel struct {
 	model *ModelInfo

--- a/plugins/configurator/configurator.go
+++ b/plugins/configurator/configurator.go
@@ -33,6 +33,7 @@ import (
 	"go.ligato.io/vpp-agent/v3/pkg/util"
 	kvs "go.ligato.io/vpp-agent/v3/plugins/kvscheduler/api"
 	"go.ligato.io/vpp-agent/v3/plugins/orchestrator"
+	"go.ligato.io/vpp-agent/v3/plugins/orchestrator/contextdecorator"
 	pb "go.ligato.io/vpp-agent/v3/proto/ligato/configurator"
 	"go.ligato.io/vpp-agent/v3/proto/ligato/kvscheduler"
 	"go.ligato.io/vpp-agent/v3/proto/ligato/linux"
@@ -110,7 +111,7 @@ func (svc *configuratorServer) Update(ctx context.Context, req *pb.UpdateRequest
 		ctx = kvs.WithResync(ctx, kvs.FullResync, true)
 	}
 
-	ctx = orchestrator.DataSrcContext(ctx, "grpc")
+	ctx = contextdecorator.DataSrcContext(ctx, "grpc")
 	results, err := svc.dispatch.PushData(ctx, kvPairs)
 
 	header := map[string]string{}
@@ -181,7 +182,7 @@ func (svc *configuratorServer) Delete(ctx context.Context, req *pb.DeleteRequest
 		})
 	}
 
-	ctx = orchestrator.DataSrcContext(ctx, "grpc")
+	ctx = contextdecorator.DataSrcContext(ctx, "grpc")
 	results, err := svc.dispatch.PushData(ctx, kvPairs)
 
 	header := map[string]string{}

--- a/plugins/orchestrator/contextdecorator/context.go
+++ b/plugins/orchestrator/contextdecorator/context.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 Pantheon.tech
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package contextdecorator handles insertions and extractions of orchestrator related data from context.
+package contextdecorator
+
+import "context"
+
+type dataSrcKeyT string
+
+var dataSrcKey = dataSrcKeyT("dataSrc")
+
+func DataSrcContext(ctx context.Context, dataSrc string) context.Context {
+	return context.WithValue(ctx, dataSrcKey, dataSrc)
+}
+
+func DataSrcFromContext(ctx context.Context) (dataSrc string, ok bool) {
+	dataSrc, ok = ctx.Value(dataSrcKey).(string)
+	return
+}

--- a/plugins/orchestrator/dispatcher.go
+++ b/plugins/orchestrator/dispatcher.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"go.ligato.io/cn-infra/v2/logging"
+	"go.ligato.io/vpp-agent/v3/plugins/orchestrator/contextdecorator"
 
 	"go.ligato.io/vpp-agent/v3/pkg/models"
 	kvs "go.ligato.io/vpp-agent/v3/plugins/kvscheduler/api"
@@ -102,7 +103,7 @@ func (p *dispatcher) PushData(ctx context.Context, kvPairs []KeyVal) (results []
 
 	pr := trace.StartRegion(ctx, "prepare kv data")
 
-	dataSrc, ok := DataSrcFromContext(ctx)
+	dataSrc, ok := contextdecorator.DataSrcFromContext(ctx)
 	if !ok {
 		dataSrc = "global"
 	}

--- a/plugins/orchestrator/localregistry/nbinitfileregistry.go
+++ b/plugins/orchestrator/localregistry/nbinitfileregistry.go
@@ -171,8 +171,12 @@ func (r *NBInitFileRegistry) retrieveConfig() (*Config, error) {
 	}
 	found, err := r.Cfg.LoadValue(config)
 	if !found {
-		r.Log.Debug("NBInitFileRegistry plugin config not found")
-		return config, nil
+		if err == nil {
+			r.Log.Debug("NBInitFileRegistry plugin config not found")
+		} else {
+			r.Log.Debugf("NBInitFileRegistry plugin config can't be loaded due to: %v", err)
+		}
+		return config, err
 	}
 	if err != nil {
 		return nil, err

--- a/plugins/orchestrator/localregistry/nbinitfileregistry.go
+++ b/plugins/orchestrator/localregistry/nbinitfileregistry.go
@@ -1,0 +1,286 @@
+// Copyright (c) 2020 Pantheon.tech
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localregistry
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	yaml2 "github.com/ghodss/yaml"
+	"github.com/go-errors/errors"
+	"github.com/golang/protobuf/proto"
+	"go.ligato.io/cn-infra/v2/config"
+	"go.ligato.io/cn-infra/v2/datasync"
+	"go.ligato.io/cn-infra/v2/datasync/kvdbsync/local"
+	"go.ligato.io/cn-infra/v2/datasync/resync"
+	"go.ligato.io/cn-infra/v2/datasync/syncbase"
+	"go.ligato.io/cn-infra/v2/db/keyval"
+	"go.ligato.io/cn-infra/v2/infra"
+	"go.ligato.io/vpp-agent/v3/client"
+	"google.golang.org/protobuf/encoding/protojson"
+	protoV2 "google.golang.org/protobuf/proto"
+)
+
+const (
+	registryName          = "nb-init-file-registry"
+	defaultNBInitFilePath = "nb-initial-config.yaml"
+)
+
+type Option func(*NBInitFileRegistry)
+
+// NBInitFileRegistry is local read-only NB configuration provider with exclusive data source from a file
+// given by a file path (InitConfigFilePath). Its purpose is to seamlessly integrated NB configuration
+// from file as another NB configuration provider (to existing providers: etcd, consul, redis) and integrate
+// it's configuration into agent in the same standard way(datasync.KeyValProtoWatcher). The content of this
+// registry is meant to be only the initial NB configuration for the agent and will not reflect any changes
+// inside given file after initial content loading.
+//
+// The NB configuration provisioning process and how this registry fits into it:
+// 	1. NB data sources register to default resync plugin (NBInitFileRegistry registers too in watchNBResync(),
+//	   but only when there are some NB config data from file, otherwise it makes no sense to register because
+//	   there is nothing to forward. This also means that before register to resync plugin, the NB config from
+//	   file will be preloaded)
+// 	2. Call to resync plugin's DoResync triggers resync to NB configuration sources (NBInitFileRegistry takes
+//	   its preloaded NB config and stores it into another inner local registry)
+// 	3. NB configuration sources are also watchable (datasync.KeyValProtoWatcher) and the resync data is
+//	   collected by the watcher.Aggregator (NBInitFileRegistry is also watchable/forwards data to watcher.Aggregator,
+//	   it relies on the watcher capabilities of its inner local registry. This is the cause why to preloaded
+//	   the NB config from file([]proto.Message storage) and push it to another inner local storage later
+//	   (syncbase.Registry). If we used only one storage (syncbase.Registry for its watch capabilities), we
+//	   couldn't answer some questins about the storage soon enough (watcher.Aggregator in Watch(...) needs to
+//	   know whether this storage will send some data or not, otherwise the retrieval can hang on waiting for
+//	   data that never come))
+// 	4. watcher.Aggregator merges all collected resync data and forwards them its watch clients (it also implements
+//	   datasync.KeyValProtoWatcher just like the NB data sources).
+//  5. Clients of Aggregator (currently orchestrator and ifplugin) handle the NB changes/resync properly.
+type NBInitFileRegistry struct {
+	infra.PluginDeps
+
+	initialized             bool
+	config                  *Config
+	watchedRegistry         *syncbase.Registry
+	pushedToWatchedRegistry bool
+	preloadedNBConfigs      []proto.Message
+}
+
+// Config holds the NBInitFileRegistry configuration.
+type Config struct {
+	DisableNBInitialConfiguration  bool   `json:"disable-nb-initial-configuration"`
+	NBInitialConfigurationFilePath string `json:"nb-initial-configuration-file-path"`
+}
+
+// NewNBInitFileRegistryPlugin creates a new Plugin with the provides Options
+func NewNBInitFileRegistryPlugin(opts ...Option) *NBInitFileRegistry {
+	p := &NBInitFileRegistry{}
+
+	p.PluginName = "nbinitfileregistry"
+	p.watchedRegistry = syncbase.NewRegistry()
+
+	for _, o := range opts {
+		o(p)
+	}
+	if p.Cfg == nil {
+		p.Cfg = config.ForPlugin(p.String(),
+			config.WithCustomizedFlag(config.FlagName(p.String()), "nbinitfileregistryplugin.conf"),
+		)
+	}
+	p.PluginDeps.SetupLog()
+
+	return p
+}
+
+// Init initialize registry
+func (r *NBInitFileRegistry) Init() error {
+	if !r.initialized {
+		return r.initialize()
+	}
+	return nil
+}
+
+// Empty checks whether this registry holds data or not. As result of the properties of this registry
+// (readonly, will be filled only once from initial file import), this method directly indicates whether
+// the watchers of this registry will receive any data (Empty() == false, receive initial resync) or
+// won't receive anything at all (Empty() == true)
+func (r *NBInitFileRegistry) Empty() bool {
+	if !r.initialized { // could be called from init of other plugins -> possibly before this plugin init
+		if err := r.initialize(); err != nil {
+			r.Log.Errorf("can't initialize NBInitFileRegistry due to: %v", err)
+		}
+	}
+	return len(r.preloadedNBConfigs) == 0
+}
+
+// Watch functionality is forwarded to inner syncbase.Registry. For some watchers might be relevant
+// whether any data will be pushed to them at all (i.e. watcher.Aggregator). They should use the
+// Empty() method to find out whether there are (=ever will be do to nature of this registry) any
+// data for pushing to watchers.
+func (r *NBInitFileRegistry) Watch(resyncName string, changeChan chan datasync.ChangeEvent,
+	resyncChan chan datasync.ResyncEvent, keyPrefixes ...string) (datasync.WatchRegistration, error) {
+	return r.watchedRegistry.Watch(resyncName, changeChan, resyncChan, keyPrefixes...)
+}
+
+// initialize will try to pre-load the NB initial data
+// (watchers of this registry will receive it only after call to resync)
+func (r *NBInitFileRegistry) initialize() error {
+	defer func() {
+		r.initialized = true
+	}()
+
+	// parse configuration file
+	var err error
+	r.config, err = r.retrieveConfig()
+	if err != nil {
+		return err
+	}
+
+	// Initial NB configuration loaded from file
+	if !r.config.DisableNBInitialConfiguration {
+		// preload NB config data from file
+		if err := r.preloadNBConfigs(r.config.NBInitialConfigurationFilePath); err != nil {
+			return errors.Errorf("can't preload initial NB configuration from file due to: %v", err)
+		}
+		if len(r.preloadedNBConfigs) != 0 {
+			// watch for resync.DefaultPlugin.DoResync() that will trigger pushing of preloaded
+			// NB config data from file into NB aggregator watcher
+			// (see NBInitFileRegistry struct docs for detailed explanation)
+			r.watchNBResync()
+		}
+	}
+	return nil
+}
+
+// retrieveConfig loads NBInitFileRegistry plugin configuration file.
+func (r *NBInitFileRegistry) retrieveConfig() (*Config, error) {
+	config := &Config{
+		// default configuration
+		DisableNBInitialConfiguration:  false,
+		NBInitialConfigurationFilePath: defaultNBInitFilePath,
+	}
+	found, err := r.Cfg.LoadValue(config)
+	if !found {
+		r.Log.Debug("NBInitFileRegistry plugin config not found")
+		return config, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return config, err
+}
+
+// watchNBResync will watch to default resync plugin's resync call(resync.DefaultPlugin.DoResync()) and will
+// load NB initial config from file (already preloaded from initialize()) when the first resync will be fired.
+func (r *NBInitFileRegistry) watchNBResync() {
+	registration := resync.DefaultPlugin.Register(registryName)
+	go r.watchResync(registration)
+}
+
+// watchResync will listen to resync plugin resync signals and at first resync will push the preloaded
+// NB initial config into internal local register (p.registry)
+func (r *NBInitFileRegistry) watchResync(resyncReg resync.Registration) {
+	for resyncStatus := range resyncReg.StatusChan() {
+		// resyncReg.StatusChan == Started => resync
+		if resyncStatus.ResyncStatus() == resync.Started && !r.pushedToWatchedRegistry {
+			if !r.Empty() { // put preloaded NB init file data into watched p.registry
+				c := client.NewClient(&txnFactory{r.watchedRegistry})
+				if err := c.ResyncConfig(r.preloadedNBConfigs...); err != nil {
+					r.Log.Errorf("resyncing preloaded NB init file data "+
+						"into watched registry failed: %v", err)
+				}
+			}
+			r.pushedToWatchedRegistry = true
+			resyncStatus.Ack()
+			// TODO some done channel to not continue as NOP goroutine
+			continue // can't unregister anymore -> need to listen to further resync signals, but it will be just NO-OPs
+		}
+		resyncStatus.Ack()
+	}
+}
+
+// preloadNBConfigs imports NB configuration from file(filepath) into preloadedNBConfigs. If file is not found,
+// it is not considered as error, but as a sign that the NB-configuration-loading-from-file feature should be
+// not used (inner registry remains empty and watchers of this registry get no data).
+func (r *NBInitFileRegistry) preloadNBConfigs(filePath string) error {
+	// check existence of NB init file
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		filePath := filePath
+		if absFilePath, err := filepath.Abs(filePath); err == nil {
+			filePath = absFilePath
+		}
+		r.Log.Debugf("Initialization NB configuration file(%v) not found. "+
+			"Skipping its preloading.", filePath)
+		return nil
+	}
+
+	// read data from file
+	b, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return errors.Errorf("problem reading file %s: %w", filePath, err)
+	}
+
+	// create dynamic config (using it instead of configurator.Config because it can hold also models defined
+	// outside the VPP-Agent repo, i.e. if this code is using 3rd party code based on VPP-Agent and having its
+	// additional properly registered configuration models)
+	knownModels, err := client.LocalClient.KnownModels("config") // locally registered models
+	if err != nil {
+		return errors.Errorf("can't get registered models: %w", err)
+	}
+	config, err := client.NewDynamicConfig(knownModels)
+	if err != nil {
+		return errors.Errorf("can't create dynamic config due to: %w", err)
+	}
+
+	// filling dynamically created config with data from NB init file
+	bj, err := yaml2.YAMLToJSON(b)
+	if err != nil {
+		return errors.Errorf("can't converting to JSON: %w", err)
+	}
+	err = protojson.Unmarshal(bj, config)
+	if err != nil {
+		return errors.Errorf("can't unmarshall NB init file data into dynamic config due to: %v", err)
+	}
+
+	// extracting proto messages from dynamic config structure
+	// (generic client wants single proto messages and not one big hierarchical config)
+	configMessages, err := client.DynamicConfigExport(config)
+	if err != nil {
+		return errors.Errorf("can't extract single NB init configuration proto messages "+
+			"from one big configuration proto message due to: %v", err)
+	}
+
+	// remember extracted data for later push to watched registry
+	r.preloadedNBConfigs = convertToProtoV1(configMessages)
+
+	return nil
+}
+
+type txnFactory struct {
+	registry *syncbase.Registry
+}
+
+func (p *txnFactory) NewTxn(resync bool) keyval.ProtoTxn {
+	if resync {
+		return local.NewProtoTxn(p.registry.PropagateResync)
+	}
+	return local.NewProtoTxn(p.registry.PropagateChanges)
+}
+
+func convertToProtoV1(messages []protoV2.Message) []proto.Message {
+	result := make([]proto.Message, 0, len(messages))
+	for _, message := range messages {
+		result = append(result, proto.MessageV1(message.ProtoReflect().Interface()))
+	}
+	return result
+}

--- a/plugins/orchestrator/meta_service.go
+++ b/plugins/orchestrator/meta_service.go
@@ -23,6 +23,7 @@ import (
 	"go.ligato.io/cn-infra/v2/logging"
 	"go.ligato.io/vpp-agent/v3/pkg/models"
 	kvs "go.ligato.io/vpp-agent/v3/plugins/kvscheduler/api"
+	"go.ligato.io/vpp-agent/v3/plugins/orchestrator/contextdecorator"
 	"go.ligato.io/vpp-agent/v3/proto/ligato/generic"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -118,7 +119,7 @@ func (s *genericService) SetConfig(ctx context.Context, req *generic.SetConfigRe
 		})
 	}
 
-	ctx = DataSrcContext(ctx, "grpc")
+	ctx = contextdecorator.DataSrcContext(ctx, "grpc")
 	if req.OverwriteAll {
 		ctx = kvs.WithResync(ctx, kvs.FullResync, true)
 	}

--- a/plugins/orchestrator/store.go
+++ b/plugins/orchestrator/store.go
@@ -15,7 +15,6 @@
 package orchestrator
 
 import (
-	"context"
 	"sort"
 
 	"github.com/golang/protobuf/proto"
@@ -82,17 +81,4 @@ func (s *memStore) Delete(dataSrc, key string) {
 // Reset clears all key-value data.
 func (s *memStore) Reset(dataSrc string) {
 	delete(s.db, dataSrc)
-}
-
-type dataSrcKeyT string
-
-var dataSrcKey = dataSrcKeyT("dataSrc")
-
-func DataSrcContext(ctx context.Context, dataSrc string) context.Context {
-	return context.WithValue(ctx, dataSrcKey, dataSrc)
-}
-
-func DataSrcFromContext(ctx context.Context) (dataSrc string, ok bool) {
-	dataSrc, ok = ctx.Value(dataSrcKey).(string)
-	return
 }

--- a/plugins/orchestrator/watcher/aggregator.go
+++ b/plugins/orchestrator/watcher/aggregator.go
@@ -20,12 +20,14 @@ import (
 	"strings"
 
 	"go.ligato.io/cn-infra/v2/datasync"
+	"go.ligato.io/cn-infra/v2/datasync/kvdbsync"
 	"go.ligato.io/cn-infra/v2/datasync/kvdbsync/local"
 	"go.ligato.io/cn-infra/v2/datasync/resync"
 	"go.ligato.io/cn-infra/v2/datasync/syncbase"
 	"go.ligato.io/cn-infra/v2/infra"
 	"go.ligato.io/cn-infra/v2/logging"
 	"go.ligato.io/cn-infra/v2/utils/safeclose"
+	"go.ligato.io/vpp-agent/v3/plugins/orchestrator/localregistry"
 )
 
 // Option is a function that acts on a Plugin to inject Dependencies or configuration
@@ -92,6 +94,29 @@ func (p *Aggregator) Watch(
 			p.Log.Warn("found local registry (localclient) in watchers, ignoring it..")
 			continue
 		}
+		// ignoring watchers that have data sources that will be never used and
+		// therefore never send configuration data to this aggregator
+		if syncer, ok := w.(*kvdbsync.Plugin); ok {
+			if syncer.KvPlugin != nil && syncer.KvPlugin.Disabled() {
+				continue
+			}
+		}
+		// TODO Handle kvdbsync.Plugin watchers that are not disabled, but won't transmit any resync data.
+		//  This aggregator collects resyncs from all watchers, but if one or more resync from watcher don't happen,
+		//  the agregator resyncing won't be triggered. This might happen when one of watchers is not registered
+		//  to resync plugin and that is usually due to not connecting to data source as the registration to
+		//  resync plugin happen in OnConnect callback function.
+		//  To properly handle the situation, OnConnect callback must be used to distinguish what watched is
+		//  reached by resync trigger. That might lead to delayed readiness of all watchers and hence the trigger
+		//  for initial call of DoResync() to do initial Agent resync must be delayed as well SOMEHOW (can't use
+		//  init or after init of plugins).
+
+		// localregistry.NBInitFileRegistry can also be watcher that never sends anything (i.e. if misconfigured
+		// or no default NB init file is present or loading of data fails or ... -> check for Empty())
+		if initRegistry, ok := w.(*localregistry.NBInitFileRegistry); ok && initRegistry.Empty() {
+			continue
+		}
+
 		watchers = append(watchers, w)
 	}
 	p.Watchers = watchers
@@ -109,7 +134,7 @@ func (p *Aggregator) Watch(
 		partResync := make(chan datasync.ResyncEvent)
 
 		name := fmt.Sprint(adapter) + "/" + resyncName
-		watcherReg, err := adapter.Watch(name, changeChan, partResync, keyPrefixes...)
+		watcherReg, err := adapter.Watch(name, partChange, partResync, keyPrefixes...)
 		if err != nil {
 			return nil, err
 		}
@@ -286,7 +311,7 @@ func (p *Aggregator) watchLocalEvents(partChange, changeChan chan datasync.Chang
 			e.Done(nil)
 
 			p.Log.Debug("LOCAL watcher calling RESYNC")
-			p.Resync.DoResync()
+			p.Resync.DoResync() // execution will appear in p.watchAggrResync go routine where p.localKVs will handled
 		}
 	}
 }

--- a/plugins/orchestrator/watcher/aggregator.go
+++ b/plugins/orchestrator/watcher/aggregator.go
@@ -111,9 +111,9 @@ func (p *Aggregator) Watch(
 		//  for initial call of DoResync() to do initial Agent resync must be delayed as well SOMEHOW (can't use
 		//  init or after init of plugins).
 
-		// localregistry.NBInitFileRegistry can also be watcher that never sends anything (i.e. if misconfigured
-		// or no default NB init file is present or loading of data fails or ... -> check for Empty())
-		if initRegistry, ok := w.(*localregistry.NBInitFileRegistry); ok && initRegistry.Empty() {
+		// localregistry.InitFileRegistry can also be watcher that never sends anything (i.e. if misconfigured
+		// or no default init file is present or loading of data fails or ... -> check for Empty())
+		if initRegistry, ok := w.(*localregistry.InitFileRegistry); ok && initRegistry.Empty() {
 			continue
 		}
 

--- a/tests/e2e/000_initial_test.go
+++ b/tests/e2e/000_initial_test.go
@@ -126,7 +126,9 @@ dial-timeout: 1s
 endpoints:
     - "%v:2379"
 `
-	etcdConfig = fmt.Sprintf(etcdConfig, ctx.Etcd.Inspect().NetworkSettings.IPAddress)
+	etcdContainer, err := ctx.Etcd.Inspect()
+	Expect(err).ShouldNot(HaveOccurred())
+	etcdConfig = fmt.Sprintf(etcdConfig, etcdContainer.NetworkSettings.IPAddress)
 
 	// create VPP-Agent
 	SetupVPPAgent(ctx,
@@ -222,7 +224,9 @@ dial-timeout: 1s
 endpoints:
     - "%v:2379"
 `
-	etcdConfig = fmt.Sprintf(etcdConfig, ctx.Etcd.Inspect().NetworkSettings.IPAddress)
+	etcdContainer, err := ctx.Etcd.Inspect()
+	Expect(err).ShouldNot(HaveOccurred())
+	etcdConfig = fmt.Sprintf(etcdConfig, etcdContainer.NetworkSettings.IPAddress)
 
 	// create VPP-Agent
 	SetupVPPAgent(ctx,

--- a/tests/e2e/000_initial_test.go
+++ b/tests/e2e/000_initial_test.go
@@ -59,10 +59,10 @@ func TestStartStopAgent(t *testing.T) {
 	}
 
 	ctx.StartAgent(agent1)
-	Eventually(msState).Should(Equal(kvscheduler.ValueState_OBTAINED)) // FIXME testing agent0 and not agent1
+	Eventually(msState).Should(Equal(kvscheduler.ValueState_OBTAINED))
 
 	ctx.StopAgent(agent1)
-	Eventually(msState).Should(Equal(kvscheduler.ValueState_NONEXISTENT)) // FIXME testing agent0 and not agent1 , did this test even passed with previous e2e changes?
+	Eventually(msState).Should(Equal(kvscheduler.ValueState_NONEXISTENT))
 }
 
 // TestInitFromFile tests configuring initial state of NB from file

--- a/tests/e2e/100_agentctl_test.go
+++ b/tests/e2e/100_agentctl_test.go
@@ -365,7 +365,7 @@ func TestAgentCtlSecureGrpc(t *testing.T) {
 }
 
 func TestAgentCtlSecureETCD(t *testing.T) {
-	ctx := Setup(t, WithEtcd(), WithEtcdHTTPsConnection(), WithEtcdVPPAgentContainerNetworking())
+	ctx := Setup(t, WithEtcd(WithEtcdHTTPsConnection(), WithEtcdVPPAgentContainerNetworking()))
 	defer ctx.Teardown()
 
 	// test without any TLS

--- a/tests/e2e/100_agentctl_test.go
+++ b/tests/e2e/100_agentctl_test.go
@@ -365,7 +365,7 @@ func TestAgentCtlSecureGrpc(t *testing.T) {
 }
 
 func TestAgentCtlSecureETCD(t *testing.T) {
-	ctx := Setup(t, WithEtcd(WithEtcdHTTPsConnection(), WithEtcdVPPAgentContainerNetworking()))
+	ctx := Setup(t, WithEtcd(WithEtcdHTTPsConnection(), WithEtcdTestContainerNetworking()))
 	defer ctx.Teardown()
 
 	// test without any TLS

--- a/tests/e2e/100_agentctl_test.go
+++ b/tests/e2e/100_agentctl_test.go
@@ -365,10 +365,8 @@ func TestAgentCtlSecureGrpc(t *testing.T) {
 }
 
 func TestAgentCtlSecureETCD(t *testing.T) {
-	ctx := Setup(t)
+	ctx := Setup(t, WithEtcd(), WithEtcdHTTPsConnection(), WithEtcdVPPAgentContainerNetworking())
 	defer ctx.Teardown()
-	etcdID := ctx.StartEtcd()
-	defer ctx.StopEtcd(etcdID)
 
 	// test without any TLS
 	t.Run("no TLS", func(t *testing.T) {

--- a/tests/e2e/e2e.go
+++ b/tests/e2e/e2e.go
@@ -161,7 +161,8 @@ func Setup(t *testing.T, options ...SetupOptModifier) *TestCtx {
 
 	// setup Etcd
 	if opt.SetupEtcd {
-		testCtx.Etcd = NewEtcdContainer(testCtx, extractEtcdOptions(opt))
+		testCtx.Etcd, err = NewEtcdContainer(testCtx, extractEtcdOptions(opt))
+		Expect(err).ShouldNot(HaveOccurred())
 	}
 
 	if opt.SetupAgent {
@@ -253,7 +254,9 @@ func (test *TestCtx) Teardown() {
 
 	// terminate etcd
 	if test.Etcd != nil {
-		test.Etcd.Terminate()
+		if err := test.Etcd.Terminate(); err != nil {
+			test.t.Logf("failed to terminate ETCD: %v", err)
+		}
 	}
 }
 

--- a/tests/e2e/etcd.go
+++ b/tests/e2e/etcd.go
@@ -15,73 +15,189 @@
 package e2e
 
 import (
-	"path/filepath"
+	"bytes"
+	"os"
 
 	docker "github.com/fsouza/go-dockerclient"
 )
 
-func (test *TestCtx) pullEtcd() {
-	err := test.dockerClient.PullImage(docker.PullImageOptions{
+// Setup options constants
+const (
+	HTTPsConnection             = "HTTPsConnection"
+	VPPAgentContainerNetworking = "VPPAgentContainerNetworking"
+)
+
+// EtcdContainer is represents running ETCD container
+type EtcdContainer struct {
+	ctx         *TestCtx
+	containerID string
+}
+
+// NewEtcdContainer creates and starts new ETCD container
+func NewEtcdContainer(ctx *TestCtx, options ...*Option) *EtcdContainer {
+	ec := &EtcdContainer{
+		ctx: ctx,
+	}
+	container := ec.create(ctx, options...)
+	ec.start(ctx, container)
+	ec.containerID = container.ID
+	return ec
+}
+
+// Put inserts key-value pair into the ETCD inside its running docker container
+func (ec *EtcdContainer) Put(key string, value string) error {
+	_, err := ec.exec("etcdctl", "put", key, value)
+	return err
+}
+
+// Get retrieves value for the key from the ETCD that is running in its docker container
+func (ec *EtcdContainer) Get(key string) (string, error) {
+	return ec.exec("etcdctl", "get", key)
+}
+
+// Get retrieves all key-value pairs from the ETCD that is running in its docker container
+func (ec *EtcdContainer) GetAll() (string, error) {
+	return ec.exec("etcdctl", "get", "", "--prefix=true")
+}
+
+// Inspect provides docker.Container of running ETCD container that can be
+// used to inspect various things about ETCD container
+func (ec *EtcdContainer) Inspect() *docker.Container {
+	container, err := ec.ctx.dockerClient.InspectContainer(ec.containerID)
+	if err != nil {
+		ec.ctx.t.Fatalf("failed to inspect container with ID %v due to: %v", ec.containerID, err)
+	}
+	return container
+}
+
+func (ec *EtcdContainer) create(ctx *TestCtx, options ...*Option) *docker.Container {
+	optionsMap := optionsMap(options)
+
+	// pull image
+	err := ctx.dockerClient.PullImage(docker.PullImageOptions{
 		Repository: etcdImage,
 		Tag:        "latest",
 	}, docker.AuthConfiguration{})
 	if err != nil {
-		test.t.Fatalf("failed to pull ETCD image: %v", err)
+		ctx.t.Fatalf("failed to pull ETCD image: %v", err)
+	}
+
+	// construct command string and container host config
+	cmd := []string{
+		"/usr/local/bin/etcd",
+	}
+	hostConfig := &docker.HostConfig{}
+	if _, found := optionsMap[HTTPsConnection]; found {
+		cmd = append(cmd,
+			"--client-cert-auth",
+			"--trusted-ca-file=/etc/certs/ca.pem",
+			"--cert-file=/etc/certs/cert1.pem",
+			"--key-file=/etc/certs/cert1-key.pem",
+			"--advertise-client-urls=https://127.0.0.1:2379",
+			"--listen-client-urls=https://127.0.0.1:2379",
+		)
+		hostConfig.Binds = []string{os.Getenv("CERTS_PATH") + ":/etc/certs"}
+	} else { // HTTP connection
+		cmd = append(cmd,
+			"--advertise-client-urls=http://0.0.0.0:2379",
+			"--listen-client-urls=http://0.0.0.0:2379",
+		)
+	}
+	if _, found := optionsMap[VPPAgentContainerNetworking]; found {
+		hostConfig.NetworkMode = "container:vpp-agent-e2e-test"
+	} else { // separate container networking (default)
+		hostConfig.PortBindings = map[docker.Port][]docker.PortBinding{
+			"2379/tcp": {{HostIP: "0.0.0.0", HostPort: "2379"}},
+		}
+	}
+
+	// create container
+	container, err := ctx.dockerClient.CreateContainer(docker.CreateContainerOptions{
+		Name: "e2e-test-etcd",
+		Config: &docker.Config{
+			Env:   []string{"ETCDCTL_API=3"},
+			Image: etcdImage,
+			Cmd:   cmd,
+		},
+		HostConfig: hostConfig,
+	})
+	if err != nil {
+		ctx.t.Fatalf("failed to create ETCD container: %v", err)
+	}
+	return container
+}
+
+// WithEtcdHTTPsConnection is ETCD test setup option that will use HTTPS connection to ETCD (by default it is used
+// unsecure HTTP connection)
+func WithEtcdHTTPsConnection() *Option {
+	return &Option{
+		key:   HTTPsConnection,
+		value: struct{}{}, // only presence is needed
 	}
 }
 
-func (test *TestCtx) StartEtcd() string {
-	container, err := test.dockerClient.CreateContainer(docker.CreateContainerOptions{
-		Name: "e2e-test-etcd",
-		Config: &docker.Config{
-			Image: etcdImage,
-			Env:   []string{"ETCDCTL_API=3"},
-			Cmd: []string{
-				"/usr/local/bin/etcd",
-				"--client-cert-auth",
-				"--trusted-ca-file=/etc/certs/ca.pem",
-				"--cert-file=/etc/certs/cert1.pem",
-				"--key-file=/etc/certs/cert1-key.pem",
-				"--advertise-client-urls=https://127.0.0.1:2379",
-				"--listen-client-urls=https://127.0.0.1:2379",
-			},
-		},
-		HostConfig: &docker.HostConfig{
-			NetworkMode: "container:vpp-agent-e2e-test",
-			Binds: []string{
-				filepath.Join(test.testDataDir, "certs") + ":/etc/certs:ro",
-			},
-		},
-	})
-	if err != nil {
-		test.t.Fatalf("failed to create ETCD container: %v", err)
+// WithEtcdVPPAgentContainerNetworking is ETCD test setup option that will use VPP-Agent test container for
+// networking (by default the ETCD has separate networking)
+func WithEtcdVPPAgentContainerNetworking() *Option {
+	return &Option{
+		key:   VPPAgentContainerNetworking,
+		value: struct{}{}, // only presence is needed
 	}
-	err = test.dockerClient.StartContainer(container.ID, nil)
+}
+
+func (ec *EtcdContainer) start(ctx *TestCtx, container *docker.Container) {
+	err := ctx.dockerClient.StartContainer(container.ID, nil)
 	if err != nil {
-		err = test.dockerClient.RemoveContainer(docker.RemoveContainerOptions{
+		err = ctx.dockerClient.RemoveContainer(docker.RemoveContainerOptions{
 			ID:    container.ID,
 			Force: true,
 		})
 		if err != nil {
-			test.t.Errorf("failed to remove ETCD container: %v", err)
+			ctx.t.Errorf("failed to remove ETCD container: %v", err)
 		}
-		test.t.Fatalf("failed to start ETCD container: %v", err)
+		ctx.t.Fatalf("failed to start ETCD container: %v", err)
 	}
-	test.t.Logf("started ETCD container %v", container.ID)
-	return container.ID
+	ctx.t.Logf("started ETCD container %v", container.ID)
 }
 
-func (test *TestCtx) StopEtcd(id string) {
-	err := test.dockerClient.StopContainer(id, msStopTimeout)
+// Terminate stops and removes the ETCD container
+func (ec *EtcdContainer) Terminate(ctx *TestCtx) {
+	ec.stop(ctx)
+	ec.remove(ctx)
+}
+
+func (ec *EtcdContainer) stop(ctx *TestCtx) {
+	err := ctx.dockerClient.StopContainer(ec.containerID, msStopTimeout)
 	if err != nil {
-		test.t.Logf("failed to stop ETCD container: %v", err)
+		ctx.t.Logf("failed to stop ETCD container: %v", err)
 	}
-	err = test.dockerClient.RemoveContainer(docker.RemoveContainerOptions{
-		ID:    id,
+}
+
+func (ec *EtcdContainer) remove(ctx *TestCtx) {
+	err := ctx.dockerClient.RemoveContainer(docker.RemoveContainerOptions{
+		ID:    ec.containerID,
 		Force: true,
 	})
 	if err != nil {
-		test.t.Fatalf("failed to remove ETCD container: %v", err)
+		ctx.t.Fatalf("failed to remove ETCD container: %v", err)
 	}
-	test.t.Logf("removed ETCD container %v", id)
+	ctx.t.Logf("removed ETCD container %v", ec.containerID)
+}
+
+// exec executes command inside Etcd container
+func (ec *EtcdContainer) exec(cmdName string, args ...string) (output string, err error) {
+	execCtx, err := ec.ctx.dockerClient.CreateExec(docker.CreateExecOptions{
+		AttachStdout: true,
+		Cmd:          append([]string{cmdName}, args...),
+		Container:    ec.containerID,
+	})
+	if err != nil {
+		ec.ctx.t.Fatalf("failed to create docker exec instance for exec in etcd container: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	err = ec.ctx.dockerClient.StartExec(execCtx.ID, docker.StartExecOptions{
+		OutputStream: &stdout,
+	})
+	return stdout.String(), err
 }

--- a/tests/e2e/options.go
+++ b/tests/e2e/options.go
@@ -1,0 +1,202 @@
+// Copyright (c) 2020 Pantheon.tech
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	docker "github.com/fsouza/go-dockerclient"
+	. "github.com/onsi/gomega"
+	"go.ligato.io/cn-infra/v2/logging"
+)
+
+const vppAgentDefaultImg = "ligato/vpp-agent:latest"
+
+// SetupOpt is options data holder for customizing setup of tests
+type SetupOpt struct {
+	*AgentOpt
+	*EtcdOpt
+	SetupAgent bool
+	SetupEtcd  bool
+}
+
+// AgentOpt is options data holder for customizing setup of agent
+type AgentOpt struct {
+	Image                 string
+	Env                   []string
+	UseEtcd               bool
+	NoManualInitialResync bool
+	ContainerOptsHook     func(*docker.CreateContainerOptions)
+}
+
+// EtcdOpt is options data holder for customizing setup of ETCD
+type EtcdOpt struct {
+	UseHTTPS                       bool
+	UseAgentContainerForNetworking bool
+}
+
+// SetupOptModifier is function customizing general setup options
+type SetupOptModifier func(*SetupOpt)
+
+// AgentOptModifier is function customizing Agent setup options
+type AgentOptModifier func(*AgentOpt)
+
+// EtcdOptModifier is function customizing ETCD seup options
+type EtcdOptModifier func(*EtcdOpt)
+
+// DefaultSetupOpt creates default values for SetupOpt
+func DefaultSetupOpt() *SetupOpt {
+	opt := &SetupOpt{
+		AgentOpt:   DefaultAgentOpt(),
+		EtcdOpt:    DefaultEtcdOpt(),
+		SetupAgent: true,
+		SetupEtcd:  false,
+	}
+	return opt
+}
+
+// DefaultEtcdOpt creates default values for EtcdOpt
+func DefaultEtcdOpt() *EtcdOpt {
+	return &EtcdOpt{
+		UseHTTPS:                       false,
+		UseAgentContainerForNetworking: false,
+	}
+}
+
+// DefaultAgentOpt creates default values for AgentOpt
+func DefaultAgentOpt() *AgentOpt {
+	agentImg := vppAgentDefaultImg
+	if img := os.Getenv("VPP_AGENT"); img != "" {
+		agentImg = img
+	}
+	grpcConfig := "grpc.conf"
+	if val := os.Getenv("GRPC_CONFIG"); val != "" {
+		grpcConfig = val
+	}
+	etcdConfig := "DISABLED"
+	if val := os.Getenv("ETCD_CONFIG"); val != "" {
+		etcdConfig = val
+	}
+	opt := &AgentOpt{
+		Image:                 agentImg,
+		UseEtcd:               false,
+		NoManualInitialResync: false,
+		Env: []string{
+			"INITIAL_LOGLVL=" + logging.DefaultLogger.GetLevel().String(),
+			"ETCD_CONFIG=" + etcdConfig,
+			"GRPC_CONFIG=" + grpcConfig,
+		},
+	}
+	return opt
+}
+
+// WithoutVPPAgent is test setup option disabling vpp-agent setup
+func WithoutVPPAgent() SetupOptModifier {
+	return func(o *SetupOpt) {
+		o.SetupAgent = false
+	}
+}
+
+// WithEtcd is test setup option enabling vpp-agent setup
+func WithEtcd(etcdOpts ...EtcdOptModifier) SetupOptModifier {
+	return func(o *SetupOpt) {
+		o.SetupEtcd = true
+		if o.EtcdOpt == nil {
+			o.EtcdOpt = DefaultEtcdOpt()
+		}
+		for _, etcdOptModifier := range etcdOpts {
+			etcdOptModifier(o.EtcdOpt)
+		}
+	}
+}
+
+// WithoutManualInitialAgentResync is test setup option disabling manual agent resync just after agent setup
+func WithoutManualInitialAgentResync() AgentOptModifier {
+	return func(o *AgentOpt) {
+		o.NoManualInitialResync = true
+	}
+}
+
+// WithAdditionalAgentCmdParams is test setup option adding additional command line parameters to executing vpp-agent
+func WithAdditionalAgentCmdParams(params ...string) AgentOptModifier {
+	return func(o *AgentOpt) {
+		o.Env = append(o.Env, params...)
+	}
+}
+
+// WithPluginConfigArg persists configContent for give VPP-Agent plugin (expecting generic plugin config name)
+// and returns argument for VPP-Agent executable to use this plugin configuration file.
+func WithPluginConfigArg(ctx *TestCtx, pluginName string, configContent string) string {
+	configFilePath := CreateFileOnSharedVolume(ctx, fmt.Sprintf("%v.config", pluginName), configContent)
+	return fmt.Sprintf("%v_CONFIG=%v", strings.ToUpper(pluginName), configFilePath)
+}
+
+// FIXME container that will use it can have it mounted in different location as seen by the container where
+//  it is created (this works now due to the same mountpoint of shared volume in every container)
+
+// CreateFileOnSharedVolume persists fileContent to file in mounted shared volume used for sharing file
+// between containers. It returns the absolute path to the newly created file as seen by the container
+// that creates it.
+func CreateFileOnSharedVolume(ctx *TestCtx, simpleFileName string, fileContent string) string {
+	filePath, err := filepath.Abs(filepath.Join(ctx.testShareDir,
+		fmt.Sprintf("e2e-test-%v-%v", ctx.t.Name(), simpleFileName)))
+	Expect(err).To(Not(HaveOccurred()))
+	Expect(ioutil.WriteFile(filePath, []byte(fileContent), 0777)).To(Succeed())
+
+	// TODO register in context and delete in teardown? this doesn't matter
+	//  that much because file names contain unique test names so no file collision can happen
+	return filePath
+}
+
+// WithEtcdHTTPsConnection is ETCD test setup option that will use HTTPS connection to ETCD (by default it is used
+// unsecure HTTP connection)
+func WithEtcdHTTPsConnection() EtcdOptModifier {
+	return func(o *EtcdOpt) {
+		o.UseHTTPS = true
+	}
+}
+
+// WithEtcdVPPAgentContainerNetworking is ETCD test setup option that will use VPP-Agent test container for
+// networking (by default the ETCD has separate networking)
+func WithEtcdVPPAgentContainerNetworking() EtcdOptModifier {
+	return func(o *EtcdOpt) {
+		o.UseAgentContainerForNetworking = true
+	}
+}
+
+func extractEtcdOptions(opt *SetupOpt) EtcdOptModifier {
+	return func(etcdOpt *EtcdOpt) {
+		copyOptions(etcdOpt, opt.EtcdOpt)
+	}
+}
+
+func extractAgentOptions(opt *SetupOpt) AgentOptModifier {
+	return func(agentOpt *AgentOpt) {
+		copyOptions(agentOpt, opt.AgentOpt)
+	}
+}
+
+func copyOptions(to interface{}, from interface{}) {
+	fromVal := reflect.ValueOf(from).Elem()
+	toVal := reflect.ValueOf(to).Elem()
+	for i := 0; i < fromVal.NumField(); i++ {
+		toVal.Field(i).Set(fromVal.Field(i))
+	}
+}

--- a/tests/e2e/options.go
+++ b/tests/e2e/options.go
@@ -48,8 +48,8 @@ type AgentOpt struct {
 
 // EtcdOpt is options data holder for customizing setup of ETCD
 type EtcdOpt struct {
-	UseHTTPS                       bool
-	UseAgentContainerForNetworking bool
+	UseHTTPS                      bool
+	UseTestContainerForNetworking bool
 }
 
 // SetupOptModifier is function customizing general setup options
@@ -75,8 +75,8 @@ func DefaultSetupOpt() *SetupOpt {
 // DefaultEtcdOpt creates default values for EtcdOpt
 func DefaultEtcdOpt() *EtcdOpt {
 	return &EtcdOpt{
-		UseHTTPS:                       false,
-		UseAgentContainerForNetworking: false,
+		UseHTTPS:                      false,
+		UseTestContainerForNetworking: false,
 	}
 }
 
@@ -173,11 +173,11 @@ func WithEtcdHTTPsConnection() EtcdOptModifier {
 	}
 }
 
-// WithEtcdVPPAgentContainerNetworking is ETCD test setup option that will use VPP-Agent test container for
+// WithEtcdTestContainerNetworking is ETCD test setup option that will use main Test container for
 // networking (by default the ETCD has separate networking)
-func WithEtcdVPPAgentContainerNetworking() EtcdOptModifier {
+func WithEtcdTestContainerNetworking() EtcdOptModifier {
 	return func(o *EtcdOpt) {
-		o.UseAgentContainerForNetworking = true
+		o.UseTestContainerForNetworking = true
 	}
 }
 

--- a/tests/e2e/run_e2e.sh
+++ b/tests/e2e/run_e2e.sh
@@ -15,6 +15,7 @@ export DOCKER_BUILDKIT=1
 testname="vpp-agent-e2e-test"
 imgname="vpp-agent-e2e-tests"
 etcdcontainername="e2e-test-etcd"
+sharevolumename="share-for-vpp-agent-e2e-tests"
 
 # Compile agentctl for testing
 go build -o ./tests/e2e/agentctl.test \
@@ -54,10 +55,29 @@ cleanup() {
     set -x
     docker stop -t 1 "${etcdcontainername}" 2>/dev/null
     docker rm -v "${etcdcontainername}" 2>/dev/null
+    set +x
   fi
+
+  echo "Removing volume for sharing files between containers"
+  if [ "$(docker volume ls | grep "${sharevolumename}")" ]; then
+    set -x
+    docker volume rm -f "${sharevolumename}"
+    set +x
+  fi
+
 }
 
 trap 'cleanup' EXIT
+
+echo "Creating volume for sharing files between containers.."
+if docker volume create "${sharevolumename}"
+then
+	echo >&2 -e " \e[32m...created\e[0m"
+else
+	res=$?
+	echo >&2 -e " \e[31m...volume creation failed!\e[0m (exit code: $res)"
+	exit $res
+fi
 
 vppver=$(docker run --rm -i "$VPP_AGENT" dpkg-query -f '${Version}' -W vpp)
 
@@ -80,6 +100,7 @@ if docker run -it \
 	--label io.ligato.vpp-agent.testname="${testname}" \
 	--volume "${TESTDATA_DIR}":/testdata:ro \
 	--volume /var/run/docker.sock:/var/run/docker.sock \
+	--volume "${sharevolumename}":/test-share \
 	--env TESTDATA_DIR \
 	--env INITIAL_LOGLVL \
 	--env VPP_AGENT \

--- a/tests/e2e/run_e2e.sh
+++ b/tests/e2e/run_e2e.sh
@@ -72,10 +72,10 @@ trap 'cleanup' EXIT
 echo "Creating volume for sharing files between containers.."
 if docker volume create "${sharevolumename}"
 then
-	echo >&2 -e " \e[32m...created\e[0m"
+	echo >&2 -e "\e[32m...created\e[0m"
 else
 	res=$?
-	echo >&2 -e " \e[31m...volume creation failed!\e[0m (exit code: $res)"
+	echo >&2 -e "\e[31m...volume creation failed!\e[0m (exit code: $res)"
 	exit $res
 fi
 

--- a/tests/e2e/run_e2e.sh
+++ b/tests/e2e/run_e2e.sh
@@ -14,6 +14,7 @@ export DOCKER_BUILDKIT=1
 
 testname="vpp-agent-e2e-test"
 imgname="vpp-agent-e2e-tests"
+etcdcontainername="e2e-test-etcd"
 
 # Compile agentctl for testing
 go build -o ./tests/e2e/agentctl.test \
@@ -46,6 +47,14 @@ cleanup() {
 	set -x
 	docker stop -t 1 "${testname}" 2>/dev/null
 	docker rm -v "${testname}" 2>/dev/null
+	set +x
+
+  echo "Stopping etcd container if running"
+  if [ "$(docker ps -a | grep "${etcdcontainername}")" ]; then
+    set -x
+    docker stop -t 1 "${etcdcontainername}" 2>/dev/null
+    docker rm -v "${etcdcontainername}" 2>/dev/null
+  fi
 }
 
 trap 'cleanup' EXIT

--- a/tests/e2e/vppagent.go
+++ b/tests/e2e/vppagent.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,46 +31,9 @@ import (
 )
 
 const (
-	vppAgentDefaultImg = "ligato/vpp-agent:latest"
 	vppAgentLabelKey   = "e2e.test.vppagent"
 	vppAgentNamePrefix = "e2e-test-vppagent-"
 )
-
-type AgentOpt struct {
-	Image                 string
-	Env                   []string
-	UseEtcd               bool
-	NoManualInitialResync bool
-	ContainerOptsHook     func(*docker.CreateContainerOptions)
-}
-
-type AgentOptModifier func(*AgentOpt)
-
-func DefaultAgentOpt() *AgentOpt {
-	agentImg := vppAgentDefaultImg
-	if img := os.Getenv("VPP_AGENT"); img != "" {
-		agentImg = img
-	}
-	grpcConfig := "grpc.conf"
-	if val := os.Getenv("GRPC_CONFIG"); val != "" {
-		grpcConfig = val
-	}
-	etcdConfig := "DISABLED"
-	if val := os.Getenv("ETCD_CONFIG"); val != "" {
-		etcdConfig = val
-	}
-	opt := &AgentOpt{
-		Image:                 agentImg,
-		UseEtcd:               false,
-		NoManualInitialResync: false,
-		Env: []string{
-			"INITIAL_LOGLVL=" + logging.DefaultLogger.GetLevel().String(),
-			"ETCD_CONFIG=" + etcdConfig,
-			"GRPC_CONFIG=" + grpcConfig,
-		},
-	}
-	return opt
-}
 
 type agent struct {
 	*AgentOpt

--- a/tests/e2e/vppagent.go
+++ b/tests/e2e/vppagent.go
@@ -38,11 +38,14 @@ const (
 )
 
 type AgentOpt struct {
-	Image             string
-	Env               []string
-	UseEtcd           bool
-	ContainerOptsHook func(*docker.CreateContainerOptions)
+	Image                 string
+	Env                   []string
+	UseEtcd               bool
+	NoManualInitialResync bool
+	ContainerOptsHook     func(*docker.CreateContainerOptions)
 }
+
+type AgentOptModifier func(*AgentOpt)
 
 func DefaultAgentOpt() *AgentOpt {
 	agentImg := vppAgentDefaultImg
@@ -58,8 +61,9 @@ func DefaultAgentOpt() *AgentOpt {
 		etcdConfig = val
 	}
 	opt := &AgentOpt{
-		Image:   agentImg,
-		UseEtcd: false,
+		Image:                 agentImg,
+		UseEtcd:               false,
+		NoManualInitialResync: false,
 		Env: []string{
 			"INITIAL_LOGLVL=" + logging.DefaultLogger.GetLevel().String(),
 			"ETCD_CONFIG=" + etcdConfig,
@@ -102,6 +106,7 @@ func startAgent(ctx *TestCtx, name string, opt *AgentOpt) (*agent, error) {
 				"/var/run/docker.sock:/var/run/docker.sock",
 				ctx.testDataDir + ":/testdata:ro",
 				filepath.Join(ctx.testDataDir, "certs") + ":/etc/certs:ro",
+				shareVolumeName + ":" + ctx.testShareDir,
 			},
 		},
 	}


### PR DESCRIPTION
Added possibility to define NB configuration as file and to picked up and applied by VPP-Agent at start.
Additional features:
 - file defined as yaml
 - ability to set up also 3rd party models (using the same components as are used for `agentctl config update --replace`, see [this issue](https://github.com/ligato/vpp-agent/issues/1767) for understanding more about 3rd party model definition/problems)
 - by default active, no additional configuration needed to use (create `nb-initial-config.yaml` in vpp-agent working directory, i.e. if you installed vpp-agent binary in one of paths from env.variable then `nb-initial-config.yaml` must be in that directory where you are when you execute vpp-agent binary - if you are still not sure about the location, don't worry, VPP-agent will tell you in debug logging where it expects the file to be by using absolute file path)
 - fully configurable (path to configuration yaml file + feature on/off switch)
 - usable in projects using VPP-Agent as its base (using the updated code in VPP-Agent plugin setup will allow usage of this feature)
 - basic merging capabilities for NB configuration coming from different data sources (NB init file source is just another source among others like etcd and others) - in case of colliding data, other sources have priority to initial NB config file
 - e2e tests (start with NB init file, start with Etcd with data, start with both sources having data and merge colliding data - etcd data is used in the end)