### PR TITLE
fix: agentctl config history not working with remote models

### DIFF
--- a/cmd/agentctl/commands/config.go
+++ b/cmd/agentctl/commands/config.go
@@ -590,7 +590,10 @@ func runConfigHistory(cli agentcli.Cli, opts ConfigHistoryOptions) (err error) {
 	if err != nil {
 		return err
 	}
-	knownModels, _ := gc.KnownModels("config")
+	knownModels, err := gc.KnownModels("config")
+	if err != nil {
+		return fmt.Errorf("getting registered models: %w", err)
+	}
 
 	// register the remote config models into the global default registry
 	for _, km := range knownModels {

--- a/cmd/agentctl/commands/config.go
+++ b/cmd/agentctl/commands/config.go
@@ -35,6 +35,7 @@ import (
 	"go.ligato.io/vpp-agent/v3/client"
 	"go.ligato.io/vpp-agent/v3/cmd/agentctl/api/types"
 	agentcli "go.ligato.io/vpp-agent/v3/cmd/agentctl/cli"
+	"go.ligato.io/vpp-agent/v3/pkg/models"
 	kvs "go.ligato.io/vpp-agent/v3/plugins/kvscheduler/api"
 	"go.ligato.io/vpp-agent/v3/proto/ligato/configurator"
 	"go.ligato.io/vpp-agent/v3/proto/ligato/kvscheduler"
@@ -581,6 +582,23 @@ func runConfigHistory(cli agentcli.Cli, opts ConfigHistoryOptions) (err error) {
 		ref, err = strconv.Atoi(opts.TxnRef)
 		if err != nil {
 			return fmt.Errorf("invalid reference: %q, use number > 0", opts.TxnRef)
+		}
+	}
+
+	// get remote config models from generic client
+	gc, err := cli.Client().GenericClient()
+	if err != nil {
+		return err
+	}
+	knownModels, _ := gc.KnownModels("config")
+
+	// register the remote config models into the global default registry
+	for _, km := range knownModels {
+		kmSpec := models.ToSpec(km.GetSpec())
+		if _, err = models.DefaultRegistry.GetModel(kmSpec.ModelName()); err != nil {
+			if _, err = models.DefaultRegistry.Register(km, kmSpec); err != nil {
+				return fmt.Errorf("registering model failed: %w", err)
+			}
 		}
 	}
 

--- a/plugins/kvscheduler/internal/utils/record.go
+++ b/plugins/kvscheduler/internal/utils/record.go
@@ -87,7 +87,7 @@ func (p *RecordedProtoMessage) UnmarshalJSON(data []byte) error {
 	msgType, err := typeRegistry.FindMessageByName(fullMsgName)
 	if err != nil {
 		// if not found use the proto global types registry as a fallback
-		logging.Debugf("cannot get message type from default registry: %v", err)
+		logging.Debugf("cannot get message type for message name %s from default registry: %v", fullMsgName, err)
 		msgType, err = protoregistry.GlobalTypes.FindMessageByName(fullMsgName)
 	}
 	if err != nil {

--- a/plugins/kvscheduler/internal/utils/record.go
+++ b/plugins/kvscheduler/internal/utils/record.go
@@ -17,6 +17,7 @@ package utils
 import (
 	"encoding/json"
 
+	"go.ligato.io/cn-infra/v2/logging"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
@@ -80,10 +81,13 @@ func (p *RecordedProtoMessage) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
+	// try to find the message type in the default registry
 	typeRegistry := models.DefaultRegistry.MessageTypeRegistry()
 	fullMsgName := protoreflect.FullName(pwn.ProtoMsgName)
 	msgType, err := typeRegistry.FindMessageByName(fullMsgName)
 	if err != nil {
+		// if not found use the proto global types registry as a fallback
+		logging.Debugf("cannot get message type from default registry: %v", err)
 		msgType, err = protoregistry.GlobalTypes.FindMessageByName(fullMsgName)
 	}
 	if err != nil {


### PR DESCRIPTION
When calling agentctl config history, just query the remote models with
grpc client and add them to the global default model registry.
Then when we unmarshal the messages we primarily use the default registry and
the proto global registry is used as a fallback.

Signed-off-by: Peter Motičák <peter.moticak@pantheon.tech>