### PR TITLE
fix-graph-bug

### DIFF
--- a/plugins/kvscheduler/internal/graph/node_write.go
+++ b/plugins/kvscheduler/internal/graph/node_write.go
@@ -369,6 +369,9 @@ func (node *node) removeFromTarget(key, relation, label string) {
 
 // removeFromSources removes given key from the sources for the given relation.
 func (node *node) removeFromSources(relation, label, key string) {
+	if node.sources == nil {
+		return
+	}
 	t, idx := node.sources.GetTargetForLabel(relation, label)
 	updated := t.MatchingKeys.Del(key)
 	if updated {


### PR DESCRIPTION
node.sources could be nil occasionally. Not sure how it happens. But it is safe to do a nil judgement.

Issue link: https://github.com/ligato/vpp-agent/issues/1865