### PR TITLE
feat: Add txn type for unimplemented configuration

### DIFF
--- a/cmd/agentctl/commands/config.go
+++ b/cmd/agentctl/commands/config.go
@@ -741,6 +741,8 @@ func getTxnColor(txn *kvs.RecordedTxn) int {
 		clr = tablewriter.FgCyanColor
 	case kvs.RetryFailedOps:
 		clr = tablewriter.FgMagentaColor
+	case kvs.RetryUnimplOps:
+		clr = tablewriter.FgHiMagentaColor
 	}
 	return clr
 }
@@ -760,8 +762,10 @@ func getTxnType(txn *kvs.RecordedTxn) string {
 		return "config change"
 	case kvs.RetryFailedOps:
 		return fmt.Sprintf("retry #%d for %d", txn.RetryAttempt, txn.RetryForTxn)
+	case kvs.RetryUnimplOps:
+		return fmt.Sprintf("retry impl for %d", txn.RetryForTxn)
 	}
-	return "?"
+	return "unknown txn type"
 }
 
 func txnValueStates(txn *kvs.RecordedTxn) string {

--- a/plugins/kvscheduler/api/api_test.go
+++ b/plugins/kvscheduler/api/api_test.go
@@ -33,6 +33,7 @@ func TestTxnTypeEncode(t *testing.T) {
 		{"SBNotification", api.SBNotification, `"SBNotification"`, nil},
 		{"NBTransaction", api.NBTransaction, `"NBTransaction"`, nil},
 		{"RetryFailedOps", api.RetryFailedOps, `"RetryFailedOps"`, nil},
+		{"RetryUnimplOps", api.RetryUnimplOps, `"RetryUnimplOps"`, nil},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -58,6 +59,7 @@ func TestTxnTypeDecode(t *testing.T) {
 		expectErr     error
 	}{
 		{"RetryFailedOps", `"RetryFailedOps"`, api.RetryFailedOps, nil},
+		{"RetryUnimplOps", `"RetryUnimplOps"`, api.RetryUnimplOps, nil},
 		{"NBTransaction", `"NBTransaction"`, api.NBTransaction, nil},
 		{"1 (NBTransaction)", `1`, api.NBTransaction, nil},
 		{"0 (SBNotification)", `0`, api.SBNotification, nil},

--- a/plugins/kvscheduler/api/kv_scheduler_api.go
+++ b/plugins/kvscheduler/api/kv_scheduler_api.go
@@ -131,23 +131,24 @@ func (v View) String() string {
 // The values are described for scheduler by registered KVDescriptor-s.
 // The scheduler learns two kinds of relations between values that have to be
 // respected by the scheduling algorithm:
-//   -> A depends on B:
-//          - A cannot exist without B
-//          - request to create A without B existing must be postponed by storing
-//            A into the cache of values with unmet dependencies (a.k.a. pending)
-//          - if B is to be removed and A exists, A must be removed first
-//            and cached in case B is restored in the future
-//          - Note: values pushed from SB are not checked for dependencies
-//   -> B is derived from A:
-//          - value B is not created directly (by NB or SB) but gets derived
-//            from base value A (using the DerivedValues() method of the base
-//            value's descriptor)
-//          - derived value exists only as long as its base does and gets removed
-//            (without caching) once the base value goes away
-//          - derived value may be described by a different descriptor than
-//            the base and usually represents property of the base value (that
-//            other values may depend on) or an extra action to be taken
-//            when additional dependencies are met.
+//
+//	-> A depends on B:
+//	       - A cannot exist without B
+//	       - request to create A without B existing must be postponed by storing
+//	         A into the cache of values with unmet dependencies (a.k.a. pending)
+//	       - if B is to be removed and A exists, A must be removed first
+//	         and cached in case B is restored in the future
+//	       - Note: values pushed from SB are not checked for dependencies
+//	-> B is derived from A:
+//	       - value B is not created directly (by NB or SB) but gets derived
+//	         from base value A (using the DerivedValues() method of the base
+//	         value's descriptor)
+//	       - derived value exists only as long as its base does and gets removed
+//	         (without caching) once the base value goes away
+//	       - derived value may be described by a different descriptor than
+//	         the base and usually represents property of the base value (that
+//	         other values may depend on) or an extra action to be taken
+//	         when additional dependencies are met.
 //
 // Every key-value pair must have at most one descriptor associated with it.
 // Base NB value without descriptor is considered unimplemented and will never
@@ -260,6 +261,8 @@ type KVScheduler interface {
 	// remotely retrieved dynamic proto messages can't be converted to such proto messages (there are
 	// no locally available statically generated proto models).
 	ValidateSemantically([]proto.Message) error
+
+	WatchNBKeyPrefixRegistration(key string) (<-chan struct{}, error)
 }
 
 // ValueProvider provides key/value data from different sources in system (NB, SB, KVProvider cache of SB)

--- a/plugins/kvscheduler/internal/registry/registry_impl.go
+++ b/plugins/kvscheduler/internal/registry/registry_impl.go
@@ -16,7 +16,6 @@ package registry
 
 import (
 	"container/list"
-
 	"fmt"
 
 	. "go.ligato.io/vpp-agent/v3/plugins/kvscheduler/api"
@@ -120,9 +119,11 @@ func (reg *registry) GetDescriptorForKey(key string) *KVDescriptor {
 			keyDescriptor = descriptor
 		}
 	}
-	// add entry to cache
-	entry := &cacheEntry{key: key, descriptor: keyDescriptor}
-	elem = reg.keyCache.PushFront(entry)
-	reg.keyToCacheEntry[key] = elem
+	// if descriptor exists, add entry to cache
+	if keyDescriptor != nil {
+		entry := &cacheEntry{key: key, descriptor: keyDescriptor}
+		elem = reg.keyCache.PushFront(entry)
+		reg.keyToCacheEntry[key] = elem
+	}
 	return keyDescriptor
 }

--- a/plugins/kvscheduler/plugin_scheduler.go
+++ b/plugins/kvscheduler/plugin_scheduler.go
@@ -289,7 +289,9 @@ func (s *Scheduler) WatchNBKeyPrefixRegistration(keyPrefix string) (<-chan struc
 		return ch, kvs.ErrDescriptorExists
 	}
 
-	s.subs[keyPrefix] = models.NewSourceBroadcast[struct{}]()
+	if _, ok := s.subs[keyPrefix]; !ok {
+		s.subs[keyPrefix] = models.NewSourceBroadcast[struct{}]()
+	}
 	return s.subs[keyPrefix].Subscribe(), nil
 }
 

--- a/plugins/kvscheduler/txn_record.go
+++ b/plugins/kvscheduler/txn_record.go
@@ -124,6 +124,9 @@ func (s *Scheduler) preRecordTransaction(txn *transaction, planned kvs.RecordedT
 		record.RetryForTxn = txn.retry.txnSeqNum
 		record.RetryAttempt = txn.retry.attempt
 	}
+	if txn.txnType == kvs.RetryUnimplOps {
+		record.RetryForTxn = txn.impl.txnSeqNum
+	}
 
 	// record values sorted alphabetically by keys
 	if txn.txnType != kvs.NBTransaction || txn.nb.resyncType != kvs.DownstreamResync {
@@ -146,7 +149,9 @@ func (s *Scheduler) preRecordTransaction(txn *transaction, planned kvs.RecordedT
 		if txn.txnType == kvs.NBTransaction && txn.nb.resyncType != kvs.NotResync {
 			txnInfo = txn.nb.resyncType.String()
 		} else if txn.txnType == kvs.RetryFailedOps && txn.retry != nil {
-			txnInfo = fmt.Sprintf("retrying TX #%d (attempt %d)", txn.retry.txnSeqNum, txn.retry.attempt)
+			txnInfo = fmt.Sprintf("retrying failed TXN #%d (attempt %d)", txn.retry.txnSeqNum, txn.retry.attempt)
+		} else if txn.txnType == kvs.RetryUnimplOps && txn.impl != nil {
+			txnInfo = fmt.Sprintf("retrying unimplemented TXN #%d", txn.impl.txnSeqNum)
 		}
 		msg := fmt.Sprintf("#%d - %s", record.SeqNum, txn.txnType.String())
 		n := 115 - len(msg)

--- a/plugins/orchestrator/orchestrator.go
+++ b/plugins/orchestrator/orchestrator.go
@@ -101,17 +101,20 @@ func (p *Plugin) Init() (err error) {
 		p.log.Infof("grpc server is not available")
 	}
 
+	var prefixes []string
 	p.Log.Infof("Found %d registered models", len(models.RegisteredModels()))
 	for _, model := range models.RegisteredModels() {
+		p.Log.Infof("- model: %+v", *model.Spec())
 		p.debugf("- model: %+v", *model.Spec())
+		prefixes = append(prefixes, model.KeyPrefix())
 	}
 
-	var prefixes []string
 	if nbPrefixes := p.kvs.GetRegisteredNBKeyPrefixes(); len(nbPrefixes) > 0 {
 		p.log.Infof("Watching %d key prefixes from KVScheduler", len(nbPrefixes))
 		for _, prefix := range nbPrefixes {
+			p.Log.Infof("- prefix: %+v", prefix)
 			p.debugf("- prefix: %s", prefix)
-			prefixes = append(prefixes, prefix)
+			// prefixes = append(prefixes, prefix)
 		}
 	} else {
 		p.log.Warnf("No key prefixes found in KVScheduler (ensure that all KVDescriptors are registered before this)")

--- a/plugins/orchestrator/orchestrator.go
+++ b/plugins/orchestrator/orchestrator.go
@@ -104,7 +104,6 @@ func (p *Plugin) Init() (err error) {
 	var prefixes []string
 	p.Log.Infof("Found %d registered models", len(models.RegisteredModels()))
 	for _, model := range models.RegisteredModels() {
-		p.Log.Infof("- model: %+v", *model.Spec())
 		p.debugf("- model: %+v", *model.Spec())
 		prefixes = append(prefixes, model.KeyPrefix())
 	}
@@ -112,9 +111,7 @@ func (p *Plugin) Init() (err error) {
 	if nbPrefixes := p.kvs.GetRegisteredNBKeyPrefixes(); len(nbPrefixes) > 0 {
 		p.log.Infof("Watching %d key prefixes from KVScheduler", len(nbPrefixes))
 		for _, prefix := range nbPrefixes {
-			p.Log.Infof("- prefix: %+v", prefix)
 			p.debugf("- prefix: %s", prefix)
-			// prefixes = append(prefixes, prefix)
 		}
 	} else {
 		p.log.Warnf("No key prefixes found in KVScheduler (ensure that all KVDescriptors are registered before this)")

--- a/plugins/orchestrator/watcher/aggregator.go
+++ b/plugins/orchestrator/watcher/aggregator.go
@@ -214,7 +214,6 @@ func (p *Aggregator) watchAggrResync(aggrResync, resyncCh chan datasync.ResyncEv
 
 		kvToKeyVals := func(prefix string, kv datasync.KeyVal) {
 			keyVals, ok := prefixKeyVals[prefix]
-			p.Log.Debugf(" - prefixkeyvals: %v", prefixKeyVals)
 			if !ok {
 				p.Log.Debugf(" - keyval prefix: %v", prefix)
 				keyVals = map[string]datasync.KeyVal{}

--- a/plugins/orchestrator/watcher/aggregator.go
+++ b/plugins/orchestrator/watcher/aggregator.go
@@ -214,6 +214,7 @@ func (p *Aggregator) watchAggrResync(aggrResync, resyncCh chan datasync.ResyncEv
 
 		kvToKeyVals := func(prefix string, kv datasync.KeyVal) {
 			keyVals, ok := prefixKeyVals[prefix]
+			p.Log.Debugf(" - prefixkeyvals: %v", prefixKeyVals)
 			if !ok {
 				p.Log.Debugf(" - keyval prefix: %v", prefix)
 				keyVals = map[string]datasync.KeyVal{}


### PR DESCRIPTION
This PR introduces new transaction type inside scheduler implementation. This transaction type is used when for a given configuration key, scheduler does not yet have the corresponding descriptor inside its registry. Instead of the operation being in the unimplemented state indefinitely, it gets retried when the descriptor eventually gets registered.

P.S. I am not sure where (in which package/file) to put the `Broadcast[T]` struct as its usage does not need to be tied to the scheduler itself.

Signed-off-by: Peter Motičák [peter.moticak@pantheon.tech](mailto:peter.moticak@pantheon.tech)