### PR TITLE
fix: changing type of variable assignment

### DIFF
--- a/plugins/vpp/puntplugin/puntplugin.go
+++ b/plugins/vpp/puntplugin/puntplugin.go
@@ -100,7 +100,7 @@ func (p *PuntPlugin) Init() (err error) {
 		}
 		key := strings.Replace(models.Key(toHost), "config/", "status/", -1)
 		if register {
-			puntToHost := proto.Clone(toHost).(*vpp_punt.Exception)
+			puntToHost := proto.Clone(toHost).(*vpp_punt.ToHost)
 			puntToHost.SocketPath = socketPath
 			if err := p.PublishState.Put(key, puntToHost, datasync.WithClientLifetimeTTL()); err != nil {
 				p.Log.Errorf("publishing registered punt socket failed: %v", err)


### PR DESCRIPTION
In this commit, I have made a modification to the code by changing the type of the variable assignment from *vpp_punt.Exception to *vpp_punt.ToHost. 
The change was made to ensure proper compatibility and consistency within the affected section.