### PR TITLE
fix: remove unnecessary print statement

### DIFF
--- a/plugins/telemetry/vppcalls/vpp2101/telemetry_vppcalls.go
+++ b/plugins/telemetry/vppcalls/vpp2101/telemetry_vppcalls.go
@@ -278,7 +278,6 @@ func (h *TelemetryHandler) GetThreads(ctx context.Context) (*vppcalls.ThreadsInf
 	}
 	var items []vppcalls.ThreadsItem
 	for _, thread := range threads {
-		fmt.Printf("thread: %v", thread)
 		items = append(items, vppcalls.ThreadsItem{
 			Name:      thread.Name,
 			ID:        thread.ID,

--- a/plugins/telemetry/vppcalls/vpp2106/telemetry_vppcalls.go
+++ b/plugins/telemetry/vppcalls/vpp2106/telemetry_vppcalls.go
@@ -278,7 +278,6 @@ func (h *TelemetryHandler) GetThreads(ctx context.Context) (*vppcalls.ThreadsInf
 	}
 	var items []vppcalls.ThreadsItem
 	for _, thread := range threads {
-		fmt.Printf("thread: %v", thread)
 		items = append(items, vppcalls.ThreadsItem{
 			Name:      thread.Name,
 			ID:        thread.ID,

--- a/plugins/telemetry/vppcalls/vpp2202/telemetry_vppcalls.go
+++ b/plugins/telemetry/vppcalls/vpp2202/telemetry_vppcalls.go
@@ -278,7 +278,6 @@ func (h *TelemetryHandler) GetThreads(ctx context.Context) (*vppcalls.ThreadsInf
 	}
 	var items []vppcalls.ThreadsItem
 	for _, thread := range threads {
-		fmt.Printf("thread: %v", thread)
 		items = append(items, vppcalls.ThreadsItem{
 			Name:      thread.Name,
 			ID:        thread.ID,


### PR DESCRIPTION
It seems to me that these print statements shouldn't be there.
VPP 2005 and 2009 files don't have them either.