### PR TITLE
fix(e2e): Pin etcd image version to v3.5.5

### DIFF
--- a/tests/e2e/etcd.go
+++ b/tests/e2e/etcd.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	etcdImage       = "gcr.io/etcd-development/etcd"
+	etcdImage       = "gcr.io/etcd-development/etcd:v3.5.5"
 	etcdStopTimeout = 1 // seconds
 )
 


### PR DESCRIPTION
The etcd:latest tag got deprecated and the latest image now does not exist in the [container registry](https://console.cloud.google.com/gcr/images/etcd-development/GLOBAL/etcd). As a result some e2e tests started failing. This PR fixes this problem by using existing v3.5.5 tag.

Signed-off-by: Peter Motičák <peter.moticak@pantheon.tech>