### PR TITLE
feat: added REST API for getting and setting NB VPP-Agent configuration

### DIFF
--- a/pkg/models/model.go
+++ b/pkg/models/model.go
@@ -155,5 +155,5 @@ func (m *LocallyKnownModel) InstanceName(x interface{}) (string, error) {
 	if m.nameFunc == nil {
 		return "", nil
 	}
-	return m.nameFunc(x, m.goType)
+	return m.nameFunc(x)
 }

--- a/pkg/models/registry.go
+++ b/pkg/models/registry.go
@@ -212,10 +212,10 @@ func (r *LocalRegistry) Register(x interface{}, spec Spec, opts ...ModelOption) 
 
 	// Use GetName as fallback for generating name
 	if _, ok := x.(named); ok {
-		model.nameFunc = func(obj interface{}, messageGoType reflect.Type) (s string, e error) {
+		model.nameFunc = func(obj interface{}) (s string, e error) {
 			// handling dynamic messages (they don't implement named interface)
 			if dynMessage, ok := obj.(*dynamicpb.Message); ok {
-				obj, e = DynamicMessageToGeneratedMessage(dynMessage, messageGoType)
+				obj, e = DynamicLocallyKnownMessageToGeneratedMessage(dynMessage)
 				if e != nil {
 					return "", e
 				}

--- a/pkg/models/remote_model.go
+++ b/pkg/models/remote_model.go
@@ -162,7 +162,7 @@ func (m *RemotelyKnownModel) InstanceName(x interface{}) (string, error) {
 		return "", errors.Errorf("can't load json of marshalled "+
 			"message to generic map due to: %v (json=%v)", err, jsonData)
 	}
-	name, err := NameTemplate(nameTemplate)(mapData, nil)
+	name, err := NameTemplate(nameTemplate)(mapData)
 	if err != nil {
 		return "", errors.Errorf("can't compute name from name template by applying generic map "+
 			"due to: %v (name template=%v, generic map=%v)", err, nameTemplate, mapData)

--- a/plugins/kvscheduler/validation.go
+++ b/plugins/kvscheduler/validation.go
@@ -51,7 +51,7 @@ func (s *Scheduler) ValidateSemantically(messages []proto.Message) error {
 					"using KVDescriptor.Validate  (dynamic message=%v)", model.ProtoName(), message)
 				continue
 			}
-			message, err = models.DynamicMessageToGeneratedMessage(dynamicMessage, goType)
+			message, err = models.DynamicLocallyKnownMessageToGeneratedMessage(dynamicMessage)
 			if err != nil {
 				return errors.Errorf("can't convert dynamic message to statically generated message "+
 					"due to: %v (dynamic message=%v)", err, dynamicMessage)

--- a/plugins/orchestrator/localregistry/initfileregistry.go
+++ b/plugins/orchestrator/localregistry/initfileregistry.go
@@ -30,6 +30,7 @@ import (
 	"go.ligato.io/cn-infra/v2/db/keyval"
 	"go.ligato.io/cn-infra/v2/infra"
 	"go.ligato.io/vpp-agent/v3/client"
+	"go.ligato.io/vpp-agent/v3/plugins/orchestrator"
 	"google.golang.org/protobuf/encoding/protojson"
 	protoV2 "google.golang.org/protobuf/proto"
 )
@@ -198,7 +199,7 @@ func (r *InitFileRegistry) watchResync(resyncReg resync.Registration) {
 		// resyncReg.StatusChan == Started => resync
 		if resyncStatus.ResyncStatus() == resync.Started && !r.pushedToWatchedRegistry {
 			if !r.Empty() { // put preloaded NB init file data into watched p.registry
-				c := client.NewClient(&txnFactory{r.watchedRegistry})
+				c := client.NewClient(&txnFactory{r.watchedRegistry}, &orchestrator.DefaultPlugin)
 				if err := c.ResyncConfig(r.preloadedNBConfigs...); err != nil {
 					r.Log.Errorf("resyncing preloaded NB init file data "+
 						"into watched registry failed: %v", err)

--- a/plugins/restapi/options.go
+++ b/plugins/restapi/options.go
@@ -17,12 +17,12 @@ package restapi
 import (
 	"go.ligato.io/cn-infra/v2/rpc/rest"
 	"go.ligato.io/cn-infra/v2/servicelabel"
-	"go.ligato.io/vpp-agent/v3/plugins/kvscheduler"
-
 	"go.ligato.io/vpp-agent/v3/plugins/govppmux"
+	"go.ligato.io/vpp-agent/v3/plugins/kvscheduler"
 	linuxifplugin "go.ligato.io/vpp-agent/v3/plugins/linux/ifplugin"
 	"go.ligato.io/vpp-agent/v3/plugins/linux/nsplugin"
 	"go.ligato.io/vpp-agent/v3/plugins/netalloc"
+	"go.ligato.io/vpp-agent/v3/plugins/orchestrator"
 	"go.ligato.io/vpp-agent/v3/plugins/vpp/aclplugin"
 	"go.ligato.io/vpp-agent/v3/plugins/vpp/ifplugin"
 	"go.ligato.io/vpp-agent/v3/plugins/vpp/l2plugin"
@@ -47,7 +47,8 @@ func NewPlugin(opts ...Option) *Plugin {
 	p.VPPL3Plugin = &l3plugin.DefaultPlugin
 	p.LinuxIfPlugin = &linuxifplugin.DefaultPlugin
 	p.NsPlugin = &nsplugin.DefaultPlugin
-	p.kvscheduler = &kvscheduler.DefaultPlugin
+	p.KVScheduler = &kvscheduler.DefaultPlugin
+	p.Dispatcher = &orchestrator.DefaultPlugin
 
 	for _, o := range opts {
 		o(p)

--- a/plugins/restapi/resturl/urls.go
+++ b/plugins/restapi/resturl/urls.go
@@ -26,7 +26,10 @@ const (
 
 // Configuration
 const (
-	// Validate is a path for validating yaml configuration for VPP-Agent (the same all-in-one dynamically
+	// Configuration is a path for handling(GET,PUT) all VPP-Agent NB configuration
+	Configuration = "/configuration"
+
+	// Validate is a path for validating NB yaml configuration for VPP-Agent (the same all-in-one dynamically
 	// created yaml configuration as used in agentctl configuration get/update)
 	Validate = "/configuration/validate"
 )


### PR DESCRIPTION
Added ability to change NB VPP-Agent configuration by REST API.

- Use GET REST action on `<VPP-Agent IP address>:9191/configuration` to retrieve NB VPP-Agent configuration in YAML format.
- Use PUT REST action on `<VPP-Agent IP address>:9191/configuration` with configuration to update in YAML format in http body to update NB VPP-Agent configuration.
- Also resync is possible by using PUT REST action on `<VPP-Agent IP address>:9191/configuration?replace=true` (`<VPP-Agent IP address>:9191/configuration?replace` will do the same).

The structure of YAML in all cases is the same as for `agentctl config ...` commands. Basically, it can be viewed as REST API equivalent to `agentctl config get`, `agentctl config update`, `agentctl config update --replace`. However, the REST API output is always YAML and can't be formatted to alternative formats as in case of `agentctl` tool.

<del>There are some code dependencies to not yet merged PR https://github.com/ligato/vpp-agent/pull/1786, therefore this PR is based on the commits of that PR. That means that commits of both PRs are visible here.</del> (rebased on master)