### PR TITLE
Fix `agentctl report` command failing in StoneWork

### DIFF
--- a/cmd/agentctl/commands/report.go
+++ b/cmd/agentctl/commands/report.go
@@ -431,8 +431,12 @@ func writeKVschedulerReport(subTaskActionName string, view string, ignoreModels 
 			View:      view,
 		})
 		if err != nil {
-			errs = append(errs, fmt.Errorf("Failed to get data for %s view and "+
-				"key prefix %s due to: %v\n", view, keyPrefix, err))
+			if strings.Contains(err.Error(), "no descriptor found matching the key prefix") {
+				cli.Out().Write([]byte(fmt.Sprintf("Skipping key prefix %s due to: %v\n", keyPrefix, err)))
+			} else {
+				errs = append(errs, fmt.Errorf("Failed to get data for %s view and "+
+					"key prefix %s due to: %v\n", view, keyPrefix, err))
+			}
 			continue
 		}
 		dumps = append(dumps, dump...)

--- a/plugins/kvscheduler/plugin_scheduler.go
+++ b/plugins/kvscheduler/plugin_scheduler.go
@@ -416,7 +416,7 @@ func (s *Scheduler) getDescriptorForKeyPrefix(keyPrefix string) string {
 func (s *Scheduler) DumpValuesByKeyPrefix(keyPrefix string, view kvs.View) (values []kvs.KVWithMetadata, err error) {
 	descriptorName := s.getDescriptorForKeyPrefix(keyPrefix)
 	if descriptorName == "" {
-		err = errors.New("unknown key prefix")
+		err = errors.New("no descriptor found matching the key prefix")
 		return
 	}
 	return s.DumpValuesByDescriptor(descriptorName, view)

--- a/plugins/kvscheduler/rest.go
+++ b/plugins/kvscheduler/rest.go
@@ -450,12 +450,18 @@ func (s *Scheduler) dumpGetHandler(formatter *render.Render) http.HandlerFunc {
 		var dump []kvs.KVWithMetadata
 		if descriptor != "" {
 			dump, err = s.DumpValuesByDescriptor(descriptor, view)
+
+			if err != nil {
+				s.logError(formatter.JSON(w, http.StatusInternalServerError, errorString{err.Error()}))
+				return
+			}
 		} else {
 			dump, err = s.DumpValuesByKeyPrefix(keyPrefix, view)
-		}
-		if err != nil {
-			s.logError(formatter.JSON(w, http.StatusInternalServerError, errorString{err.Error()}))
-			return
+
+			if err != nil {
+				s.logError(formatter.JSON(w, http.StatusNotFound, errorString{err.Error()}))
+				return
+			}
 		}
 		s.logError(formatter.JSON(w, http.StatusOK, kvsWithMetaForREST(dump)))
 	}


### PR DESCRIPTION
`agentctl report` command fails when run against [StoneWork](https://github.com/PANTHEONtech/StoneWork) with this error message:
```
Retrieving agent kvscheduler NB configuration... Error... (this error will be part of the report zip file, see _failed-reports.txt):
dumping kvscheduler data failed due to:
Failed to get data for NB view and key prefix config/vpp/dns/v1/dnscache due to: Error response from daemon: [500] {
  "Error": "unknown key prefix"
}
, Failed to get data for NB view and key prefix config/vpp/ipfix/v2/flowprobe-feature/ due to: Error response from daemon: [500] {
  "Error": "unknown key prefix"
}
, Failed to get data for NB view and key prefix config/vpp/ipfix/v2/flowprobe-params due to: Error response from daemon: [500] {
  "Error": "unknown key prefix"
}
, Failed to get data for NB view and key prefix config/vpp/ipfix/v2/ipfix due to: Error response from daemon: [500] {
  "Error": "unknown key prefix"
}
, Failed to get data for NB view and key prefix config/vpp/wg/v1/peer/ due to: Error response from daemon: [500] {
  "Error": "unknown key prefix"
} 
```
`agentctl` is getting prefixes from all registered models and then searches for their corresponding descriptors. However, some models are registered even though they don't have registered their descriptor. This is normal and expected. That's why this PR tries to "suppress" the error messages. They still appear, but don't result in failure of the `report` command. The PR also changes some of the messages and the server status code.

Signed-off-by: Samuel Dudík <samuel.dudik@pantheon.tech>