### PR TITLE
fix: Report VPP not responding state as unhealthy status

### DIFF
--- a/plugins/govppmux/plugin_impl_govppmux.go
+++ b/plugins/govppmux/plugin_impl_govppmux.go
@@ -478,6 +478,13 @@ func (p *Plugin) handleVPPConnectionEvents(ctx context.Context) {
 				/*if event.State == govpp.Failed {
 					p.vppConn, p.vppConChan, _ = govpp.AsyncConnect(p.vppAdapter, p.config.RetryConnectCount, p.config.RetryConnectTimeout)
 				}*/
+			} else if event.State == govpp.NotResponding {
+				p.infoMu.Lock()
+				p.vppInfo.Connected = false
+				p.infoMu.Unlock()
+
+				p.lastConnErr = errors.Errorf("VPP is not responding (event: %+v)", event)
+				p.StatusCheck.ReportStateChange(p.PluginName, statuscheck.Error, p.lastConnErr)
 			} else {
 				p.Log.Warnf("unknown VPP connection state: %+v", event)
 			}


### PR DESCRIPTION
This state was added recently to GoVPP but govppmux plugin did not yet recognize it, thus not reporting as unhealthy which in cases can lead to _broken instance_ if the communication with VPP is not restored.