### PR TITLE
fix: Fix metadata Update for Linux interfaces

### DIFF
--- a/plugins/linux/ifplugin/descriptor/interface.go
+++ b/plugins/linux/ifplugin/descriptor/interface.go
@@ -494,17 +494,16 @@ func (d *InterfaceDescriptor) Update(key string, oldLinuxIf, newLinuxIf *interfa
 	oldHostName := getHostIfName(oldLinuxIf)
 	newHostName := getHostIfName(newLinuxIf)
 
-	// update metadata
-	link, err := d.ifHandler.GetLinkByName(newHostName)
-	if err != nil {
-		d.log.Error(err)
-		return nil, err
-	}
-	oldMetadata.LinuxIfIndex = link.Attrs().Index
-	oldMetadata.HostIfName = newHostName
-	oldMetadata.VrfMasterIf = newLinuxIf.VrfMasterInterface
 	if oldLinuxIf.Type == interfaces.Interface_EXISTING {
 		// with existing interface only metadata needs to be updated
+		link, err := d.ifHandler.GetLinkByName(newHostName)
+		if err != nil {
+			d.log.Error(err)
+			return nil, err
+		}
+		oldMetadata.LinuxIfIndex = link.Attrs().Index
+		oldMetadata.HostIfName = newHostName
+		oldMetadata.VrfMasterIf = newLinuxIf.VrfMasterInterface
 		return oldMetadata, nil
 	}
 
@@ -583,6 +582,10 @@ func (d *InterfaceDescriptor) Update(key string, oldLinuxIf, newLinuxIf *interfa
 			}
 		}
 	}
+
+	// update metadata
+	oldMetadata.HostIfName = newHostName
+	oldMetadata.VrfMasterIf = newLinuxIf.VrfMasterInterface
 	return oldMetadata, nil
 }
 

--- a/tests/e2e/012_linux_interfaces_test.go
+++ b/tests/e2e/012_linux_interfaces_test.go
@@ -104,6 +104,14 @@ func TestDummyInterface(t *testing.T) {
 	Expect(ctx.PingFromMs(msName, ipAddr1)).To(Succeed())
 	Expect(ctx.PingFromMs(msName, ipAddr2)).To(Succeed())
 	Expect(ctx.AgentInSync()).To(BeTrue())
+
+	// Disable dummy1
+	dummyIf1.Enabled = false
+	req = ctx.GenericClient().ChangeRequest()
+	err = req.Update(
+		dummyIf1,
+	).Send(context.Background())
+	Expect(err).ToNot(HaveOccurred())
 }
 
 // Test interfaces created externally but with IP addresses assigned by the agent.


### PR DESCRIPTION
Extended one of the e2e tests such that it fails due to this bug. 
With the fix all e2e tests pass successfully.

Signed-off-by: Milan Lenco <milan.lenco@pantheon.tech>