### PR TITLE
fix: Pin delve version to v1.9.0

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -93,7 +93,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN mkdir -p "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 
 # Install debugger
-RUN go get -u github.com/go-delve/delve/cmd/dlv && dlv version
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.9.0 && dlv version
 
 # Copy configs
 COPY \


### PR DESCRIPTION
Some dependency of delve debugger got recently upgraded and as a result delve requires Go 1.18.
That broke the dev-image build as we still use Go 1.17.6. This PR pins the delve version to 1.9.0 so that the dev-image build succeeds.

Signed-off-by: Peter Motičák <peter.moticak@pantheon.tech>