### PR TITLE
docs: Fix documentation comment formatting

### DIFF
--- a/proto/ligato/vpp/interfaces/interface.proto
+++ b/proto/ligato/vpp/interfaces/interface.proto
@@ -420,7 +420,7 @@ message WireguardLink {
   string src_addr = 4  [(ligato_options).type = IP];
 }
 
-// https://github.com/FDio/vpp/blob/master/src/plugins/rdma/rdma_doc.md
+// https://github.com/FDio/vpp/blob/master/src/plugins/rdma/rdma_doc.rst
 message RDMALink {
     enum Mode {
         AUTO = 0;

--- a/proto/ligato/vpp/interfaces/interface.proto
+++ b/proto/ligato/vpp/interfaces/interface.proto
@@ -298,8 +298,8 @@ message IPSecLink {
 
 // VmxNet3Link defines configuration for interface type: VMXNET3_INTERFACE
 // PCI address (unsigned 32bit int) is derived from vmxnet3 interface name. It is expected that the interface
-// name is in format "vmxnet3-<d>/<b>/<s>/<f>", where 'd' stands for domain (max ffff), 'b' is bus (max ff),
-// 's' is slot (max 1f) and 'f is function' (max 7). All values are base 16
+// name is in format `vmxnet3-<d>/<b>/<s>/<f>`, where `d` stands for domain (max ffff), `b` is bus (max ff),
+// `s` is slot (max 1f) and `f` is function (max 7). All values are base 16
 message VmxNet3Link {
     // Turn on elog
     bool enable_elog = 2;


### PR DESCRIPTION
Fixes https://github.com/PANTHEONtech/StoneWork/issues/15.

Replaces `'` with backtick quotes so that Markdown doesn't interpret the text inside.

Also fixes a broken link unrelated to the issue above.