### PR TITLE
test: Add e2e test testing vlan/subinterface functionality

### DIFF
--- a/tests/e2e/010_interfaces_test.go
+++ b/tests/e2e/010_interfaces_test.go
@@ -16,6 +16,7 @@ package e2e
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -24,6 +25,7 @@ import (
 	linux_interfaces "go.ligato.io/vpp-agent/v3/proto/ligato/linux/interfaces"
 	linux_namespace "go.ligato.io/vpp-agent/v3/proto/ligato/linux/namespace"
 	vpp_interfaces "go.ligato.io/vpp-agent/v3/proto/ligato/vpp/interfaces"
+	vpp_l2 "go.ligato.io/vpp-agent/v3/proto/ligato/vpp/l2"
 )
 
 // connect VPP with a microservice via TAP interface
@@ -146,6 +148,238 @@ func TestInterfaceConnTap(t *testing.T) {
 	ctx.Eventually(ctx.PingFromVPPClb(linuxTapIP)).Should(Succeed())
 	ctx.Expect(ctx.PingFromMs(msName, vppTapIP)).To(Succeed())
 	ctx.Expect(ctx.AgentInSync()).To(BeTrue())
+}
+
+func TestMemifSubinterfaceVlanConn(t *testing.T) {
+	ctx := Setup(t, WithoutVPPAgent())
+	defer ctx.Teardown()
+
+	const (
+		vpp1MemifName  = "vpp1-to-vpp2"
+		vpp2MemifName  = "vpp2-to-vpp1"
+		vpp1Subif1Name = "vpp1Subif1"
+		vpp1Subif2Name = "vpp1Subif2"
+		vpp1Subif1IP   = "192.168.1.10"
+		vpp1Subif2IP   = "192.168.2.20"
+		vpp2Subif1Name = "vpp2Subif1"
+		vpp2Subif2Name = "vpp2Subif2"
+		vpp2Tap1Name   = "vpp2-to-ms1"
+		vpp2Tap2Name   = "vpp2-to-ms2"
+		ms1TapName     = "ms1-to-vpp2"
+		ms2TapName     = "ms2-to-vpp2"
+		ms1TapIP       = "192.168.1.1"
+		ms2TapIP       = "192.168.2.2"
+		bd1Name        = "bd1"
+		bd2Name        = "bd2"
+		ms1Name        = "ms1"
+		ms2Name        = "ms2"
+		agent1Name     = "agent1"
+		agent2Name     = "agent2"
+		netMask        = "/24"
+		msTapHostname  = "tap"
+		memifFilepath  = "/test-memif-subif-vlan-conn/memif/"
+		memifSockname  = "memif.sock"
+	)
+
+	if err := os.MkdirAll(shareDir+memifFilepath, os.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+
+	// agent1 configuration
+	vpp1Memif := &vpp_interfaces.Interface{
+		Name:    vpp1MemifName,
+		Type:    vpp_interfaces.Interface_MEMIF,
+		Enabled: true,
+		Link: &vpp_interfaces.Interface_Memif{
+			Memif: &vpp_interfaces.MemifLink{
+				Master:         true,
+				Id:             1,
+				SocketFilename: shareDir + memifFilepath + memifSockname,
+			},
+		},
+	}
+	vpp1Subif1 := &vpp_interfaces.Interface{
+		Name:        vpp1Subif1Name,
+		Type:        vpp_interfaces.Interface_SUB_INTERFACE,
+		Enabled:     true,
+		IpAddresses: []string{vpp1Subif1IP + netMask},
+		Link: &vpp_interfaces.Interface_Sub{
+			Sub: &vpp_interfaces.SubInterface{
+				ParentName:  vpp1MemifName,
+				SubId:       10,
+				TagRwOption: vpp_interfaces.SubInterface_POP1,
+			},
+		},
+	}
+	vpp1Subif2 := &vpp_interfaces.Interface{
+		Name:        vpp1Subif2Name,
+		Type:        vpp_interfaces.Interface_SUB_INTERFACE,
+		Enabled:     true,
+		IpAddresses: []string{vpp1Subif2IP + netMask},
+		Link: &vpp_interfaces.Interface_Sub{
+			Sub: &vpp_interfaces.SubInterface{
+				ParentName:  vpp1MemifName,
+				SubId:       20,
+				TagRwOption: vpp_interfaces.SubInterface_POP1,
+			},
+		},
+	}
+
+	// agent2 configuration
+	vpp2Memif := &vpp_interfaces.Interface{
+		Name:    vpp2MemifName,
+		Type:    vpp_interfaces.Interface_MEMIF,
+		Enabled: true,
+		Link: &vpp_interfaces.Interface_Memif{
+			Memif: &vpp_interfaces.MemifLink{
+				Master:         false,
+				Id:             1,
+				SocketFilename: shareDir + memifFilepath + memifSockname,
+			},
+		},
+	}
+	vpp2Subif1 := &vpp_interfaces.Interface{
+		Name:    vpp2Subif1Name,
+		Type:    vpp_interfaces.Interface_SUB_INTERFACE,
+		Enabled: true,
+		Link: &vpp_interfaces.Interface_Sub{
+			Sub: &vpp_interfaces.SubInterface{
+				ParentName:  vpp2MemifName,
+				SubId:       10,
+				TagRwOption: vpp_interfaces.SubInterface_POP1,
+			},
+		},
+	}
+	vpp2Subif2 := &vpp_interfaces.Interface{
+		Name:    vpp2Subif2Name,
+		Type:    vpp_interfaces.Interface_SUB_INTERFACE,
+		Enabled: true,
+		Link: &vpp_interfaces.Interface_Sub{
+			Sub: &vpp_interfaces.SubInterface{
+				ParentName:  vpp2MemifName,
+				SubId:       20,
+				TagRwOption: vpp_interfaces.SubInterface_POP1,
+			},
+		},
+	}
+
+	vpp2Tap1 := &vpp_interfaces.Interface{
+		Name:    vpp2Tap1Name,
+		Type:    vpp_interfaces.Interface_TAP,
+		Enabled: true,
+		Link: &vpp_interfaces.Interface_Tap{
+			Tap: &vpp_interfaces.TapLink{
+				Version:        2,
+				ToMicroservice: MsNamePrefix + ms1Name,
+			},
+		},
+	}
+	vpp2Tap2 := &vpp_interfaces.Interface{
+		Name:    vpp2Tap2Name,
+		Type:    vpp_interfaces.Interface_TAP,
+		Enabled: true,
+		Link: &vpp_interfaces.Interface_Tap{
+			Tap: &vpp_interfaces.TapLink{
+				Version:        2,
+				ToMicroservice: MsNamePrefix + ms2Name,
+			},
+		},
+	}
+
+	ms1Tap := &linux_interfaces.Interface{
+		Name:        ms1TapName,
+		Type:        linux_interfaces.Interface_TAP_TO_VPP,
+		Enabled:     true,
+		IpAddresses: []string{ms1TapIP + netMask},
+		HostIfName:  msTapHostname,
+		Link: &linux_interfaces.Interface_Tap{
+			Tap: &linux_interfaces.TapLink{
+				VppTapIfName: vpp2Tap1Name,
+			},
+		},
+		Namespace: &linux_namespace.NetNamespace{
+			Type:      linux_namespace.NetNamespace_MICROSERVICE,
+			Reference: MsNamePrefix + ms1Name,
+		},
+	}
+	ms2Tap := &linux_interfaces.Interface{
+		Name:        ms2TapName,
+		Type:        linux_interfaces.Interface_TAP_TO_VPP,
+		Enabled:     true,
+		IpAddresses: []string{ms2TapIP + netMask},
+		HostIfName:  msTapHostname,
+		Link: &linux_interfaces.Interface_Tap{
+			Tap: &linux_interfaces.TapLink{
+				VppTapIfName: vpp2Tap2Name,
+			},
+		},
+		Namespace: &linux_namespace.NetNamespace{
+			Type:      linux_namespace.NetNamespace_MICROSERVICE,
+			Reference: MsNamePrefix + ms2Name,
+		},
+	}
+
+	bd1 := &vpp_l2.BridgeDomain{
+		Name:    bd1Name,
+		Flood:   true,
+		Forward: true,
+		Learn:   true,
+		Interfaces: []*vpp_l2.BridgeDomain_Interface{
+			{
+				Name: vpp2Subif1Name,
+			},
+			{
+				Name: vpp2Tap1Name,
+			},
+		},
+	}
+
+	bd2 := &vpp_l2.BridgeDomain{
+		Name:    bd2Name,
+		Flood:   true,
+		Forward: true,
+		Learn:   true,
+		Interfaces: []*vpp_l2.BridgeDomain_Interface{
+			{
+				Name: vpp2Subif2Name,
+			},
+			{
+				Name: vpp2Tap2Name,
+			},
+		},
+	}
+
+	ctx.StartMicroservice(ms1Name)
+	ctx.StartMicroservice(ms2Name)
+	agent1 := ctx.StartAgent(agent1Name)
+	agent2 := ctx.StartAgent(agent2Name)
+
+	err := agent1.GenericClient().ChangeRequest().Update(
+		vpp1Memif,
+		vpp1Subif1,
+		vpp1Subif2,
+	).Send(context.Background())
+	ctx.Expect(err).ToNot(HaveOccurred())
+	err = agent2.GenericClient().ChangeRequest().Update(
+		vpp2Memif,
+		vpp2Subif1,
+		vpp2Subif2,
+		vpp2Tap1,
+		vpp2Tap2,
+		ms1Tap,
+		ms2Tap,
+		bd1,
+		bd2,
+	).Send(context.Background())
+	ctx.Expect(err).ToNot(HaveOccurred())
+
+	ctx.Eventually(agent1.GetValueStateClb(vpp1Memif)).Should(Equal(kvscheduler.ValueState_CONFIGURED))
+	ctx.Eventually(agent2.GetValueStateClb(ms1Tap)).Should(Equal(kvscheduler.ValueState_CONFIGURED))
+	ctx.Eventually(agent2.GetValueStateClb(ms2Tap)).Should(Equal(kvscheduler.ValueState_CONFIGURED))
+	ctx.Expect(agent1.PingFromVPP(ms1TapIP)).To(Succeed())
+	ctx.Expect(agent1.PingFromVPP(ms2TapIP)).To(Succeed())
+	@next
+	// TODO: add wrong sources for the vpp ping command from agent1 (ping from wrong subif to wrong vlan should fail)
 }
 
 // connect VPP with a microservice via TAP tunnel interface

--- a/tests/e2e/010_interfaces_test.go
+++ b/tests/e2e/010_interfaces_test.go
@@ -412,12 +412,15 @@ func TestMemifSubinterfaceVlanConn(t *testing.T) {
 	ctx.Eventually(agent1.GetValueStateClb(vpp1Memif)).Should(Equal(kvscheduler.ValueState_CONFIGURED))
 	ctx.Eventually(agent2.GetValueStateClb(ms1Tap)).Should(Equal(kvscheduler.ValueState_CONFIGURED))
 	ctx.Eventually(agent2.GetValueStateClb(ms2Tap)).Should(Equal(kvscheduler.ValueState_CONFIGURED))
-	// Pings from correct vlan should succeed
+	// Pings from VPP should automatically go through correct vlan
 	ctx.Expect(agent1.PingFromVPP(ms1TapIP)).To(Succeed())
 	ctx.Expect(agent1.PingFromVPP(ms2TapIP)).To(Succeed())
+	// Pings from correct vlan should succeed
+	ctx.Expect(agent1.PingFromVPP(ms1TapIP, "source", "memif1/1.10")).To(Succeed())
+	ctx.Expect(agent1.PingFromVPP(ms2TapIP, "source", "memif1/1.20")).To(Succeed())
 	// Pings from incorrect vlan should fail
-	ctx.Expect(agent1.PingFromVPP(ms1TapIP, "source", "memif1/1.20")).NotTo(Succeed())
-	ctx.Expect(agent1.PingFromVPP(ms2TapIP, "source", "memif1/1.10")).NotTo(Succeed())
+	ctx.Expect(agent1.PingFromVPP(ms1TapIP, "source", "memif1/1.10")).NotTo(Succeed())
+	ctx.Expect(agent1.PingFromVPP(ms2TapIP, "source", "memif1/1.20")).NotTo(Succeed())
 }
 
 // connect VPP with a microservice via TAP tunnel interface

--- a/tests/e2e/vppagent.go
+++ b/tests/e2e/vppagent.go
@@ -265,16 +265,16 @@ func (agent *Agent) ExecVppctl(action string, args ...string) (string, error) {
 
 // PingFromVPPAsCallback can be used to ping repeatedly inside the assertions "Eventually"
 // and "Consistently" from Omega.
-func (agent *Agent) PingFromVPPAsCallback(destAddress string) func() error {
+func (agent *Agent) PingFromVPPAsCallback(destAddress string, args ...string) func() error {
 	return func() error {
-		return agent.PingFromVPP(destAddress)
+		return agent.PingFromVPP(destAddress, args...)
 	}
 }
 
 // PingFromVPP pings <dstAddress> from inside the VPP.
-func (agent *Agent) PingFromVPP(destAddress string) error {
+func (agent *Agent) PingFromVPP(destAddress string, args ...string) error {
 	// run ping on VPP using vppctl
-	stdout, err := agent.ExecVppctl("ping", destAddress)
+	stdout, err := agent.ExecVppctl("ping", append([]string{destAddress}, args...)...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR also slightly modifies PingFromVPP function to allow additional arguments via string variadic argument. This is used to specify source IP address of the ping in the new test.

Signed-off-by: Peter Motičák [peter.moticak@pantheon.tech](mailto:peter.moticak@pantheon.tech)