### PR TITLE
Remove config item labels support from local client

### DIFF
--- a/client/local_client.go
+++ b/client/local_client.go
@@ -146,84 +146,13 @@ func (c *client) GetItems(ctx context.Context) ([]*ConfigItem, error) {
 }
 
 func (c *client) UpdateItems(ctx context.Context, items []UpdateItem, resync bool) ([]*UpdateResult, error) {
-	txn := c.txnFactory.NewTxn(resync)
-	for _, ui := range items {
-		key, err := models.GetKey(ui.Message)
-		if err != nil {
-			return nil, err
-		}
-		txn.Put(key, ui.Message)
-		_, withDataSrc := contextdecorator.DataSrcFromContext(ctx)
-		if !withDataSrc {
-			ctx = contextdecorator.DataSrcContext(ctx, "localclient")
-		}
-		ctx = contextdecorator.LabelsContext(ctx, ui.Labels)
-	}
-	if err := txn.Commit(ctx); err != nil {
-		return nil, err
-	}
-	var updateResults []*UpdateResult
-	r, _ := contextdecorator.PushDataResultFromContext(ctx)
-	resWrapper, ok := r.(orchestrator.ResultWrapper)
-	if !ok {
-		return nil, fmt.Errorf("cannot retrieve update results!")
-	}
-	for _, res := range resWrapper.Results {
-		var msg string
-		if details := res.Status.GetDetails(); len(details) > 0 {
-			msg = strings.Join(res.Status.GetDetails(), ", ")
-		} else {
-			msg = res.Status.GetError()
-		}
-		updateResults = append(updateResults, &UpdateResult{
-			Key: res.Key,
-			Status: &generic.ItemStatus{
-				Status:  res.Status.State.String(),
-				Message: msg,
-			},
-		})
-	}
-	return updateResults, nil
+	// TODO: use grpc client to update items with labels
+	return nil, nil
 }
 
 func (c *client) DeleteItems(ctx context.Context, items []UpdateItem) ([]*UpdateResult, error) {
-	txn := c.txnFactory.NewTxn(false)
-	for _, ui := range items {
-		key, err := models.GetKey(ui.Message)
-		if err != nil {
-			return nil, err
-		}
-		txn.Delete(key)
-		_, withDataSrc := contextdecorator.DataSrcFromContext(ctx)
-		if !withDataSrc {
-			ctx = contextdecorator.DataSrcContext(ctx, "localclient")
-		}
-	}
-	if err := txn.Commit(ctx); err != nil {
-		return nil, err
-	}
-	var updateResults []*UpdateResult
-	r, _ := contextdecorator.PushDataResultFromContext(ctx)
-	resWrapper, ok := r.(orchestrator.ResultWrapper)
-	if !ok {
-		return nil, fmt.Errorf("cannot retrieve update results!")
-	}
-	for _, res := range resWrapper.Results {
-		var msg string
-		if details := res.Status.GetDetails(); len(details) > 0 {
-			msg = strings.Join(res.Status.GetDetails(), ", ")
-		} else {
-			msg = res.Status.GetError()
-		}
-		updateResults = append(updateResults, &UpdateResult{
-			Key: res.Key,
-			Status: &generic.ItemStatus{
-				Status:  res.Status.State.String(),
-				Message: msg,
-			},
-		})
-	}
-	return updateResults, nil
+	// TODO: use grpc client to delete items with labels
+	return nil, nil
 }
 
 func (c *client) DumpState() ([]*generic.StateItem, error) {

--- a/plugins/orchestrator/contextdecorator/context.go
+++ b/plugins/orchestrator/contextdecorator/context.go
@@ -29,36 +29,3 @@ func DataSrcFromContext(ctx context.Context) (dataSrc string, ok bool) {
 	dataSrc, ok = ctx.Value(dataSrcKey).(string)
 	return
 }
-
-type labelsKeyT string
-
-var labelsKey = labelsKeyT("labels")
-
-func LabelsContext(ctx context.Context, labels map[string]string) context.Context {
-	return context.WithValue(ctx, labelsKey, labels)
-}
-
-func LabelsFromContext(ctx context.Context) (labels map[string]string, ok bool) {
-	labels, ok = ctx.Value(labelsKey).(map[string]string)
-	return
-}
-
-// TODO: This is hack to avoid import cycle between orchestrator and contextdecorator package.
-// Figure out a way to pass result into local client without using interface implemented by
-// a wrapper type defined inside orchestrator package.
-type resulter interface {
-	IsPushDataResult()
-}
-
-type pushDataResultKeyT string
-
-var pushDataResultKey = pushDataResultKeyT("pushDataResult")
-
-func PushDataResultContext(ctx context.Context, pushDataResult resulter) context.Context {
-	return context.WithValue(ctx, pushDataResultKey, pushDataResult)
-}
-
-func PushDataResultFromContext(ctx context.Context) (pushDataResult resulter, ok bool) {
-	pushDataResult, ok = ctx.Value(pushDataResultKey).(resulter)
-	return
-}


### PR DESCRIPTION
Due to limitations of cn-infra library config labels were never working properly for local client. For now, user should use remote client for this functionality.

Signed-off-by: Peter Motičák <peter.moticak@pantheon.tech>