### PR TITLE
Fix agentctl report command

### DIFF
--- a/cmd/agentctl/commands/config.go
+++ b/cmd/agentctl/commands/config.go
@@ -97,7 +97,7 @@ func runConfigGet(cli agentcli.Cli, opts ConfigGetOptions) error {
 	// create dynamically config that can hold all known models
 	knownModels, err := c.KnownModels("config")
 	if err != nil {
-		return fmt.Errorf("getting registered models: %w", err)
+		return fmt.Errorf("can't retrieve registered models: %w", err)
 	}
 	_ = models.RegisterModelInfos(knownModels)
 	config, err := client.NewDynamicConfig(knownModels)
@@ -190,7 +190,7 @@ func runConfigUpdate(cli agentcli.Cli, opts ConfigUpdateOptions, args []string) 
 	// create dynamically config that can hold all known models
 	knownModels, err := c.KnownModels("config")
 	if err != nil {
-		return fmt.Errorf("getting registered models: %w", err)
+		return fmt.Errorf("can't retrieve registered models: %w", err)
 	}
 	_ = models.RegisterModelInfos(knownModels)
 	config, err := client.NewDynamicConfig(knownModels)

--- a/cmd/agentctl/commands/report.go
+++ b/cmd/agentctl/commands/report.go
@@ -33,6 +33,7 @@ import (
 	"github.com/spf13/cobra"
 	govppapi "go.fd.io/govpp/api"
 
+	"go.ligato.io/vpp-agent/v3/client"
 	"go.ligato.io/vpp-agent/v3/cmd/agentctl/api/types"
 	agentcli "go.ligato.io/vpp-agent/v3/cmd/agentctl/cli"
 	"go.ligato.io/vpp-agent/v3/pkg/models"
@@ -132,6 +133,7 @@ func runReport(cli agentcli.Cli, opts ReportOptions) error {
 		writeReportTo("vpp-statistics-interfaces.txt", dirName, writeVPPInterfaceStatsReport, cli),
 		writeReportTo("vpp-statistics-errors.txt", dirName, writeVPPErrorStatsReport, cli),
 		writeReportTo("vpp-api-trace.txt", dirName, writeVPPApiTraceReport, cli),
+		writeReportTo("vpp-api-trace.json", dirName, writeVPPApiTraceReportJSON, cli),
 		writeReportTo("vpp-other-srv6.txt", dirName, writeVPPSRv6LocalsidReport, cli),
 		writeReportTo("vpp-other-srv6.txt", dirName, writeVPPSRv6PolicyReport, cli),
 		writeReportTo("vpp-other-srv6.txt", dirName, writeVPPSRv6SteeringReport, cli),
@@ -372,26 +374,36 @@ func writeVPPRunningConfigReport(w io.Writer, errorW io.Writer, cli agentcli.Cli
 }
 
 func writeAgentNBConfigReport(w io.Writer, errorW io.Writer, cli agentcli.Cli, otherArgs ...interface{}) error {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	subTaskActionName := "Retrieving agent NB configuration"
 	cliOutputDefer, cliOutputErrPassing := subTaskCliOutputs(cli, subTaskActionName)
 	defer cliOutputDefer(cli)
 
-	// TODO replace with new implementation for agentctl config get (https://github.com/ligato/vpp-agent/pull/1754)
-	client, err := cli.Client().ConfiguratorClient()
+	c, err := cli.Client().GenericClient()
 	if err != nil {
 		return fileErrorPassing(cliOutputErrPassing(err, "getting configuration client"),
 			w, errorW, subTaskActionName)
 	}
-	resp, err := client.Get(ctx, &configurator.GetRequest{})
+
+	knownModels, err := c.KnownModels("config")
 	if err != nil {
-		return fileErrorPassing(cliOutputErrPassing(err, "getting configuration"), w, errorW, subTaskActionName)
+		return fileErrorPassing(cliOutputErrPassing(err, "getting registered models"),
+			w, errorW, subTaskActionName)
 	}
 
-	if err := formatAsTemplate(w, "yaml", resp.GetConfig()); err != nil {
-		return fileErrorPassing(cliOutputErrPassing(err, "formatting"), w, errorW, subTaskActionName)
+	config, err := client.NewDynamicConfig(knownModels)
+	if err != nil {
+		return fileErrorPassing(cliOutputErrPassing(err, "creating dynamic config"),
+			w, errorW, subTaskActionName)
+	}
+
+	err = c.GetConfig(config)
+	if err != nil {
+		return fileErrorPassing(cliOutputErrPassing(err, "getting configuration"),
+			w, errorW, subTaskActionName)
+	}
+
+	if err := formatAsTemplate(w, "yaml", config); err != nil {
+		return fileErrorPassing(cliOutputErrPassing(err, "formatting configuration"), w, errorW, subTaskActionName)
 	}
 	return nil
 }
@@ -456,7 +468,7 @@ func writeKVschedulerReport(subTaskActionName string, view string, ignoreModels 
 		})
 		if err != nil {
 			if strings.Contains(err.Error(), "no descriptor found matching the key prefix") {
-				if _, e := cli.Out().Write([]byte(fmt.Sprintf("Skipping key prefix %s due to: %v\n", keyPrefix, err))); err != nil {
+				if _, e := cli.Out().Write([]byte(fmt.Sprintf("Skipping key prefix %s due to: %v\n", keyPrefix, err))); e != nil {
 					return e
 				}
 			} else {
@@ -633,30 +645,16 @@ func writeHardwareVPPStatsMemoryReport(w io.Writer, errorW io.Writer, cli agentc
 }
 
 func writeVPPApiTraceReport(w io.Writer, errorW io.Writer, cli agentcli.Cli, otherArgs ...interface{}) error {
-	var saveFileCmdOutput *string
-	var errs Errors
-	err := writeVPPCLICommandReport("Saving vpp api trace remotely to a file",
-		"api trace save agentctl-report.api", w, errorW, cli, func(vppCLICmd, cmdOutput string) string { // formatting output
-			saveFileCmdOutput = &cmdOutput
-			return fmt.Sprintf("vppctl# %s:\n%s\n\n", vppCLICmd, cmdOutput) // default formatting
+	return writeVPPCLICommandReport("Retrieving vpp api trace in text format",
+		"api trace dump", w, errorW, cli, func(vppCLICmd, cmdOutput string) string { // formatting output
+			return fmt.Sprintf("vppctl# %s:\n%s\n", vppCLICmd, cmdOutput)
 		})
-	if err != nil {
-		errs = append(errs, err)
-	}
-
-	// retrieve file location on remote machine
-	// Example output: "API trace saved to /tmp/agentctl-report.api"
-	fileLocation := "/tmp/agentctl-report.api"
-	expectedFormattingPrefix := "API trace saved to"
-	if strings.HasPrefix(*saveFileCmdOutput, expectedFormattingPrefix) {
-		fileLocation = strings.TrimSpace(strings.TrimPrefix(*saveFileCmdOutput, expectedFormattingPrefix))
-	}
-
-	if err := writeVPPCLICommandReport("Retrieving vpp api trace from saved remote file",
-		fmt.Sprintf("api trace custom-dump %s", fileLocation), w, errorW, cli); err != nil {
-		errs = append(errs, err)
-	}
-	return errs
+}
+func writeVPPApiTraceReportJSON(w io.Writer, errorW io.Writer, cli agentcli.Cli, otherArgs ...interface{}) error {
+	return writeVPPCLICommandReport("Retrieving vpp api trace in JSON format",
+		"api trace dump-json", w, errorW, cli, func(vppCLICmd, cmdOutput string) string { // formatting output
+			return cmdOutput
+		})
 }
 
 func writeVPPEventLogReport(w io.Writer, errorW io.Writer, cli agentcli.Cli, otherArgs ...interface{}) error {


### PR DESCRIPTION
- `agentctl report` command failed reporting transaction history because of unregistered models

- VPP CLI commands for api tracing changed so adapt trace to these changes 

- output trace in JSON format which is more suited to automatic processing

- use GenericClient to fetch agent NB config (allows for showing user defined models)


Signed-off-by: Peter Motičák [peter.moticak@pantheon.tech](mailto:peter.moticak@pantheon.tech)
