### PR TITLE
feat: Allow modification of default telemetry config, add metrics

### DIFF
--- a/plugins/telemetry/config.go
+++ b/plugins/telemetry/config.go
@@ -36,17 +36,18 @@ type Config struct {
 	Skipped []string `json:"skipped"`
 }
 
-func defaultConfig() *Config {
+var DefaultConfig = func() *Config {
 	return &Config{
 		PollingInterval: defaultUpdatePeriod,
-		// TODO Even if disabled, the metric endpoint is still active. Consider shutting it down completely (discuss).
-		Disabled: true,
 	}
 }
 
 // loadConfig returns telemetry plugin file configuration if exists
 func (p *Plugin) loadConfig() (*Config, error) {
-	cfg := defaultConfig()
+	cfg := &Config{}
+	if DefaultConfig != nil {
+		cfg = DefaultConfig()
+	}
 
 	found, err := p.Cfg.LoadValue(cfg)
 	if err != nil {

--- a/plugins/telemetry/config.go
+++ b/plugins/telemetry/config.go
@@ -39,6 +39,8 @@ type Config struct {
 func defaultConfig() *Config {
 	return &Config{
 		PollingInterval: defaultUpdatePeriod,
+		// TODO Even if disabled, the metric endpoint is still active. Consider shutting it down completely (discuss).
+		Disabled: true,
 	}
 }
 
@@ -50,12 +52,12 @@ func (p *Plugin) loadConfig() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if !found {
-		p.Log.Debug("Telemetry config not found")
-		return nil, nil
+		p.Log.Debugf("Telemetry config not found. Using default config: %+v", cfg)
+	} else {
+		p.Log.Debugf("Telemetry config found: %+v", cfg)
 	}
 
-	p.Log.Debugf("Telemetry config found: %+v", cfg)
-
-	return cfg, err
+	return cfg, nil
 }

--- a/plugins/telemetry/options.go
+++ b/plugins/telemetry/options.go
@@ -13,7 +13,7 @@ import (
 // DefaultPlugin is default instance of Plugin
 var DefaultPlugin = *NewPlugin()
 
-// NewPlugin creates a new Plugin with the provides Options
+// NewPlugin creates a new Plugin with the provided Options
 func NewPlugin(opts ...Option) *Plugin {
 	p := &Plugin{}
 

--- a/plugins/telemetry/telemetry.go
+++ b/plugins/telemetry/telemetry.go
@@ -96,7 +96,7 @@ func (p *Plugin) Init() error {
 	if config != nil {
 		// If telemetry is not enabled, skip plugin initialization
 		if config.Disabled {
-			p.Log.Info("Telemetry plugin is disabled")
+			p.Log.Info("Telemetry plugin disabled")
 			p.disabled = true
 			return nil
 		}

--- a/plugins/telemetry/telemetry.go
+++ b/plugins/telemetry/telemetry.go
@@ -96,7 +96,7 @@ func (p *Plugin) Init() error {
 	if config != nil {
 		// If telemetry is not enabled, skip plugin initialization
 		if config.Disabled {
-			p.Log.Info("Telemetry plugin disabled via config file")
+			p.Log.Info("Telemetry plugin is disabled")
 			p.disabled = true
 			return nil
 		}

--- a/plugins/vpp/ifplugin/metrics.go
+++ b/plugins/vpp/ifplugin/metrics.go
@@ -1,0 +1,23 @@
+package ifplugin
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var operationalStates = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "ligato",
+	Subsystem: "ifplugin",
+	Name:      "operational_state",
+	Help:      "The operational state of available interfaces.",
+}, []string{"name"})
+var adminStates = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "ligato",
+	Subsystem: "ifplugin",
+	Name:      "admin_state",
+	Help:      "The admin state of available interfaces.",
+}, []string{"name"})
+
+func registerMetrics() {
+	prometheus.MustRegister(operationalStates)
+	prometheus.MustRegister(adminStates)
+}


### PR DESCRIPTION
This PR adds the option to modify the default config of the telemetry plugin.

Additionally 2 new metrics were added - operational and admin state of available interfaces.